### PR TITLE
FIX - Highlight Travis-CI regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ script:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+
+after_failure:
+- cat /tmp/bbt-logs/log.txt | grep Expected


### PR DESCRIPTION
- when integration tests fail cat log file and grep for the XML unit "Expected" errors.
