### PR TITLE
Fix recently broken ModuleBase.skipBytes method

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -1295,7 +1295,7 @@ public abstract class ModuleBase
     }
 
     public static double readDouble (RandomAccessFile file, boolean endian)
-        throws IOException 
+        throws IOException
     {
         double f = 0.0F;
         if (endian) {
@@ -1354,32 +1354,31 @@ public abstract class ModuleBase
         return f;
     }
 
-    /* Skip over some bytes.  */
-	public long skipBytes(DataInputStream stream, long bytesToSkip)
-            throws IOException
+    /** Skip over some bytes. Return number of bytes skipped. */
+    public long skipBytes(DataInputStream stream, long bytesToSkip)
+        throws IOException
     {
-	return skipBytes (stream, bytesToSkip, null);
+        return skipBytes(stream, bytesToSkip, null);
     }
 
-    /* Skip over some bytes.  */
-	public long skipBytes(DataInputStream stream, long bytesToSkip,
-			  ModuleBase counted) 
-            throws IOException
+    /** Skip over some bytes. Return number of bytes skipped. */
+    public long skipBytes(DataInputStream stream, long bytesToSkip,
+                          ModuleBase counted)
+        throws IOException
     {
-        long retVal = 0;
-        long bytesLeft = bytesToSkip;
-        while (bytesLeft > 0) {
-            long n = stream.skip(bytesToSkip);
-            bytesLeft -= n;
-            retVal += n;
-            if (counted != null) {
-                counted._nByte += n;
-            }
-            if (stream.available() == 0) {
-                break;
-            }
+        long totalBytesSkipped = 0;
+        while (bytesToSkip > 0) {
+            long bytesSkipped = stream.skip(bytesToSkip);
+            totalBytesSkipped += bytesSkipped;
+            bytesToSkip -= bytesSkipped;
+            // Cease skipping if end of stream reached before
+            // requested number of bytes have been skipped.
+            if (stream.available() == 0) break;
         }
-        return retVal;
+        if (counted != null) {
+            counted._nByte += totalBytesSkipped;
+        }
+        return totalBytesSkipped;
     }
 
     /**


### PR DESCRIPTION
Broken during incorrect merge of PR #117. Each loop of the skip method was skipping the same amount of bytes, not subtracting the amount already skipped. Reverted to original pull request code then refactored. Fixes #71, fixes #193.

Since this bug is in the core JHOVE code and can affect all modules, I'd say it warrants a minor version release.