### PR TITLE
Fix validation of WAVE files over 2 GB

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -654,7 +654,6 @@ public class WaveModule extends ModuleBase {
 
     /**
      * Reads a WAVE Chunk.
-     * 
      */
     protected boolean readChunk(RepInfo info) throws IOException {
         Chunk chunk = null;
@@ -662,7 +661,7 @@ public class WaveModule extends ModuleBase {
         if (!chunkh.readHeader(_dstream)) {
             return false;
         }
-        int chunkSize = (int) chunkh.getSize();
+        long chunkSize = chunkh.getSize();
         bytesRemaining -= chunkSize + 8;
 
         if (bytesRemaining < 0) {


### PR DESCRIPTION
Chunk sizes were being incorrectly cast from `long` to `int`, producing inaccurate size calculations for chunks over the maximum value of `int` (2,147,483,647). Fixes #167.