### PR TITLE
Removing final keyword from parsing method in jhove modules

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
@@ -145,7 +145,7 @@ public class AsciiModule extends ModuleBase {
      * RepInfo.
      */
     @Override
-    public final int parse(InputStream stream, RepInfo info, int parseIndex)
+    public int parse(InputStream stream, RepInfo info, int parseIndex)
             throws IOException {
         // Test if textMD is to be generated
         if (_defaultParams != null) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
@@ -309,7 +309,7 @@ public class Jpeg2000Module extends ModuleBase {
      *            with each call.
      */
     @Override
-    public final void parse(RandomAccessFile raf, RepInfo info)
+    public void parse(RandomAccessFile raf, RepInfo info)
             throws IOException {
         initParse();
         _rafStream = new RAFInputStream(raf, _je != null ? _je.getBufferSize()

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -457,7 +457,7 @@ public class PdfModule
      *                the descriptive information
      */
     @Override
-    public final void parse (RandomAccessFile raf, RepInfo info) 
+    public void parse (RandomAccessFile raf, RepInfo info) 
         throws IOException
     {
         initParse ();

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -392,7 +392,7 @@ public class TiffModule extends ModuleBase {
      *            Representation informatino
      */
     @Override
-    public final void parse(RandomAccessFile raf, RepInfo info)
+    public void parse(RandomAccessFile raf, RepInfo info)
             throws IOException {
         if (_defaultParams != null) {
             Iterator<String> iter = _defaultParams.iterator();

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
@@ -168,7 +168,7 @@ public class Utf8Module extends ModuleBase {
      *
      */
     @Override
-    public final int parse(InputStream stream, RepInfo info, int parseIndex)
+    public int parse(InputStream stream, RepInfo info, int parseIndex)
             throws IOException {
         // Test if textMD is to be generated
         if (_defaultParams != null) {


### PR DESCRIPTION
this way anyone can easily extend a module that already exists.
