### PR TITLE
Update pom.xml to fix broken windows Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 								<mainClass>JhoveView</mainClass>
 							</manifest>
 						</archive>
-						<finalName>${project.artifactId}-GUI-${project.version}</finalName>
+						<finalName>${project.artifactId}-${project.version}</finalName>
 					</configuration>
 			</execution>
 		</executions>
@@ -82,7 +82,7 @@
             <configuration>
               <artifacts>
                 <artifact>
-                  <file>${project.build.directory}/${project.artifactId}-GUI-${project.version}.jar</file>
+                  <file>${project.build.directory}/${project.artifactId}-${project.version}-gui.jar</file>
                   <type>jar</type>
                   <classifier>gui</classifier>
                 </artifact>


### PR DESCRIPTION
I had a build problem with Maven, as a JAR could not be found.
After running the build with "mvn install -X" revealed the exception.
Two minor fixes in the pom.xml solved the problem:
Apache Maven 3.1.1 (0728685237757ffbf44136acec0402957f723d9a; 2013-09-17 17:22:22+0200)
Java version: 1.7.0_55, vendor: Oracle Corporation
Default locale: en_US, platform encoding: Cp1252
OS name: "windows 7", version: "6.1", arch: "amd64", family: "windows"

Best regards,
Svante
