### PR TITLE
Added appassembler plugin to create working target/appassembler/bin/j…

### DIFF
--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -16,6 +16,51 @@
 
   <build>
     <plugins>
+      <!-- create the tarball layout -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>appassembler-maven-plugin</artifactId>
+        <version>1.10</version>
+        <configuration>
+          <!-- http://www.mojohaus.org/appassembler/appassembler-maven-plugin/assemble-mojo.html -->
+          <platforms>
+            <platform>unix</platform>
+            <!-- "$BASEDIR/conf" to locate configuration file does not work under Windows -->
+          </platforms>
+          <configurationDirectory>conf</configurationDirectory>
+          <copyConfigurationDirectory>true</copyConfigurationDirectory>
+          <filterConfigurationDirectory>false</filterConfigurationDirectory>
+
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>libs</repositoryName>
+          <!-- for logback -->
+          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
+          <logsDirectory>logs</logsDirectory>
+          <projectArtifactFirstInClassPath>true</projectArtifactFirstInClassPath>
+        </configuration>
+        <!-- needed for some reason -->
+        <executions>
+          <execution>
+            <id>assemble</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+            <configuration>
+              <programs>
+                <program>
+                  <mainClass>Jhove</mainClass>
+                  <commandLineArguments>
+                    <commandLineArgument>-c</commandLineArgument>
+                    <commandLineArgument>$BASEDIR/conf/jhove.conf</commandLineArgument>
+                  </commandLineArguments>
+                  <id>jhove</id>
+                </program>
+              </programs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -24,7 +24,7 @@
         <configuration>
           <!-- http://www.mojohaus.org/appassembler/appassembler-maven-plugin/assemble-mojo.html -->
           <platforms>
-            <platform>unix</platform>
+            <platform>all</platform>
             <!-- "$BASEDIR/conf" to locate configuration file does not work under Windows -->
           </platforms>
           <configurationDirectory>conf</configurationDirectory>
@@ -37,6 +37,7 @@
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <logsDirectory>logs</logsDirectory>
           <projectArtifactFirstInClassPath>true</projectArtifactFirstInClassPath>
+          <extraJvmArguments>-Duser.timezone=UTC</extraJvmArguments>
         </configuration>
         <!-- needed for some reason -->
         <executions>
@@ -50,10 +51,6 @@
               <programs>
                 <program>
                   <mainClass>Jhove</mainClass>
-                  <commandLineArguments>
-                    <commandLineArgument>-c</commandLineArgument>
-                    <commandLineArgument>$BASEDIR/conf/jhove.conf</commandLineArgument>
-                  </commandLineArguments>
                   <id>jhove</id>
                 </program>
               </programs>

--- a/jhove-apps/src/main/config/jhove.conf
+++ b/jhove-apps/src/main/config/jhove.conf
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- copied in from jhove-installer -->
+<jhoveConfig version="1.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig"
+ xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig
+                     http://hul.harvard.edu/ois/xml/xsd/jhove/1.6/jhoveConfig.xsd">
+ <jhoveHome>unused</jhoveHome>
+ <defaultEncoding>utf-8</defaultEncoding>
+ <bufferSize>131072</bufferSize>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.AiffModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.WaveModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.PdfModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.Jpeg2000Module</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.JpegModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.GifModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.TiffModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.XmlModule</class>
+  <param>schema=http://www.example.com/schema;/home/schemas/exampleschema.xsd</param>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.HtmlModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.AsciiModule</class>
+ </module>
+ <module>
+  <class>edu.harvard.hul.ois.jhove.module.Utf8Module</class>
+ </module>
+</jhoveConfig>

--- a/jhove-core/src/main/examples/tiff/geotiff/README
+++ b/jhove-core/src/main/examples/tiff/geotiff/README
@@ -7,11 +7,11 @@ Copied 2003-08-15 from <http://pubs.usgs.gov/of/of99-396/htmldocs/data.htm>.
 
 compis.tif  Completed sidescan sonar mosaic with black background. (18 MB)
 compis.htm  Metadata
-compis.txt  Georeferencing report
+compis.txt  Georeferencing dk.statsbiblioteket.dpaviser.report
 compis.tfw  ESRI world file
 
 bathy1.tif  Bathymetry image of study area. Bathymetry shown in a gradiated
             pseudo-color table. (18 MB)
 bathy1.htm  Metadata
-bathy1.txt  Georeferencing report
+bathy1.txt  Georeferencing dk.statsbiblioteket.dpaviser.report
 bathy1.tfw  ESRI world file

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
@@ -399,7 +399,7 @@ public class AESAudioMetadata
 			
 	    // BWF allows for a negative timestamp but tcf does not, so adjust
 	    // time accordingly
-	    // this might be a good place to report a warning during validation
+	    // this might be a good place to dk.statsbiblioteket.dpaviser.report a warning during validation
 	    if (_sample_count < 0) {
 		_sample_count += sample_in_1_day;
 		_sample_count = (_sample_count % sample_in_1_day);

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/DocumentType.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/DocumentType.java
@@ -27,7 +27,7 @@ public final class DocumentType
      */
     public static final DocumentType BOOK = new DocumentType ("Book");
     /**
-     *  Document type for a report.
+     *  Document type for a dk.statsbiblioteket.dpaviser.report.
      */
     public static final DocumentType REPORT = new DocumentType ("Report");
     /**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -78,7 +78,7 @@ public abstract class ModuleBase
     protected MessageDigest _sha1;
         /**  Flag indicating valid checksum information set */
     protected boolean _checksumFinished;
-    /**  Indicator of how much data to report */
+    /**  Indicator of how much data to dk.statsbiblioteket.dpaviser.report */
     protected int _verbosity;
     /**  Flag to indicate read routines should count the stream */
     protected boolean _countStream;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/XMPHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/XMPHandler.java
@@ -165,7 +165,7 @@ public class XMPHandler extends org.xml.sax.helpers.DefaultHandler {
     }
     
     /** Catch a fatal error.  This is put here because the default
-     *  behavior is to report a "fatal error" to standard output,
+     *  behavior is to dk.statsbiblioteket.dpaviser.report a "fatal error" to standard output,
      *  which is harmless but scary.  
      */
     public void fatalError(SAXParseException exception)

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
@@ -343,7 +343,7 @@ public class AiffModule
        // Most properties were added by the Chunks.  The Annotations, Saxel
        // and MIDIData properties could have come from multiple chunks,
        // and these were added to lists which we now make into Properties
-       // if there's anything to report.
+       // if there's anything to dk.statsbiblioteket.dpaviser.report.
        if (!_annotationList.isEmpty ()) {
            _propList.add (new Property ("Annotations",
                 PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
@@ -436,7 +436,7 @@ public class GifModule extends ModuleBase
                 new Integer (bgColorIndex)));
         int pixAspectRatio = readUnsignedByte (_dstream, this);
         // The pixel aspect ratio is turned into a real aspect
-        // ratio by a formula, but we just report the raw number.
+        // ratio by a formula, but we just dk.statsbiblioteket.dpaviser.report the raw number.
         propVec.add (new Property ("PixelAspectRatio",
                 PropertyType.SHORT,
                 new Short ((short) pixAspectRatio)));

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
@@ -29,7 +29,7 @@ import edu.harvard.hul.ois.jhove.module.html.*;
  * 
  * HTML is different from most of the other documents in that sloppy
  * construction is practically assumed in the specification. This module attempt
- * to report as many errors as possible and recover reasonably from errors. To
+ * to dk.statsbiblioteket.dpaviser.report as many errors as possible and recover reasonably from errors. To
  * do this, there is more heuristic behavior built into this module than into
  * the more straightforward ones.
  * 
@@ -40,7 +40,7 @@ import edu.harvard.hul.ois.jhove.module.html.*;
  * 
  * HTML should be placed ahead of XML in the module order. If the XML module
  * sees an XHTML file first, it will recognize it as XHTML, but won't be able to
- * report the complete properties.
+ * dk.statsbiblioteket.dpaviser.report the complete properties.
  * 
  * The HTML module uses code created with the JavaCC parser generator and
  * lexical analyzer generator. There is apparently a bug in JavaCC which causes

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -178,7 +178,7 @@ public class JpegModule extends ModuleBase {
      */
     protected boolean _seenJPEGL;
 
-    /* Flag to make sure we report signature matching only once. */
+    /* Flag to make sure we dk.statsbiblioteket.dpaviser.report signature matching only once. */
     protected boolean _reportedSigMatch;
 
     /* SPIFF directory information. */
@@ -609,7 +609,7 @@ public class JpegModule extends ModuleBase {
                     case 0XEE:
                     case 0XEF:
                         // Appn extensions which we don't handle specially,
-                        // but do report the existence thereof
+                        // but do dk.statsbiblioteket.dpaviser.report the existence thereof
                         reportAppExt(dbyt, info);
                         skipSegment(info);
                         break;
@@ -1052,7 +1052,7 @@ public class JpegModule extends ModuleBase {
             _seenExif = true;
             if (!JpegExif.isTiffAvailable()) {
                 info.setMessage(new InfoMessage(
-                        "TIFF-HUL module required to report Exif data", _nByte));
+                        "TIFF-HUL module required to dk.statsbiblioteket.dpaviser.report Exif data", _nByte));
                 skipBytes(_dstream, length - 8, this);
                 return;
             }
@@ -1252,9 +1252,9 @@ public class JpegModule extends ModuleBase {
 
     /*
      * Accumulate reports of APPn segments into a property. It's tempting to
-     * report information about the segment, since many APPn segments have ASCII
+     * dk.statsbiblioteket.dpaviser.report information about the segment, since many APPn segments have ASCII
      * identifiers, but there's no guarantee of any content beyond the length
-     * field, so we just report the existence of all APPn segments. No attempt
+     * field, so we just dk.statsbiblioteket.dpaviser.report the existence of all APPn segments. No attempt
      * is made to weed out duplicates, since multiple instances of the same
      * segment number are legitimate and informative.
      */

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -81,7 +81,7 @@ public class PdfModule
      ******************************************************************/
     
     /* The maximum number of fonts that will be reported before we just
-     * give up and report a stub to avoid running out of memory. */
+     * give up and dk.statsbiblioteket.dpaviser.report a stub to avoid running out of memory. */
     protected int DEFAULT_MAX_FONTS = 1000;
     
     /* Constants for trailer parsing */
@@ -171,7 +171,7 @@ public class PdfModule
     /** Map of visited nodes when walking through an outline. */
     protected Set<Integer> _visitedOutlineNodes;
     
-    /** maximum number of fonts to report full information on. */
+    /** maximum number of fonts to dk.statsbiblioteket.dpaviser.report full information on. */
     protected int maxFonts;
     
     /** Number of fonts reported so far. */
@@ -611,7 +611,7 @@ public class PdfModule
 			}
         }
         if (_nFonts > maxFonts) {
-            info.setMessage(new InfoMessage ("Too many fonts to report; some fonts omitted.", 
+            info.setMessage(new InfoMessage ("Too many fonts to dk.statsbiblioteket.dpaviser.report; some fonts omitted.",
                           "Total fonts = " + _nFonts));
         }
         if (_xmpProp != null) {
@@ -2205,7 +2205,7 @@ public class PdfModule
                         }
                         // If we've been directed appropriately,
                         // we accumulate the information, but don't
-                        // report it.  In that case, we post a message
+                        // dk.statsbiblioteket.dpaviser.report it.  In that case, we post a message
                         // just once to that effect.
                         if (!_skippedFontsReported && 
                             !_showFonts && 
@@ -2742,8 +2742,8 @@ public class PdfModule
                         pagePropList.add (annotProp);
                     }
                     else {
-                        // We don't report annotations if we got here,
-                        // but we do report that we don't report them.
+                        // We don't dk.statsbiblioteket.dpaviser.report annotations if we got here,
+                        // but we do dk.statsbiblioteket.dpaviser.report that we don't dk.statsbiblioteket.dpaviser.report them.
                         if (!_skippedAnnotationsReported) {
                             info.setMessage (new InfoMessage
                                 (annotationsSkippedString));
@@ -2806,7 +2806,7 @@ public class PdfModule
                         PropertyArity.LIST,
                         vplist));
             }
-            // Thumbnail -- we just report if it's there. It's a 
+            // Thumbnail -- we just dk.statsbiblioteket.dpaviser.report if it's there. It's a
             // non-inheritable property
             PdfObject thumb = page.get ("Thumb", false);
             if (thumb != null) {
@@ -3155,7 +3155,7 @@ public class PdfModule
                         (dest.getIndirectDest ());
                     if (pageObjNum == -1) {
                     // The scope of the reference is outside this
-                    // file, so we just report it as such.
+                    // file, so we just dk.statsbiblioteket.dpaviser.report it as such.
                     propList.add (new Property (propName,
                                     PropertyType.STRING,
                                     "External"));
@@ -3971,7 +3971,7 @@ public class PdfModule
                     }
                 }
                 else if (!_skippedOutlinesReported) {
-                    // We report that we aren't reporting skipped outlines
+                    // We dk.statsbiblioteket.dpaviser.report that we aren't reporting skipped outlines
                     info.setMessage (new InfoMessage
                                 (outlinesSkippedString));
                     _skippedOutlinesReported = true;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -331,7 +331,7 @@ public class WaveModule extends ModuleBase {
         }
 
         // Add note and label properties, if there's anything
-        // to report.
+        // to dk.statsbiblioteket.dpaviser.report.
         if (!_labels.isEmpty()) {
             _propList.add(new Property("Labels", PropertyType.PROPERTY,
                     PropertyArity.LIST, _labels));

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -452,7 +452,7 @@ public class XmlModule
                 info.setSigMatch(_name);
             }
             // Sometimes the message will be null and another message
-            // wrapped inside it.  Try to report that.
+            // wrapped inside it.  Try to dk.statsbiblioteket.dpaviser.report that.
             String msg = e.getMessage ();
             if (msg == null) {
                 Throwable ee = e.getCause();

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/ApplicationChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/ApplicationChunk.java
@@ -56,7 +56,7 @@ public class ApplicationChunk extends Chunk {
         // If the application signature is 'pdos' or 'stoc',
         // then the beginning of the data area is a Pascal
         // string naming the application.  Otherwise, we
-        // just report the raw data.  ('pdos' is for Apple II
+        // just dk.statsbiblioteket.dpaviser.report the raw data.  ('pdos' is for Apple II
         // applications, 'stoc' for the entire non-Apple world.)
         if ("stoc".equals (applicationSignature) ||
                 "pdos".equals (applicationSignature)) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlDocDesc.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlDocDesc.java
@@ -80,7 +80,7 @@ public abstract class HtmlDocDesc {
         // HtmlTagDesc object for the tag that we find, with the closing tag indicated
         // as optional.
         // For each open tag, we push the HtmlTagDesc object onto the stack.  We check
-        // if it's in the allowed content of the enclosing element.  If not, we report it
+        // if it's in the allowed content of the enclosing element.  If not, we dk.statsbiblioteket.dpaviser.report it
         // as an error but continue with it anyway.  
         //
         // We special-case HTML, HEAD and BODY, which can be implied.
@@ -282,7 +282,7 @@ public abstract class HtmlDocDesc {
     {
         String name = tag.getName ();
         // Dig down into the stack till we find an element which
-        // matches this.  If there's none, report the document
+        // matches this.  If there's none, dk.statsbiblioteket.dpaviser.report the document
         // as not well formed.  Also allow for the special case
         // of an empty body.  (An empty head is illegal.)
         int idx = elementStack.search (name);
@@ -423,7 +423,7 @@ public abstract class HtmlDocDesc {
         
         // Pop elements till we find a valid context.  If
         // the enclosing element doesn't have an optional close
-        // tag, report an error but pop it anyway.  But first
+        // tag, dk.statsbiblioteket.dpaviser.report an error but pop it anyway.  But first
         // check if there even is a context to which we can pop things.
         boolean complained = false;
         boolean searchStack = false;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/TokenMgrError.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/TokenMgrError.java
@@ -107,7 +107,7 @@ public class TokenMgrError extends Error
     * For example, cases like LOOP_DETECTED and INVALID_LEXICAL_STATE are not
     * of end-users concern, so you can return something like : 
     *
-    *     "Internal Error : Please file a bug report .... "
+    *     "Internal Error : Please file a bug dk.statsbiblioteket.dpaviser.report .... "
     *
     * from this method for such cases in the release version of your parser.
     */

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/BinaryFilterBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/BinaryFilterBox.java
@@ -26,7 +26,7 @@ import edu.harvard.hul.ois.jhove.*;
  *  encoded inside another BinaryFilterBox.  
  * 
  *  This is untested code, due to lack of sample files;
- *  please report any bugs found to HUL/OIS.
+ *  please dk.statsbiblioteket.dpaviser.report any bugs found to HUL/OIS.
  * 
  * @author Gary McGath
  *
@@ -61,7 +61,7 @@ public class BinaryFilterBox extends JP2Box {
      */
     public boolean readBox() throws IOException {
         // Compare the filter type with the GZIP type.
-        // If it's anything else, just report a property
+        // If it's anything else, just dk.statsbiblioteket.dpaviser.report a property
         // and ignore the contents.
         byte[] uuidbuf = new byte[16];
         ModuleBase.readByteBuf (_dstrm, uuidbuf, _module);
@@ -78,13 +78,13 @@ public class BinaryFilterBox extends JP2Box {
                     PropertyArity.ARRAY,
                     uuidbuf));
         if (isGzip) {
-            // report that we've left information unprocessed
+            // dk.statsbiblioteket.dpaviser.report that we've left information unprocessed
             _repInfo.setMessage(new InfoMessage
                     ("Binary Filter Box of type other than Gzip, contents not processed",
                      _module.getFilePos ()));
         }
         else {
-            // We use a CountedInputStream, which will report an
+            // We use a CountedInputStream, which will dk.statsbiblioteket.dpaviser.report an
             // EOF after streamLimit bytes.
             // The caller is responsible for making sure that
             // the underlying stream doesn't get mixed up with this
@@ -99,7 +99,7 @@ public class BinaryFilterBox extends JP2Box {
                     (new CountedInputStream (_dstrm, streamLimit)));
         }
         
-        // We report _bytesRead as the total number of bytes in the
+        // We dk.statsbiblioteket.dpaviser.report _bytesRead as the total number of bytes in the
         // box, including the stream which hasn't actually been read
         // yet, because that makes things easier for the caller to
         // keep things counted.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/BoxHolder.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/BoxHolder.java
@@ -50,7 +50,7 @@ public class BoxHolder implements Iterator<Object> {
      * In practice, this means returning the beginning of the Box. */
     protected long getFilePos () 
     {
-        // ghaaaaaa ... Maybe the best I can do is report
+        // ghaaaaaa ... Maybe the best I can do is dk.statsbiblioteket.dpaviser.report
         // the start of the box in the file.  the module's
         // file position is useless.  Of course, for a Binary
         // Filter box, even getting the start of the box in

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ChannelDefBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ChannelDefBox.java
@@ -62,7 +62,7 @@ public class ChannelDefBox extends JP2Box {
             len -= 6;
             
             // The interpretation of the assoc field depends
-            // on the color space, so we just report it as
+            // on the color space, so we just dk.statsbiblioteket.dpaviser.report it as
             // an integer.
             cprop[2] = new Property ("ChannelAssociation",
                         PropertyType.INTEGER,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DigSignatureBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DigSignatureBox.java
@@ -103,7 +103,7 @@ public class DigSignatureBox extends JP2Box {
             }
             catch (NoSuchAlgorithmException e) { 
                 // In the unlikely event the algorithms aren't
-                // available, just don't report validity.  
+                // available, just don't dk.statsbiblioteket.dpaviser.report validity.
             }
             catch (IOException f) {}
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FileTypeBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FileTypeBox.java
@@ -83,9 +83,9 @@ public class FileTypeBox extends JP2Box {
             String citem = _module.read4Chars (_dstrm);
             
             // Some files have a count of entries, which isn't supposed
-            // to be there.  If we see any nulls, report an ill-formed condition.
+            // to be there.  If we see any nulls, dk.statsbiblioteket.dpaviser.report an ill-formed condition.
             // For each entry, we build a hex string in hexcitem just in case
-            // it's necessary to report the string in hex.
+            // it's necessary to dk.statsbiblioteket.dpaviser.report the string in hex.
             char[] cbytes = citem.toCharArray();
             boolean binflag = false;
             for (int j = 0; j < cbytes.length; j++) {
@@ -94,7 +94,7 @@ public class FileTypeBox extends JP2Box {
                 if (ch == 0 || ch >= 0X7F) {
                     binflag = true;
                     if (!eflag) {
-                        eflag = true;   // Avoid multiple report of same error
+                        eflag = true;   // Avoid multiple dk.statsbiblioteket.dpaviser.report of same error
                         _repInfo.setValid (false);
                         _repInfo.setMessage (new ErrorMessage
                             ("Non-ASCII characters in compatibility item of File Type Box",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FragmentListBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FragmentListBox.java
@@ -64,7 +64,7 @@ public class FragmentListBox extends JP2Box {
             int dataRef = _module.readUnsignedShort (_dstrm);
 
             // If dataRef is nonzero, the stream is outside the file,
-            // and all we can do is report the reference.  In fact,
+            // and all we can do is dk.statsbiblioteket.dpaviser.report the reference.  In fact,
             // if any of the fragments are outside the file, we 
             // have to punt.  So we should collect all the
             // fragments and then read the stream.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/GTSOBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/GTSOBox.java
@@ -40,7 +40,7 @@ public class GTSOBox extends JP2Box {
     public boolean readBox() throws IOException {
         initBytesRead ();
         // Short of pulling out the bytes and somehow
-        // analyzing them, about all we can do is report
+        // analyzing them, about all we can do is dk.statsbiblioteket.dpaviser.report
         // the presence and length of the profile.  
         
         // There can be only one GTSO box within the file,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/JP2Box.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/JP2Box.java
@@ -327,7 +327,7 @@ public abstract class JP2Box extends BoxHolder {
     }
 
     /* Adds an Association property.  Most superboxes can
-     * contain Association boxes; these report themselves
+     * contain Association boxes; these dk.statsbiblioteket.dpaviser.report themselves
      * as Association properties. 
      */
     protected void addAssociation (Property p)

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/AProfile.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/AProfile.java
@@ -24,7 +24,7 @@ import javax.xml.parsers.*;
  *  means "PDF/A-1" in the documentation of this code.
  * 
  *  There are two levels of conformance, called Level A and Level B.
- *  We report these as two different profiles.  To accomplish this,
+ *  We dk.statsbiblioteket.dpaviser.report these as two different profiles.  To accomplish this,
  *  we use AProfileLevelA, linked to an instance of this, which
  *  simply checks if this profile established Level A compliance.
  */

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
@@ -1377,7 +1377,7 @@ public class TiffIFD
                                              NEWSUBFILETYPE_L, rawOutput));
         }
         else {
-            // if 0, always report as a raw number
+            // if 0, always dk.statsbiblioteket.dpaviser.report as a raw number
             entries.add (new Property ("NewSubfileType", PropertyType.LONG,
                                     new Long (_newSubfileType)));
         }
@@ -1386,7 +1386,7 @@ public class TiffIFD
                                              SUBFILETYPE_L, rawOutput));
         }
         else if (_subfileType != NULL) {
-            // if 0, always report as a raw number
+            // if 0, always dk.statsbiblioteket.dpaviser.report as a raw number
             entries.add (new Property ("SubfileType", PropertyType.LONG,
                                     new Long (_subfileType)));
         }
@@ -3482,7 +3482,7 @@ public class TiffIFD
             }
             else if (tag == TRANSFERFUNCTION) {
                 /* Transfer function arrays potentially can have millions
-                 * of elements, so we just report presence */
+                 * of elements, so we just dk.statsbiblioteket.dpaviser.report presence */
                 checkType  (tag, type, SHORT);
                 _transferFunction = true;
             }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExifIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExifIFD.java
@@ -21,7 +21,7 @@ public class TiffProfileExifIFD extends TiffProfile {
     public TiffProfileExifIFD ()
     {        
         super ();
-        // This isn't used directly to report a profile, so the
+        // This isn't used directly to dk.statsbiblioteket.dpaviser.report a profile, so the
         // profile text is irrelevant.
         _profileText = null;
         _majVersion = -1;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExifThumb.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExifThumb.java
@@ -29,7 +29,7 @@ public class TiffProfileExifThumb extends TiffProfile {
     public TiffProfileExifThumb ()
     {
         super ();
-        // This isn't used directly to report a profile, so the
+        // This isn't used directly to dk.statsbiblioteket.dpaviser.report a profile, so the
         // profile text is irrelevant.
         _profileText = null;
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
@@ -75,7 +75,7 @@ public class XmlModuleHandler extends DefaultHandler {
      * check on the use of unparsed entities. */
     private Set<String> _attributeVals;
     
-    /* Limit on number of errors to report. */
+    /* Limit on number of errors to dk.statsbiblioteket.dpaviser.report. */
     private static final int MAXERRORS = 2000;
 
     /* XHTML flag, only for XHTML documents referred


### PR DESCRIPTION
…hove during build.

We would like to use jhove as a library for our own application, but it is designed to be used from the command line only.  In order to enclose it in our build (as a git submodule providing a maven module) I have added appassembler-maven-plugin support in order to create a "jhove" binary in jhove/jhove-apps/target/appassembler during the maven build we can call from integration tests etc.

Due to the design of jhove a configuration file _must_ be present in the file system.  I have added a copy of the jhove.conf file found in jhove-installer and set joveHome to "unused", and let the unix wrapper know about it.
