### PR TITLE
Fix NPE preventing XRefStream objects being read

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,21 +10,20 @@ Versions 1.12 onwards of JHOVE released by the Open Preservation Foundation.
 
 JHOVE 1.16
 ----------
-2016-07-20
-### FIX - NPE preventing CrossRefStream objects from being read
+
+### 2017-07-20 : FIX - NPE preventing CrossRefStream objects from being read
 See [Pull Request #258](https://github.com/openpreserve/jhove/pull/258)
 
-The NPEs were hidden by overly general exception handling ending file validation where no errors were reported. This results PDFs with CrossRefStream objects being reported as "Well-formed and valid" when most of the file's contents remain unchecked.
+Fixes PDFs with CrossRefStream objects being reported as "Well-formed and valid" when most of the file's contents remain unchecked.
 
-2016-03-20
-### FIX - Broken ModuleBase.skipBytes method
+### 2017-03-20 : FIX - Broken ModuleBase.skipBytes method
 See [Pull Request #194](https://github.com/openpreserve/jhove/pull/194)
 
 Fixes:
 - [Issue #71](https://github.com/openpreserve/jhove/issues/71)
 - [Issue #193](https://github.com/openpreserve/jhove/issues/193)
 
-2016-03-16
+2017-03-16
 
 ### General
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,20 @@ Versions 1.12 onwards of JHOVE released by the Open Preservation Foundation.
 
 JHOVE 1.16
 ----------
+2016-07-20
+### FIX - NPE preventing CrossRefStream objects from being read
+See [Pull Request #258](https://github.com/openpreserve/jhove/pull/258)
+
+The NPEs were hidden by overly general exception handling ending file validation where no errors were reported. This results PDFs with CrossRefStream objects being reported as "Well-formed and valid" when most of the file's contents remain unchecked.
+
+2016-03-20
+### FIX - Broken ModuleBase.skipBytes method
+See [Pull Request #194](https://github.com/openpreserve/jhove/pull/194)
+
+Fixes:
+- [Issue #71](https://github.com/openpreserve/jhove/issues/71)
+- [Issue #193](https://github.com/openpreserve/jhove/issues/193)
+
 2016-03-16
 
 ### General

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -12,12 +12,14 @@ JHOVE 1.16
 ----------
 
 ### 2017-07-20 : FIX - NPE preventing CrossRefStream objects from being read
-See [Pull Request #258](https://github.com/openpreserve/jhove/pull/258)
+Contains:
+- [Pull Request #258](https://github.com/openpreserve/jhove/pull/258)
 
 Fixes PDFs with CrossRefStream objects being reported as "Well-formed and valid" when most of the file's contents remain unchecked.
 
 ### 2017-03-20 : FIX - Broken ModuleBase.skipBytes method
-See [Pull Request #194](https://github.com/openpreserve/jhove/pull/194)
+Contains:
+- [Pull Request #194](https://github.com/openpreserve/jhove/pull/194)
 
 Fixes:
 - [Issue #71](https://github.com/openpreserve/jhove/issues/71)

--- a/jhove-bbt/scripts/create-1.16-target.sh
+++ b/jhove-bbt/scripts/create-1.16-target.sh
@@ -64,8 +64,8 @@ find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i '/^   <module 
 
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.5">UTF8-hul<\/module>$/   <module release="1.6">UTF8-hul<\/module>/' {} \;
 
-find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.7">PDF-hul<\/module>$/   <module release="1.8">PDF-hul<\/module>/' {} \;
-find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <release>1.7<\/release>$/  <release>1.8<\/release>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.7">PDF-hul<\/module>$/   <module release="1.9">PDF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <release>1.7<\/release>$/  <release>1.9<\/release>/' {} \;
 
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.3">WAVE-hul<\/module>$/   <module release="1.4">WAVE-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's/^  <release>1.3<\/release>$/  <release>1.4<\/release>/' {} \;
@@ -76,11 +76,11 @@ find "${targetRoot}" -type f -name "audit-UTF8-hul.jhove.xml" -exec sed -i 's/^ 
 
 find "${targetRoot}" -type f -name "*.jhove.xml" -exec sed -i 's/2011-02-03/2014-07-18/' {} \;
 
-find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <date>2012-08-12<\/date>$/  <date>2017-03-14<\/date>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <date>2012-08-12<\/date>$/  <date>2017-07-20<\/date>/' {} \;
 find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's/^  <date>2007-12-14<\/date>$/  <date>2017-03-14<\/date>/' {} \;
 
-find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">PDF%<reportingModule release="1.8" date="2017-03-14">PDF%' {} \;
-find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">PDF%<reportingModule release="1.8" date="2017-03-14">PDF%' {} \;
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">PDF%<reportingModule release="1.9" date="2017-07-20">PDF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">PDF%<reportingModule release="1.9" date="2017-07-20">PDF%' {} \;
 find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<reportingModule release="1.3" date="2007-12-14">WAVE%<reportingModule release="1.4" date="2017-03-14">WAVE%' {} \;
 
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/<rights>.*<\/rights>/<rights>Derived from software Copyright 2004-2011 by the President and Fellows of Harvard College. Version 1.7 to 1.11 independently released. Version 1.12 onwards released by Open Preservation Foundation. Released under the GNU Lesser General Public License.<\/rights>/' {} \;
@@ -91,28 +91,28 @@ find "${targetRoot}" -type f -name "*.jhove.xml" -exec sed -i 's%Unicode6\.0\.0%
 
 find "${targetRoot}" -type f -name "*.jhove.xml" -exec sed -i 's%<reportingModule release="1.5"%<reportingModule release="1.6"%' {} \;
 
-falsePositivePdfs="pdf-hul-10-814778526.pdf.jhove.xml
-pdf-hul-11-govdocs-152588.pdf.jhove.xml
-pdf-hul-15-grid-system.pdf.jhove.xml
-pdf-hul-2-simple-annotated-in-adobe-x.pdf.jhove.xml
-pdf-hul-33-826355544.pdf.jhove.xml
-pdf-hul-39-616615442.pdf.jhove.xml
+falsePositivePdfs="pdf-hul-2-simple-annotated-in-adobe-x.pdf.jhove.xml
 pdf-hul-4-615006647.pdf.jhove.xml
 pdf-hul-4-govdocs-788261.pdf.jhove.xml
+pdf-hul-5-externalLink.pdf.jhove.xml
+pdf-hul-10-814778526.pdf.jhove.xml
+pdf-hul-15-grid-system.pdf.jhove.xml
+pdf-hul-33-826355544.pdf.jhove.xml
+pdf-hul-39-616615442.pdf.jhove.xml
 pdf-hul-40-61501688X.pdf.jhove.xml
 pdf-hul-40-govdocs-088919.pdf.jhove.xml
 pdf-hul-41-834460599.pdf.jhove.xml
 pdf-hul-44-629642362.pdf.jhove.xml
 pdf-hul-45-52897422X.pdf.jhove.xml
 pdf-hul-45-govdocs-600753.pdf.jhove.xml
-pdf-hul-5-externalLink.pdf.jhove.xml
+pdf-hul-51-govdocs-085551.pdf.jhove.xml
+pdf-hul-52-govdocs-983827.pdf.jhove.xml
 pdf-hul-55-govdocs-616137.pdf.jhove.xml
 pdf-hul-56-improperly-constructed-page-tree.pdf.jhove.xml
 pdf-hul-59-629642362.pdf.jhove.xml
 pdf-hul-59-govdocs-681811.pdf.jhove.xml
 pdf-hul-64-616615027.pdf.jhove.xml
 pdf-hul-65-847453723.pdf.jhove.xml
-pdf-hul-8-Secured.pdf.jhove.xml
 pdf-hul-84-govdocs-484279.pdf.jhove.xml
 pdf-hul-87-embedded_video_avi.pdf.jhove.xml
 pdf-hul-87-webCapture.pdf.jhove.xml"

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -42,8 +42,8 @@ public class PdfModule
      ******************************************************************/
 
     private static final String NAME = "PDF-hul";
-    private static final String RELEASE = "1.8";
-    private static final int [] DATE = {2017, 3, 14};
+    private static final String RELEASE = "1.9";
+    private static final int [] DATE = {2017, 7, 20};
     private static final String [] FORMAT = {
         "PDF", "Portable Document Format"
     };

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/CrossRefStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/CrossRefStream.java
@@ -105,6 +105,7 @@ public class CrossRefStream {
 
                 _index = new IndexRange[indexObjCount / 2];
                 for (int i = 0; i < _index.length; i++) {
+                    _index[i] = new IndexRange();
                     _index[i].start = ((PdfSimpleObject)indexObjs.get(i * 2)).getIntValue();
                     _index[i].len = ((PdfSimpleObject)indexObjs.get(i * 2 + 1)).getIntValue();
                 }
@@ -112,6 +113,7 @@ public class CrossRefStream {
             else {
                 // Set up default index.
                 _index = new IndexRange[1];
+                _index[0] = new IndexRange();
                 _index[0].start = 0;
                 _index[0].len = _size;
             }


### PR DESCRIPTION
A NullPointerException was being thrown when trying to validate the
Index entry of any CrossRefStream dictionary.

The NPEs were hidden by the method's general Exception handling, and even
though the containing method was returning false, and ending file
validation, no errors of any kind were being reported.

This resulted in any PDF with a CrossRefStream object being reported as
"Well-formed and valid" though most of the file's contents would remain
unchecked.