### PR TITLE
Remove forced test logging output regardless of logging level.

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -305,11 +305,6 @@ public class JhoveBase {
                 }
             }
         }
-        _logger.severe("Testing SEVERE level");
-        _logger.warning("Testing WARN level");
-        _logger.info("Testing INFO level");
-        _logger.fine("Testing FINE level");
-        _logger.finest("Testing FINEST level");
 
         _bufferSize = configHandler.getBufferSize();
         if (_bufferSize < 0) {


### PR DESCRIPTION
When running JHOVE from a terminal it is not possible to turn off an initial logging statement "SEVERE: Testing SEVERE level". Would like to remove these few "test?" logging lines of code in a future release.
