### PR TITLE
REFACT - WAVE Module message constants

### DIFF
--- a/jhove-bbt/scripts/create-1.17-target.sh
+++ b/jhove-bbt/scripts/create-1.17-target.sh
@@ -112,11 +112,14 @@ find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.9">PDF-hul<\/module>$/   <module release="1.10">PDF-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.2">JPEG-hul<\/module>$/   <module release="1.3">JPEG-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.7">TIFF-hul<\/module>$/   <module release="1.8">TIFF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.4">WAVE-hul<\/module>$/   <module release="1.5">WAVE-hul<\/module>/' {} \;
 
 find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's%<release>1.9<\/release>%<release>1.10<\/release>%' {} \;
 find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's%<date>2017-07-20<\/date>%<date>2017-10-31<\/date>%' {} \;
 find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's%<release>1.3<\/release>%<release>1.4<\/release>%' {} \;
 find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's%<date>2006-09-05<\/date>%<date>2017-10-31<\/date>%' {} \;
+find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's%<release>1.4<\/release>%<release>1.5<\/release>%' {} \;
+find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's%<date>2017-03-14<\/date>%<date>2017-10-31<\/date>%' {} \;
 find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.9" date="2017-07-20">PDF%<reportingModule release="1.10" date="2017-10-31">PDF%' {} \;
 find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.9" date="2017-07-20">PDF%<reportingModule release="1.10" date="2017-10-31">PDF%' {} \;
 
@@ -129,4 +132,6 @@ find "${targetRoot}" -type f -name "compos.*.jhove.xml" -exec sed -i 's%<reporti
 find "${targetRoot}" -type f -name "*.jpg.jhove.xml" -exec sed -i 's%<reportingModule release="1.2" date="2007-02-13">JPEG%<reportingModule release="1.3" date="2017-05-11">JPEG%' {} \;
 find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
 find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.2" date="2007-02-13">JPEG%<reportingModule release="1.3" date="2017-05-11">JPEG%' {} \;
-find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%44100.0</aes:sampleRate>%44100</aes:sampleRate>%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<reportingModule release="1.4" date="2017-03-14">WAVE%<reportingModule release="1.5" date="2017-10-31">WAVE%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%44100.0<\/aes:sampleRate>%44100<\/aes:sampleRate>%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i "s%Chunk type 'id3 ' ignored%Ignored Chunk type: id3 %" {} \;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -32,8 +32,8 @@ public class WaveModule extends ModuleBase {
 
     /* Module metadata */
     private static final String NAME = "WAVE-hul";
-    private static final String RELEASE = "1.4";
-    private static final int[] DATE = { 2017, 3, 14 };
+    private static final String RELEASE = "1.5";
+    private static final int[] DATE = { 2017, 10, 31 };
     private static final String[] FORMAT = { "WAVE", "Audio for Windows",
             "EBU Technical Specification 3285", "Broadcast Wave Format", "BWF" };
     private static final String COVERAGE = "WAVE (PCMWAVEFORMAT, WAVEFORMATEX, WAVEFORMATEXTENSIBLE), "
@@ -297,7 +297,7 @@ public class WaveModule extends ModuleBase {
                 int ch = readUnsignedByte(_dstream, this);
                 if (ch != RIFF_SIGNATURE[i]) {
                     info.setMessage(new ErrorMessage(
-                            "Document does not start with RIFF chunk", 0));
+                            MessageConstants.ERR_RIFF_CHUNK_MISSING, 0));
                     info.setWellFormed(false);
                     return 0;
                 }
@@ -315,7 +315,7 @@ public class WaveModule extends ModuleBase {
             bytesRemaining -= 4;
             if (!"WAVE".equals(typ)) {
                 info.setMessage(new ErrorMessage(
-                        "File type in RIFF header is not WAVE", _nByte));
+                        MessageConstants.ERR_RIFF_HDR_TYPE_NOT_WAV, _nByte));
                 info.setWellFormed(false);
                 return 0;
             }
@@ -327,12 +327,12 @@ public class WaveModule extends ModuleBase {
             }
         } catch (EOFException eofe) {
             info.setWellFormed(false);
-            info.setMessage(new ErrorMessage("Unexpected end of file", _nByte));
+            info.setMessage(new ErrorMessage(MessageConstants.ERR_EOF_UNEXPECTED, _nByte));
             return 0;
         } catch (Exception e) { // TODO make this more specific
             e.printStackTrace();
             info.setWellFormed(false);
-            info.setMessage(new ErrorMessage("Exception reading file: "
+            info.setMessage(new ErrorMessage(MessageConstants.ERR_FILE_IO_EXCEP
                     + e.getClass().getName() + ", " + e.getMessage(), _nByte));
             return 0;
         }
@@ -364,7 +364,7 @@ public class WaveModule extends ModuleBase {
             _propList.add(_exifInfo.buildProperty());
         }
         if (!formatChunkSeen) {
-            info.setMessage(new ErrorMessage("No Format Chunk"));
+            info.setMessage(new ErrorMessage(MessageConstants.ERR_FMT_CHUNK_MISS));
             info.setWellFormed(false);
             return 0;
         }
@@ -648,7 +648,7 @@ public class WaveModule extends ModuleBase {
         bytesRemaining -= chunkSize + 8;
 
         if (bytesRemaining < 0) {
-            info.setMessage(new ErrorMessage("Invalid chunk size", _nByte));
+            info.setMessage(new ErrorMessage(MessageConstants.ERR_CHUNK_SIZE_INVAL, _nByte));
             return false;
         }
 
@@ -730,7 +730,7 @@ public class WaveModule extends ModuleBase {
             chunk = new CueChunk(this, chunkh, _dstream);
             cueChunkSeen = true;
         } else {
-            info.setMessage(new InfoMessage("Chunk type '" + id + "' ignored",
+            info.setMessage(new InfoMessage(MessageConstants.INF_CHU_TYPE_IGND + id,
                     _nByte));
         }
 
@@ -758,8 +758,8 @@ public class WaveModule extends ModuleBase {
 
     /** Reports a duplicate chunk. */
     protected void dupChunkError(RepInfo info, String chunkName) {
-        info.setMessage(new ErrorMessage("Multiple " + chunkName
-                + " Chunks not permitted", _nByte));
+        info.setMessage(new ErrorMessage(MessageConstants.ERR_CHUNK_DUP + chunkName,
+                                         _nByte));
         info.setValid(false);
     }
 

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/AssocDataListChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/AssocDataListChunk.java
@@ -54,9 +54,8 @@ public class AssocDataListChunk extends Superchunk {
         // why), but any others will be considered non-conforming.
         String typeID = module.read4Chars(_dstream);
         if (!"adtl".equals (typeID)) {
-            info.setMessage (new ErrorMessage ("Unknown list type " +
-                    "in Associated Data List Chunk", 
-                    "Type = " + typeID,
+            info.setMessage (new ErrorMessage (MessageConstants.ERR_LIST_TYPE_UNK, 
+                    MessageConstants.SUB_MESS_TYPE + typeID,
                     _module.getNByte()));
             info.setWellFormed (false);
             return false;
@@ -84,7 +83,7 @@ public class AssocDataListChunk extends Superchunk {
             if (chunk == null) {
                 _module.skipBytes (_dstream, (int) chunkSize, _module);
                 info.setMessage (new InfoMessage
-                    ("Chunk type '" + id + "' in Associated Data Chunk ignored"));
+                    (MessageConstants.INF_DATA_CHUNK_TYPE_IGN + id));
             }
             else {
                 if (!chunk.readChunk (info)) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
@@ -110,8 +110,8 @@ public class BroadcastExtChunk extends Chunk {
             // If it's a higher version, we can't read its fields,
             // so skip any remaining reserved bytes anyway.
             module.skipBytes(_dstream, VER_2_RESERVED_LENGTH, module);
-            info.setMessage(new InfoMessage(
-                    "BWF version '" + version +"' unrecognized"));
+            info.setMessage(new InfoMessage(MessageConstants.ERR_BWF_VER_UNREC +
+                   version));
         }
 
         String codingHistory = "";

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ExifUserCommentChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ExifUserCommentChunk.java
@@ -54,7 +54,7 @@ public class ExifUserCommentChunk extends Chunk {
         WaveModule module = (WaveModule) _module;
         if (bytesLeft < 8) {
             info.setMessage (new ErrorMessage
-                ("Exif User Comment Chunk is too short"));
+                (MessageConstants.ERR_EXIF_COMM_TOO_SHORT));
             info.setWellFormed (false);
             return false;
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ExifVersionChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ExifVersionChunk.java
@@ -45,7 +45,7 @@ public class ExifVersionChunk extends Chunk {
         WaveModule module = (WaveModule) _module;
         if (bytesLeft != 4) {
             info.setMessage (new ErrorMessage
-                ("Incorrect length for Exif Version Chunk"));
+                (MessageConstants.ERR_EXIF_VER_CHUNK_LEN_WRNG));
             info.setWellFormed (false);
             return false;
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/LinkChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/LinkChunk.java
@@ -94,13 +94,13 @@ public class LinkChunk extends Chunk {
         }
         catch (SAXException se) {
             info.setMessage (new ErrorMessage
-                ("SAXException in reading Link Chunk"));
+                (MessageConstants.ERR_LINK_CHUNK_SAX_EXCEP));
             info.setValid (false);
             return true;
         }
         catch (ParserConfigurationException pe) {
             info.setMessage (new ErrorMessage
-                ("ParserConfigurationException in reading Link Chunk"));
+                (MessageConstants.ERR_LINK_CHUNK_PARS_EXCEP));
             info.setValid (false);
             return true;
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ListInfoChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ListInfoChunk.java
@@ -64,9 +64,8 @@ public class ListInfoChunk extends Superchunk {
             return readAdtlChunk (info);
         }
         else {
-            info.setMessage (new ErrorMessage ("Unknown list type " +
-                    typeID + " in List Chunk", 
-                    _module.getNByte()));
+            info.setMessage (new ErrorMessage (MessageConstants.ERR_LIST_CHUNK_TYPE_UNK +
+                    typeID,_module.getNByte()));
             info.setWellFormed (false);
             return false;
         }
@@ -94,7 +93,7 @@ public class ListInfoChunk extends Superchunk {
             if (chunk == null) {
                 _module.skipBytes (_dstream, (int) chunkSize, _module);
                 info.setMessage (new InfoMessage
-                    ("Chunk type '" + id + "' in List Info Chunk ignored"));
+                    (MessageConstants.INF_INFO_CHUNK_TYPE_IGN + id));
             }
             else {
                 if (!chunk.readChunk (info)) {
@@ -147,7 +146,7 @@ public class ListInfoChunk extends Superchunk {
             if (chunk == null) {
                 _module.skipBytes (_dstream, (int) chunkSize, _module);
                 info.setMessage (new InfoMessage
-                    ("Chunk type '" + id + "' in Associated Data Chunk ignored"));
+                    (MessageConstants.INF_DATA_CHUNK_TYPE_IGN + id));
             }
             else {
                 if (!chunk.readChunk (info)) {
@@ -192,8 +191,7 @@ public class ListInfoChunk extends Superchunk {
            
             if (chunk == null) {
                 _module.skipBytes (_dstream, (int) chunkSize, _module);
-                info.setMessage (new InfoMessage ("Chunk type '" + id +
-				  "' in Associated Data Chunk ignored"));
+                info.setMessage (new InfoMessage (MessageConstants.INF_DATA_CHUNK_TYPE_IGN + id));
             }
             else {
                 if (!chunk.readChunk (info)) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ListInfoTextChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/ListInfoTextChunk.java
@@ -143,7 +143,7 @@ public class ListInfoTextChunk extends Chunk {
         }
         else {
             info.setMessage (new InfoMessage
-                ("Chunk type '" + _chunkID + "' in List Info Chunk ignored"));
+                (MessageConstants.INF_INFO_CHUNK_TYPE_IGN + _chunkID));
         }
         return true;
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/MessageConstants.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/MessageConstants.java
@@ -34,77 +34,31 @@ package edu.harvard.hul.ois.jhove.module.wave;
 public enum MessageConstants {
 	INSTANCE;
 
+	public static final String SUB_MESS_TYPE = "Type = ";
 	/**
 	 * Information messages
 	 */
-	public static final String ERR_NOT_START_RIFF = "Document does not start with RIFF chunk";
+	public static final String INF_CHU_TYPE_IGND = "Ignored Chunk type: ";
+	public static final String INF_DATA_CHUNK_TYPE_IGN = "Ignored Associated Data Chunk of type: ";
+	public static final String INF_INFO_CHUNK_TYPE_IGN = "Ignored List Info Chunk of type: ";
 
-	// public static final String ERR_NOT_WAVE_HEAD_BYTES = _nByte
-	public static final String ERR_NOT_WAVE_HEAD_STRING = "File type in RIFF header is not WAVE ";
-	// + ERR_NOT_WAVE_HEAD_BYTES 
-
-	// public static final String ERR_UNEX_EOF_BYTES = _nByte
-	public static final String ERR_UNEX_EOF_BYTES_STRING = "Unexpected end of file ";
-	// + ERR_UNEX_EOF_BYTES
-
-	// public static final String ERR_EX_READ_NAME =  // e.getClass().getName() 
-	// public static final String ERR_EX_READ_MESSAGE = // e.getMessage()
-	//	public static final String ERR_EX_READ_BYTES = _nByte
-	public static final String ERR_EX_READ_STRING = "Exception reading file: ";
-	//+ ERR_EX_READ_NAME  + ", " + ERR_EX_READ_MESSAGE, ERR_EX_READ_BYTES
-
-	//public static final String ERR_INV_CHU_SIZE_BYTES = _nByte
-	public static final String ERR_INV_CHU_SIZE_STRING = "Invalid chunk size";
-	// , ERR_INV_CHU_SIZE_BYTES 
-
-	// public static final String ERR_MULTI_CHU_NO_PERM_NAME = chunkName
-	// public static final String ERR_MULTI_CHU_NO_PERM_BYTES = _nByte
-	public static final String ERR_MULTI_CHU_NO_PERM_STRING_1 = "Multiple ";
-	public static final String ERR_MULTI_CHU_NO_PERM_STRING_2 = " Chunks not permitted";
-	// + ERR_MULTI_CHU_NO_PERM_NAME + " Chunks not permitted", ERR_MULTI_CHU_NO_PERM_BYTES
-
-	// public static final String ERR_UNKNO_LIST_TYPE_IN_CHU_TYPE = typeID
-	// public static final String ERR_UNKNO_LIST_TYPE_IN_CHU_BYTES = // _module.getNByte()
-	public static final String ERR_UNKNO_LIST_TYPE_IN_CHU_STRING = "Unknown list type in Associated Data List Chunk";
-	// , "Type = " + ERR_UNKNO_LIST_TYPE_IN_CHU_TYPE , ERR_UNKNO_LIST_TYPE_IN_CHU_BYTES 
-
-	// public static final String INF_ASSOC_CHU_IGNOR_ID = id
-	public static final String INF_ASSOC_CHU_IGNOR_STRING_1 = "Chunk type '";
-	// + INF_ASSOC_CHU_IGNOR_ID +
-	public static final String INF_ASSOC_CHU_IGNOR_STRING_2 = "' in Associated Data Chunk ignored";
-
-	public static final String ERR_EXIF_USER_COMM__TOO_SHORT = "Exif User Comment Chunk is too short";
-	public static final String ERR_INCOR_LEN_EXIF_V_CHU = "Incorrect length for Exif Version Chunk";
-	
-	// public static final String JHO_ERR_IN_FORMAT_CHU_NAME = //e.getClass().getName()
-	public static final String JHO_ERR_IN_FORMAT_CHU_STRING = "Error in FormatChunk: ";
-	// + JHO_ERR_IN_FORMAT_CHU_NAME
-
-	public static final String ERR_SAX_EXC_READ_LINK_CHU = "SAXException in reading Link Chunk";
-	public static final String ERR_PARS_EXC_READ_LINK_CHU = "ParserConfigurationException in reading Link Chunk";
-	
-	//public static final String ERR_UNKN_LIST_TYPE_ID = typeID
-	//public static final String ERR_UNKN_LIST_TYPE_NAME = // _module.getNByte()
-	public static final String ERR_UNKN_LIST_TYPE_STRING_1 = "Unknown list type ";
-	// + ERR_UNKN_LIST_TYPE_ID +
-	public static final String ERR_UNKN_LIST_TYPE_STRING_2 = " in List Chunk";
-	// , ERR_UNKN_LIST_TYPE_NAME
-
-	// public static final String INF_CHU_IGNOR_LIST_ID = id
-	public static final String INF_CHU_IGNOR_LIST_STRING_1 = "Chunk type '";
-	// + INF_CHU_IGNOR_LIST_ID + 
-	public static final String INF_CHU_IGNOR_LIST_STRING_2 = "' in List Info Chunk ignored";
-
-	// public static final String INF_CHU_IGNOR_ASS_ID = id
-	public static final String INF_CHU_IGNOR_ASS_STRING_1 = "Chunk type '";
-	// + INF_CHU_IGNOR_ASS_ID +
-	public static final String INF_CHU_IGNOR_ASS_STRING_2 = "' in Associated Data Chunk ignored";
-
-	// public static final String INF_CHU_IGNOR_LIST_CHU_ID = _chunkID
-	public static final String INF_CHU_IGNOR_LIST_CHU_STRING_1 = "Chunk type '";
-	// + INF_CHU_IGNOR_LIST_CHU_ID +
-	public static final String INF_CHU_IGNOR_LIST_CHU_STRING_2 = "' in List Info Chunk ignored";
-
-	public static final String ERR_INVA_PEAK_VALUE = "Invalid format value in Peak Envelope Chunk";
-	public static final String ERR_INVA_PPV_PEAK_ENV_CHU = "Invalid pointsPerValue in Peak Envelope Chunk";
+	/**
+	 * Error messages
+	 */
+	public static final String ERR_CHUNK_DUP = "Duplicate Chunks found for type: ";
+	public static final String ERR_EXIF_COMM_TOO_SHORT = "Exif User Comment Chunk is too short";
+	public static final String ERR_EXIF_VER_CHUNK_LEN_WRNG = "Incorrect length for Exif Version Chunk";
+	public static final String ERR_CHUNK_SIZE_INVAL = "Invalid chunk size";
+	public static final String ERR_BWF_VER_UNREC = "Unrecognized BWF version: ";
+	public static final String ERR_EOF_UNEXPECTED = "Unexpected end of file";
+	public static final String ERR_FILE_IO_EXCEP = "Exception reading file: ";
+	public static final String ERR_FMT_CHUNK_MISS = "No Format Chunk";
+	public static final String ERR_LINK_CHUNK_SAX_EXCEP = "SAXException in reading Link Chunk";
+	public static final String ERR_LINK_CHUNK_PARS_EXCEP = "ParserConfigurationException in reading Link Chunk";
+	public static final String ERR_LIST_TYPE_UNK = "Unknown list type in Associated Data List Chunk";
+	public static final String ERR_LIST_CHUNK_TYPE_UNK = "List Chunk contains unknown type: ";
+	public static final String ERR_PEC_FORMAT_INVAL = "Invalid format value in Peak Envelope Chunk";
+	public static final String ERR_PEC_PPV_INVAL = "Invalid pointsPerValue in Peak Envelope Chunk";
+	public static final String ERR_RIFF_CHUNK_MISSING = "Document does not start with RIFF chunk";
+	public static final String ERR_RIFF_HDR_TYPE_NOT_WAV = "File type in RIFF header is not WAVE ";
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/PeakEnvelopeChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/PeakEnvelopeChunk.java
@@ -76,7 +76,7 @@ public class PeakEnvelopeChunk extends Chunk {
             else {
                 info.setValid (false);
                 info.setMessage (new ErrorMessage 
-                        ("Invalid format value in Peak Envelope Chunk"));
+                        (MessageConstants.ERR_PEC_FORMAT_INVAL));
             }
             if (pointsPerValue == 1) {
                 nValues = nPoints;
@@ -87,7 +87,7 @@ public class PeakEnvelopeChunk extends Chunk {
             else {
                 info.setValid (false);
                 info.setMessage (new ErrorMessage 
-                        ("Invalid pointsPerValue in Peak Envelope Chunk"));
+                        (MessageConstants.ERR_PEC_PPV_INVAL));
             }
             if (info.getValid() == RepInfo.FALSE) {
                 module.skipBytes (_dstream, (int) bytesLeft - 120, module);


### PR DESCRIPTION
- tidied commented code in `MessageConstants`;
- renamed constants to fit convention;
- factored out String constants from WAVE Module;
- bumped version number for WAVE module;
- update test script to reflect changes; and
- re-worked some messages so that single String required.