### PR TITLE
Fix NPE preventing CrossRefStream objects from being read

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/CrossRefStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/CrossRefStream.java
@@ -105,6 +105,7 @@ public class CrossRefStream {
 
                 _index = new IndexRange[indexObjCount / 2];
                 for (int i = 0; i < _index.length; i++) {
+                    _index[i] = new IndexRange();
                     _index[i].start = ((PdfSimpleObject)indexObjs.get(i * 2)).getIntValue();
                     _index[i].len = ((PdfSimpleObject)indexObjs.get(i * 2 + 1)).getIntValue();
                 }
@@ -112,6 +113,7 @@ public class CrossRefStream {
             else {
                 // Set up default index.
                 _index = new IndexRange[1];
+                _index[0] = new IndexRange();
                 _index[0].start = 0;
                 _index[0].len = _size;
             }


### PR DESCRIPTION
A NullPointerException was being thrown when trying to validate the Index entry of any CrossRefStream dictionary. For examples, see the PDFs in the [regression test corpus](https://github.com/openpreserve/jhove/tree/dcb90c52766c64e15361a31a36edc261822ef49b/test-root/corpora/regression/modules/PDF-hul), many of which include CrossRefStreams.

The NPEs were hidden by the method's overly general exception handling, and even though the containing method was returning false, and ending file validation, no errors of any kind were being reported. This resulted in any PDF with a CrossRefStream object being reported as "Well-formed and valid" though most of the file's contents would remain unchecked.

This bug was introduced in 1.16, and is likely to affect many modern PDF files, reporting them as valid with almost no validation. I'd suggest another hotfix release, if there's bandwidth.