### PR TITLE
WAVE: Add support for recognizing BWF v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ JHOVE is currently being maintained by the
 Pre-requisites
 --------------
  1. Java JRE 1.6  
-    (JHOVE was originally implemented using the Sun J2SE SDK 1.4.1 and has
-    been tested to work with 1.5). Version 1.16 of JHOVE is built and
-    tested against Oracle JDK 7, and OpenJDK 6 & 7 on Travis. Releases are
-    built using Oracle JDK 7 from the [OPF's Jenkins server](http://jenkins.openpreservation.org/).
+    Version 1.16 of JHOVE is built and tested against Oracle JDK 8,
+    and OpenJDK 7 & 8 on Travis. Releases are built using Oracle JDK 7
+    from the [OPF's Jenkins server](http://jenkins.openpreservation.org/).
 
  2. If you would like to build JHOVE from source, then life will be easiest if
     you use [Apache Maven](https://maven.apache.org/).

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -149,15 +149,15 @@ public class JhoveBase {
      * Instantiate a <tt>JhoveBase</tt> object.
      * 
      * @throws JhoveException
-     *             If invoked with JVM lower than 1.5
+     *             If invoked with JVM lower than 1.6
      */
     public JhoveBase() throws JhoveException {
         _logger = Logger.getLogger("edu.harvard.hul.ois.jhove");
         _logger.setLevel(Level.SEVERE); // May be changed by config file
         /* Make sure we have a satisfactory version of Java. */
         String version = System.getProperty("java.vm.version");
-        if (version.compareTo("1.5.0") < 0) {
-            String bad = "Java 1.5 or higher is required";
+        if (version.compareTo("1.6.0") < 0) {
+            String bad = "Java 1.6 or higher is required";
             _logger.severe(bad);
             throw new JhoveException(bad);
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -37,7 +37,7 @@ public class WaveModule extends ModuleBase {
     private static final String[] FORMAT = { "WAVE", "Audio for Windows",
             "EBU Technical Specification 3285", "Broadcast Wave Format", "BWF" };
     private static final String COVERAGE = "WAVE (PCMWAVEFORMAT, WAVEFORMATEX, WAVEFORMATEXTENSIBLE), "
-            + "Broadcast Wave Format (BWF) version 0 and 1";
+            + "Broadcast Wave Format (BWF) version 0, 1 and 2";
     private static final String[] MIMETYPE = { "audio/vnd.wave", "audio/wav",
             "audio/wave", "audio/x-wav", "audio/x-wave" };
     private static final String WELLFORMED = null;
@@ -149,12 +149,6 @@ public class WaveModule extends ModuleBase {
      */
     protected boolean flagBroadcastWave;
 
-    /**
-     * Version of Broadcast Wave, as determined from the Broadcast Extension
-     * Chunk.
-     */
-    protected int broadcastVersion;
-
     /** Flag to note that first sample offset has been recorded */
     protected boolean firstSampleOffsetMarked;
 
@@ -209,12 +203,15 @@ public class WaveModule extends ModuleBase {
                 .web("http://www.ebu.ch")
                 .build();
 
-        doc = new Document("Broadcast Wave Format (EBU N22-1987)",
+        doc = new Document("Specification of the Broadcast Wave Format (BWF)",
                 DocumentType.REPORT);
+        doc.setIdentifier(new Identifier("EBU Technical Specification 3285",
+                IdentifierType.OTHER));
         doc.setIdentifier(new Identifier(
-                "http://www.ebu.ch/CMSimages/en/tec_doc_t3285_tcm6-10544.pdf",
+                "https://tech.ebu.ch/docs/tech/tech3285.pdf",
                 IdentifierType.URL));
         doc.setPublisher(ebuAgent);
+        doc.setDate("2011-05");
         _specification.add(doc);
 
         Signature sig = new ExternalSignature(".wav", SignatureType.EXTENSION,
@@ -409,20 +406,7 @@ public class WaveModule extends ModuleBase {
                 }
             }
             if (flagBroadcastWave) {
-                String prof = null;
-                switch (broadcastVersion) {
-                    case 0:
-                        prof = "Broadcast Wave Version 0";
-                        break;
-                    case 1:
-                        prof = "Broadcast Wave Version 1";
-                        break;
-
-                    // Other versions are unknown at this time
-                }
-                if (prof != null) {
-                    info.setProfile(prof);
-                }
+                info.setProfile("BWF");
             }
         }
         return 0;
@@ -594,11 +578,6 @@ public class WaveModule extends ModuleBase {
     /** Sets the profile flag for Broadcast Wave. */
     public void setBroadcastWave(boolean b) {
         flagBroadcastWave = b;
-    }
-
-    /** Sets the version from the Broadcast Audio Extension chunk. */
-    public void setBroadcastVersion(int version) {
-        broadcastVersion = version;
     }
 
     /** Initializes the state of the module for parsing. */

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -214,6 +214,19 @@ public class WaveModule extends ModuleBase {
         doc.setDate("2011-05");
         _specification.add(doc);
 
+        Agent ietfAgent = new Agent.Builder("IETF", AgentType.STANDARD)
+                .web("https://www.ietf.org")
+                .build();
+
+        doc = new Document("WAVE and AVI Codec Registries",
+                DocumentType.RFC);
+        doc.setPublisher(ietfAgent);
+        doc.setDate("1998-06");
+        doc.setIdentifier(new Identifier("RFC 2361", IdentifierType.RFC));
+        doc.setIdentifier(new Identifier(
+                "https://www.ietf.org/rfc/rfc2361.txt", IdentifierType.URL));
+        _specification.add(doc);
+
         Signature sig = new ExternalSignature(".wav", SignatureType.EXTENSION,
                 SignatureUseType.OPTIONAL);
         _signature.add(sig);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/iff/Chunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/iff/Chunk.java
@@ -1,74 +1,74 @@
 /**********************************************************************
- * Jhove - JSTOR/Harvard Object Validation Environment
+ * JHOVE - JSTOR/Harvard Object Validation Environment
  * Copyright 2004 by JSTOR and the President and Fellows of Harvard College
- *
  **********************************************************************/
 
 package edu.harvard.hul.ois.jhove.module.iff;
 
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.JhoveException;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.RepInfo;
 
-import java.io.*;
+import java.io.DataInputStream;
+import java.io.IOException;
 
 /**
  * Abstract superclass for IFF/AIFF chunks.
- * 
- * @author Gary McGath
  *
+ * @author Gary McGath
  */
 public abstract class Chunk {
 
     protected ModuleBase _module;
+    protected long chunkSize;
     protected long bytesLeft;
     protected DataInputStream _dstream;
 
     /**
-     *  Constructor.
+     * Class constructor.
+     *
      * @param module   The Module under which this was called
      * @param hdr      The header for this chunk
      * @param dstrm    The stream from which the data are being read
      */
-    public Chunk (ModuleBase module,
-            ChunkHeader hdr, 
-            DataInputStream dstrm)
+    public Chunk(ModuleBase module, ChunkHeader hdr, DataInputStream dstrm)
     {
         _module = module;
-        bytesLeft = hdr.getSize ();
+        chunkSize = hdr.getSize();
+        bytesLeft = chunkSize;
         _dstream = dstrm;
     }
-    
-    
-    /** Reads a chunk and puts appropriate information into
-     *  the RepInfo object. 
-     * 
-     * @param    info  RepInfo object to receive information
-     * 
-     *  @return   <code>false</code> if the chunk is structurally
-     *            invalid, otherwise <code>true</code>
-     * @throws JhoveException 
-     * 
+
+    /**
+     * Reads a chunk and puts appropriate information into the RepInfo object.
+     *
+     * @param info  RepInfo object to receive information
+     * @return      <code>false</code> if the chunk is structurally
+     *              invalid, otherwise <code>true</code>
      */
-    public abstract boolean readChunk (RepInfo info) throws IOException, JhoveException;
-    
-    /** Convert a byte buffer cleanly to an ASCII string.
-     *  This is used for fixed-allocation strings in Broadcast
-     *  WAVE chunks, and might have uses elsewhere.
-     *  If a string is shorter than its fixed allocation, we're
-     *  guaranteed only that there is a null terminating the string,
-     *  and noise could follow it.  So we can't use the byte buffer
-     *  constructor for a string.
+    public abstract boolean readChunk(RepInfo info)
+            throws IOException, JhoveException;
+
+    /**
+     * Converts a byte buffer cleanly into an ASCII string.
+     * This is used for fixed-allocation strings in Broadcast
+     * WAVE chunks, and might have uses elsewhere.
+     *
+     * If a string is shorter than its fixed allocation, we're
+     * guaranteed only that there is a null terminating the string,
+     * and noise could follow it. So we can't use the byte buffer
+     * constructor for a string.
      */
-    protected String byteBufString (byte[] b)
+    protected String byteBufString(byte[] byteArray)
     {
-        StringBuffer sb = new StringBuffer (b.length);
-        for (int i = 0; i < b.length; i++) {
-            byte c = b[i];
-            if (c == 0) {
-                // Terminate when we see a null
+        StringBuilder sb = new StringBuilder(byteArray.length);
+        for (byte b : byteArray) {
+            // Terminate if we see a null
+            if (b == 0) {
                 break;
             }
-            sb.append((char) c);
+            sb.append((char) b);
         }
-        return sb.toString ();
+        return sb.toString();
     }
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
@@ -1,123 +1,255 @@
 /**********************************************************************
- * Jhove - JSTOR/Harvard Object Validation Environment
+ * JHOVE - JSTOR/Harvard Object Validation Environment
  * Copyright 2004 by JSTOR and the President and Fellows of Harvard College
  **********************************************************************/
 
 package edu.harvard.hul.ois.jhove.module.wave;
 
-
-import edu.harvard.hul.ois.jhove.RepInfo;
-import edu.harvard.hul.ois.jhove.module.iff.*;
 import edu.harvard.hul.ois.jhove.*;
 import edu.harvard.hul.ois.jhove.module.WaveModule;
-import java.io.*;
-import java.util.*;
+import edu.harvard.hul.ois.jhove.module.iff.Chunk;
+import edu.harvard.hul.ois.jhove.module.iff.ChunkHeader;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implementation of the WAVE Broadcast Audio Extension Chunk.
  *
  * @author Gary McGath
- *
  */
 public class BroadcastExtChunk extends Chunk {
 
+    private final static int BASE_CHUNK_SIZE = 602;
+    private final static int VER_0_RESERVED_LENGTH = 254;
+    private final static int VER_1_RESERVED_LENGTH = 190;
+    private final static int VER_2_RESERVED_LENGTH = 180;
+    private final static int UNUSED_LOUDNESS_FIELD = 0x7FFF;
+
     /**
      * Constructor.
-     * 
+     *
      * @param module   The WaveModule under which this was called
      * @param hdr      The header for this chunk
      * @param dstrm    The stream from which the WAVE data are being read
      */
-    public BroadcastExtChunk (
+    public BroadcastExtChunk(
             ModuleBase module,
             ChunkHeader hdr,
             DataInputStream dstrm) {
         super(module, hdr, dstrm);
     }
 
-    /** Reads a chunk and puts a BroadcastAudioExtension Property into
-     *  the RepInfo object. 
-     * 
-     *  @return   <code>false</code> if the chunk is structurally
-     *            invalid, otherwise <code>true</code>
+    /**
+     * Reads a chunk and puts a BroadcastAudioExtension Property into
+     * the RepInfo object.
+     *
+     * @return  <code>false</code> if the chunk is structurally
+     *          invalid, otherwise <code>true</code>
      */
     public boolean readChunk(RepInfo info) throws IOException {
+
         WaveModule module = (WaveModule) _module;
+
         byte[] buf256 = new byte[256];
-        ModuleBase.readByteBuf (_dstream, buf256, module);
+        ModuleBase.readByteBuf(_dstream, buf256, module);
         String description = byteBufString(buf256);
+
         byte[] buf32 = new byte[32];
-        ModuleBase.readByteBuf (_dstream, buf32, module);
-        String originator = byteBufString (buf32);
-        ModuleBase.readByteBuf (_dstream, buf32, module);
-        String originatorRef = byteBufString (buf32);
+        ModuleBase.readByteBuf(_dstream, buf32, module);
+        String originator = byteBufString(buf32);
+
+        ModuleBase.readByteBuf(_dstream, buf32, module);
+        String originatorRef = byteBufString(buf32);
+
         byte[] buf10 = new byte[10];
-        ModuleBase.readByteBuf (_dstream, buf10, module);
-        String originationDate = byteBufString (buf10);
+        ModuleBase.readByteBuf(_dstream, buf10, module);
+        String originationDate = byteBufString(buf10);
+
         byte[] buf8 = new byte[8];
-        ModuleBase.readByteBuf (_dstream, buf8, module);
-        String originationTime = byteBufString (buf8);
-        // TimeReference is stored as a 64-bit little-endian
-        // number -- I think
-        long timeReference = module.readSignedLong (_dstream);
-        int version = module.readUnsignedShort (_dstream);
-        module.setBroadcastVersion (version);
-        byte[] smtpe_umid = new byte[64];
-        ModuleBase.readByteBuf (_dstream, smtpe_umid, module);
-        module.skipBytes (_dstream, 190, module);
+        ModuleBase.readByteBuf(_dstream, buf8, module);
+        String originationTime = byteBufString(buf8);
+
+        long timeReference = module.readSignedLong(_dstream);
+        int version = module.readUnsignedShort(_dstream);
+
+        String umid = "";
+        if (version >= 1) {
+            byte[] buf64 = new byte[64];
+            ModuleBase.readByteBuf(_dstream, buf64, module);
+            umid = formatUmid(buf64);
+        }
+
+        String loudnessValue = "";
+        String loudnessRange = "";
+        String maxTruePeakLevel = "";
+        String maxMomentaryLoudness = "";
+        String maxShortTermLoudness = "";
+        if (version >= 2) {
+            loudnessValue = formatLoudness(module.readSignedShort(_dstream));
+            loudnessRange = formatLoudness(module.readSignedShort(_dstream));
+            maxTruePeakLevel = formatLoudness(
+                    module.readSignedShort(_dstream));
+            maxMomentaryLoudness = formatLoudness(
+                    module.readSignedShort(_dstream));
+            maxShortTermLoudness = formatLoudness(
+                    module.readSignedShort(_dstream));
+        }
+
+        if (version == 0) {
+            module.skipBytes(_dstream, VER_0_RESERVED_LENGTH, module);
+        } else if (version == 1) {
+            module.skipBytes(_dstream, VER_1_RESERVED_LENGTH, module);
+        } else if (version == 2) {
+            module.skipBytes(_dstream, VER_2_RESERVED_LENGTH, module);
+        } else {
+            // If it's a higher version, we can't read its fields,
+            // so skip any remaining reserved bytes anyway.
+            module.skipBytes(_dstream, VER_2_RESERVED_LENGTH, module);
+            info.setMessage(new InfoMessage(
+                    "BWF version '" + version +"' unrecognized"));
+        }
+
         String codingHistory = "";
-        if (bytesLeft > 602) {
-            byte[] bufCodingHistory = new byte[(int) bytesLeft - 602];
-	    ModuleBase.readByteBuf (_dstream, bufCodingHistory, module);
-            codingHistory = byteBufString (bufCodingHistory);
+        int codingHistorySize = (int) chunkSize - BASE_CHUNK_SIZE;
+        if (codingHistorySize > 0) {
+            byte[] bufCodingHistory = new byte[codingHistorySize];
+            ModuleBase.readByteBuf(_dstream, bufCodingHistory, module);
+            codingHistory = byteBufString(bufCodingHistory);
         }
 
         // Whew -- we've read the whole thing.  Now make that into a
         // list of Properties.
-        List plist = new ArrayList (20);
-        if (description.length () > 0) {
-            plist.add (new Property 
-                    ("Description", PropertyType.STRING, description));
+        List<Property> plist = new ArrayList<Property>(14);
+
+        if (!description.isEmpty()) {
+            plist.add(new Property("Description",
+                    PropertyType.STRING, description));
         }
-        if (originator.length () > 0) {
-            plist.add (new Property 
-                    ("Originator", PropertyType.STRING, originator));
+        if (!originator.isEmpty()) {
+            plist.add(new Property("Originator",
+                    PropertyType.STRING, originator));
         }
-        if (originatorRef.length () > 0) {
-            plist.add (new Property 
-                    ("Originator Reference", PropertyType.STRING, originatorRef));
+        if (!originatorRef.isEmpty()) {
+            plist.add(new Property("OriginatorReference",
+                    PropertyType.STRING, originatorRef));
         }
-        if (originationDate.length () > 0) {
-            plist.add (new Property
-                    ("OriginationDate", PropertyType.STRING, originationDate));
+        if (!originationDate.isEmpty()) {
+            plist.add(new Property("OriginationDate",
+                    PropertyType.STRING, originationDate));
         }
-        if (originationTime.length () > 0) {
-            plist.add (new Property
-                    ("OriginationTime", PropertyType.STRING, originationTime));
-        }
-        plist.add (new Property
-                    ("TimeReference", PropertyType.LONG, new Long (timeReference)));
-        plist.add (new Property
-                    ("Version", PropertyType.INTEGER, new Integer (version)));
-        plist.add (new Property ("UMID", 
-                PropertyType.BYTE,
-                PropertyArity.ARRAY,
-                smtpe_umid));
-        if (codingHistory.length () > 0) {
-            plist.add (new Property
-                    ("CodingHistory", PropertyType.STRING, codingHistory));
+        if (!originationTime.isEmpty()) {
+            plist.add(new Property("OriginationTime",
+                    PropertyType.STRING, originationTime));
         }
 
-        module.addWaveProperty (new Property ("BroadcastAudioExtension", 
-                PropertyType.PROPERTY,
-                PropertyArity.LIST,
-                plist));
-				
-	// set time reference in AES metadata set @author David Ackerman
-	AESAudioMetadata aes = module.getAESMetadata ();
-	aes.setStartTime (timeReference);
+        plist.add(new Property("TimeReference",
+                PropertyType.LONG, timeReference));
+        plist.add(new Property("Version",
+                PropertyType.INTEGER, version));
+
+        if (!umid.isEmpty()) {
+            plist.add(new Property("UMID",
+                    PropertyType.STRING, umid));
+        }
+
+        if (!loudnessValue.isEmpty()) {
+            plist.add(new Property("LoudnessValue",
+                    PropertyType.STRING, loudnessValue));
+        }
+        if (!loudnessRange.isEmpty()) {
+            plist.add(new Property("LoudnessRange",
+                    PropertyType.STRING, loudnessRange));
+        }
+        if (!maxTruePeakLevel.isEmpty()) {
+            plist.add(new Property("MaxTruePeakLevel",
+                    PropertyType.STRING, maxTruePeakLevel));
+        }
+        if (!maxMomentaryLoudness.isEmpty()) {
+            plist.add(new Property("MaxMomentaryLoudness",
+                    PropertyType.STRING, maxMomentaryLoudness));
+        }
+        if (!maxShortTermLoudness.isEmpty()) {
+            plist.add(new Property("MaxShortTermLoudness",
+                    PropertyType.STRING, maxShortTermLoudness));
+        }
+
+        if (!codingHistory.isEmpty()) {
+            plist.add(new Property("CodingHistory",
+                    PropertyType.STRING, codingHistory));
+        }
+
+        module.addWaveProperty(new Property("BroadcastAudioExtension",
+                PropertyType.PROPERTY, PropertyArity.LIST, plist));
+
+        AESAudioMetadata aes = module.getAESMetadata();
+        aes.setStartTime(timeReference);
 
         return true;
     }
 
+    /**
+     * Returns a UMID formatted as a hexadecimal string.
+     *
+     * @return  an empty String if no UMID is found; a basic UMID if the
+     *          extension space is empty; and an extended UMID if it isn't
+     */
+    private static String formatUmid(byte[] umid) {
+
+        String formattedUmid = "";
+
+        byte[] basicUmid = Arrays.copyOfRange(umid, 0, 32);
+        byte[] umidExtension = Arrays.copyOfRange(umid, 32, 64);
+
+        boolean basicUmidExists = hasValue(basicUmid);
+        boolean extendedUmidExists = false;
+
+        if (basicUmidExists) {
+            extendedUmidExists = hasValue(umidExtension);
+        }
+
+        if (extendedUmidExists) {
+            formattedUmid = DatatypeConverter.printHexBinary(umid);
+        }
+        else if (basicUmidExists) {
+            formattedUmid = DatatypeConverter.printHexBinary(basicUmid);
+        }
+
+        return formattedUmid;
+    }
+
+    /** Checks for a non-zero value in an array of bytes. */
+    private static boolean hasValue(byte[] byteArray) {
+
+        for (byte b : byteArray) {
+            if (b != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns a properly formatted loudness value.
+     *
+     * Loudness fields store integer values accurate to two decimal places by
+     * multiplying the original value by 100, and rounding away any remainder.
+     * To recover the original value, we do the reverse.
+     *
+     * Unused fields should contain the value 0x7FFF.
+     */
+    private static String formatLoudness(int value) {
+
+        String formattedValue = "";
+
+        if (value != UNUSED_LOUDNESS_FIELD) {
+            formattedValue = String.format("%.2f", value / 100f);
+        }
+
+        return formattedValue;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <mvn.surefire.version>2.19.1</mvn.surefire.version>
     <mvn.release.version>2.5.3</mvn.release.version>
     <jacoco.version>0.7.9</jacoco.version>
-    <java.source.version>1.5</java.source.version>
+    <java.source.version>1.6</java.source.version>
     <java.target.version>1.6</java.target.version>
     <jhove.timestamp>${maven.build.timestamp}</jhove.timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>


### PR DESCRIPTION
- Simplified BWF profile detection, allowing JHOVE to detect any future BWF versions. All BWF versions will now be reported as "BWF" instead of "BWF version #", and any unrecognized version numbers will be reported as informational messages.
- Added support for all BWF v2 fields (LoudnessValue, LoudnessRange, MaxTruePeakLevel, MaxMomentaryLoudness, and MaxShortTermLoudness).
- Formatted the BWF v1 UMID field into a hexadecimal string instead of a long sequence of numbers.
- Increased the minimum required Java version of JHOVE from 1.5 to 1.6 for the use of newer Array methods, and updated the build server JDK information in the README.
- Added missing WAVE reference documentation.