### PR TITLE
Absolute config path for beta-installer.

### DIFF
--- a/jhove-installer/src/main/scripts/jhove
+++ b/jhove-installer/src/main/scripts/jhove
@@ -43,7 +43,7 @@ CP=${JHOVE_HOME}/bin/jhove-apps-${JHOVE_VERSION}.jar:${EXTRA_JARS}
 
 # Retrieve a copy of all command line arguments to pass to the application.
 
-ARGS="-c conf/jhove.conf"
+ARGS="-c ${JHOVE_HOME}/conf/jhove.conf"
 for ARG do
     ARGS="$ARGS $ARG"
 done

--- a/jhove-installer/src/main/scripts/jhove-gui
+++ b/jhove-installer/src/main/scripts/jhove-gui
@@ -43,7 +43,7 @@ CP=${JHOVE_HOME}/bin/jhove-apps-${JHOVE_VERSION}.jar:${EXTRA_JARS}
 
 # Retrieve a copy of all command line arguments to pass to the application.
 
-ARGS="-c conf/jhove.conf"
+ARGS="-c ${JHOVE_HOME}/conf/jhove.conf"
 for ARG do
     ARGS="$ARGS $ARG"
 done

--- a/jhove-installer/src/main/scripts/jhove-gui.bat
+++ b/jhove-installer/src/main/scripts/jhove-gui.bat
@@ -53,7 +53,7 @@ IF "%EXTRA_JARS%"=="" GOTO FI
 
 REM Retrieve a copy of all command line arguments to pass to the application
 
-SET ARGS=-c conf\jhove.conf
+SET ARGS=-c %JHOVE_HOME%\conf\jhove.conf
 :WHILE
 IF "%1"=="" GOTO LOOP
   SET ARGS=%ARGS% %1

--- a/jhove-installer/src/main/scripts/jhove.bat
+++ b/jhove-installer/src/main/scripts/jhove.bat
@@ -53,7 +53,7 @@ IF "%EXTRA_JARS%"=="" GOTO FI
 
 REM Retrieve a copy of all command line arguments to pass to the application
 
-SET ARGS=-c conf\jhove.conf
+SET ARGS=-c %JHOVE_HOME%\conf\jhove.conf
 :WHILE
 IF "%1"=="" GOTO LOOP
   SET ARGS=%ARGS% %1


### PR DESCRIPTION
- Config needs tidying.
- Preserves existing config.
- Isolates beta config.
- Ensures double click of gui bat works on Mac.
