### PR TITLE
FEAT - Maven Central Ready

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,33 +60,33 @@
     <system>OPF Jenkins</system>
     <url>http://jenkins.opf-labs.org</url>
   </ciManagement>
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
   <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
     <repository>
-      <id>OPF Artefactory</id>
-      <name>OPF Artefactory-releases</name>
-      <url>http://artifactory.openpreservation.org/artifactory/opf-dev-local/</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
-
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>opf-dev</id>
-      <name>OPF development</name>
-      <url>http://artifactory.openpreservation.org/artifactory/opf-dev/</url>
-    </repository>
-  </repositories>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <mvn.compiler.version>3.3</mvn.compiler.version>
+    <mvn.deploy.version>2.8.1</mvn.deploy.version>
     <mvn.resources.version>2.6</mvn.resources.version>
+    <mvn.gpg.version>1.6</mvn.gpg.version>
     <mvn.jar.version>2.6</mvn.jar.version>
     <mvn.javadoc.version>2.10</mvn.javadoc.version>
     <mvn.source.version>2.4</mvn.source.version>
+    <mvn.surefire.version>2.19.1</mvn.surefire.version>
+    <mvn.release.version>2.5.3</mvn.release.version>
     <jacoco.version>0.7.6.201602180812</jacoco.version>
     <java.source.version>1.5</java.source.version>
     <java.target.version>1.6</java.target.version>
@@ -125,6 +125,31 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${mvn.javadoc.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${mvn.gpg.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${mvn.release.version}</version>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <useReleaseProfile>false</useReleaseProfile>
+            <releaseProfiles>release</releaseProfiles>
+            <goals>deploy</goals>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${mvn.deploy.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${mvn.surefire.version}</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -197,10 +222,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -316,21 +337,18 @@
               </execution>
             </executions>
           </plugin>
-
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <autoVersionSubmodules>true</autoVersionSubmodules>
+              <useReleaseProfile>false</useReleaseProfile>
+              <releaseProfiles>release</releaseProfiles>
+              <goals>deploy</goals>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>sonar</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <sonar.host.url>
-          http://sonar.opf-labs.org
-        </sonar.host.url>
-      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
- removed OPF artefactory from distribution;
- added Sonatype repo information;
- moved source and javadoc plugins to release profile; and
- adjusted setup for closer control using maven local `~/.m2/settings.xml`.