### PR TITLE
RC - JHOVE 1.18 Release Candidate

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,36 +1,91 @@
 RELEASE NOTES
 =============
-JHOVE - JSTOR/Harvard Object Validation Environment
-Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.
+JHOVE - JSTOR/Harvard Object Validation Environment  
+Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.  
 JHOVE is made available under the GNU Lesser General Public License (LGPL;
 see the file LICENSE for details).
 
-Versions 1.7 to 1.11 of JHOVE released independently.
+Versions 1.7 to 1.11 of JHOVE released independently.  
 Versions 1.12 onwards released by the Open Preservation Foundation.
 
 JHOVE 1.18-RC
 -------------
-- Validation for ICC profiles in JPEG and TIFF files [[#249](https://github.com/openpreserve/jhove/pull/249)]
-- Added WAVE module support for BWF v2 recognition [[#273](https://github.com/openpreserve/jhove/pull/273)].
-- External modules now an optional installation (default to yes) [[#292](https://github.com/openpreserve/jhove/pull/292)].
-- Fixed bug in parsing of escape characters in PDF name objects [[#280](https://github.com/openpreserve/jhove/pull/280)].
-- Fixed handling of Exif profiles in JPEG files [[#253](https://github.com/openpreserve/jhove/pull/253)].
-- Fixed ArrayIndexOutOfBoundsException when processing some WAVE files [[#118](https://github.com/openpreserve/jhove/pull/118)]
-- Fixes for various small issues in [[#257](https://github.com/openpreserve/jhove/pull/257)]:
-  * fix for false invalid result for encrypted PDFs;
-  * improvements to TIFF and PDF error handling;
-  * inaccessible files now return "Unknown" status; and
-  * changed WAVE reported MIME type from `audio/xwave` to `audio/vnd.wave`.
-- Improvements to report of PDF indirect references with non-existent destination [[#123](https://github.com/openpreserve/jhove/pull/123)].
-- All JHOVE module error messages now factored as String constants in discrete message classes.
-- JHOVE core error messages factored as String constants in [`CoreMessageConstants`](https://github.com/openpreserve/jhove/blob/integration/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/CoreMessageConstants.java).
-- Improvements to WAVE module documentation [[#269](https://github.com/openpreserve/jhove/pull/269)]
+2017-11-07
+
+### General
+
+- Installation of external modules is now optional [[#292][]]
+- Inaccessible files are now reported as "Unknown" instead of "Not well-formed" [[#257][]]
+- General improvements to error handling and uncaught module exceptions,
+  increasing resilience during batch processing [[#257][], [#259][]]
+- Improved path handling, allowing installation locations and file paths to
+  contain spaces and more exotic characters [[#206][]]
+- Error and informational messages have been consolidated into discrete message
+  classes for easier maintenance and future improvement [[#120][], [#157][],
+  [#283][]–[#285][], [#287][]–[#291][]]
+
+### JPEG Module
+
+- Added validation for ICC profiles [[#249][]]
+- Fixed handling of Exif profiles [[#253][]]
+
+### PDF Module
+
+- Fixed a false invalid result for some types of encrypted document [[#257][]]
+- Fixed incorrect parsing of escaped characters in name objects [[#280][]]
+- More detailed error messages for indirect references to non-existent
+  destinations [[#123][]]
+
+### PNG Module
+
+- Report invalid NISO color types [[#171][]]
+
+### TIFF Module
+
+- Added validation for ICC profiles [[#249][]]
+
+### WAVE Module
+
+- Added support for reporting BWF v2 fields [[#273][]]
+- Simplified BWF profile detection, allowing detection of any future BWF
+  versions. All BWF versions will now be reported as "BWF" instead of
+  "BWF version #", with any unrecognized versions being reported [[#273][]]
+- Reformatted the BWF UMID field into a hexadecimal string instead of a long
+  sequence of numbers [[#273][]]
+- Fixed incorrectly reported format names and `ArrayIndexOutOfBoundsException`
+  errors when processing certain non-PCM WAVE files [[#118][]]
+- Changed reported MIME type from `audio/x-wave` to `audio/vnd.wave` [[#257][]]
+
+### XML Handler
+
+- Fixed MIX 1.0 and TextMD XML generation for images with certain properties
+  [[#220][]]
+
+[#118]: https://github.com/openpreserve/jhove/pull/118
+[#120]: https://github.com/openpreserve/jhove/pull/120
+[#123]: https://github.com/openpreserve/jhove/pull/123
+[#157]: https://github.com/openpreserve/jhove/pull/157
+[#171]: https://github.com/openpreserve/jhove/pull/171
+[#206]: https://github.com/openpreserve/jhove/pull/206
+[#220]: https://github.com/openpreserve/jhove/pull/220
+[#249]: https://github.com/openpreserve/jhove/pull/249
+[#253]: https://github.com/openpreserve/jhove/pull/253
+[#257]: https://github.com/openpreserve/jhove/pull/257
+[#259]: https://github.com/openpreserve/jhove/pull/259
+[#273]: https://github.com/openpreserve/jhove/pull/273
+[#280]: https://github.com/openpreserve/jhove/pull/280
+[#283]: https://github.com/openpreserve/jhove/pull/283
+[#285]: https://github.com/openpreserve/jhove/pull/285
+[#287]: https://github.com/openpreserve/jhove/pull/287
+[#291]: https://github.com/openpreserve/jhove/pull/291
+[#292]: https://github.com/openpreserve/jhove/pull/292
+
 
 JHOVE 1.16.7
 ------------
 2017-07-20
 
-### PDF module
+### PDF Module
 
 - Fixed: Some PDFs being reported as "Well-formed and valid" while remaining
   largely unchecked [[#258](https://github.com/openpreserve/jhove/pull/258)]
@@ -56,7 +111,7 @@ JHOVE 1.16.0
 - Improvements to GitHub pages website
 - Formatting improvements to README.md, RELEASENOTES.md and pom.xml
 
-### PDF module
+### PDF Module
 
 - Fixed: CrossRefStream incorrectly assumes Index value is a two-element array
 - Fixed: Bug in `skipIISBytes` and `PdfModule.getObject`
@@ -64,10 +119,11 @@ JHOVE 1.16.0
 - Better handling of "empty" hex strings
 - Better handling where form-fields are PdfIndirectObjects
 
-### WAVE module
+### WAVE Module
 
 - Fixed: Validation of WAVE files larger than 2 GB
 - Fixed: Skip Bytes issue for WAVE files larger than 100 MB
+
 
 JHOVE 1.14
 ----------
@@ -78,23 +134,23 @@ JHOVE 1.14
 
 ### General
 
- - Ant build replaced with Maven
- - Modularised project structure with "fat" JAR packaging
- - Java 5 support
- - Cross-platform installer
- - Travis CI builds
- - Maven distribution through OPF Artefactory server
- - Updated JHOVE site pages
+- Ant build replaced with Maven
+- Modularised project structure with "fat" JAR packaging
+- Java 5 support
+- Cross-platform installer
+- Travis CI builds
+- Maven distribution through OPF Artefactory server
+- Updated JHOVE site pages
 
 ### New Format Modules
 
- - GZIP Module, ported from JHOVE2 via JWAT by KB
- - WARC Module, ported from JHOVE2 via JWAT by KB
- - PNG Module, developed by Gary McGath
+- GZIP Module, ported from JHOVE2 via JWAT by KB
+- WARC Module, ported from JHOVE2 via JWAT by KB
+- PNG Module, developed by Gary McGath
 
 ### UTF-8 Module
 
- - Support for Unicode 7.0.0
+- Support for Unicode 7.0.0
 
 
 JHOVE 1.11

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,12 +1,30 @@
 RELEASE NOTES
 =============
-JHOVE - JSTOR/Harvard Object Validation Environment  
-Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.  
+JHOVE - JSTOR/Harvard Object Validation Environment
+Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.
 JHOVE is made available under the GNU Lesser General Public License (LGPL;
 see the file LICENSE for details).
 
-Versions 1.7 to 1.11 of JHOVE released independently.  
+Versions 1.7 to 1.11 of JHOVE released independently.
 Versions 1.12 onwards released by the Open Preservation Foundation.
+
+JHOVE 1.18-RC
+-------------
+- Validation for ICC profiles in JPEG and TIFF files [[#249](https://github.com/openpreserve/jhove/pull/249)]
+- Added WAVE module support for BWF v2 recognition [[#273](https://github.com/openpreserve/jhove/pull/273)].
+- External modules now an optional installation (default to yes) [[#292](https://github.com/openpreserve/jhove/pull/292)].
+- Fixed bug in parsing of escape characters in PDF name objects [[#280](https://github.com/openpreserve/jhove/pull/280)].
+- Fixed handling of Exif profiles in JPEG files [[#253](https://github.com/openpreserve/jhove/pull/253)].
+- Fixed ArrayIndexOutOfBoundsException when processing some WAVE files [[#118](https://github.com/openpreserve/jhove/pull/118)]
+- Fixes for various small issues in [[#257](https://github.com/openpreserve/jhove/pull/257)]:
+  * fix for false invalid result for encrypted PDFs;
+  * improvements to TIFF and PDF error handling;
+  * inaccessible files now return "Unknown" status; and
+  * changed WAVE reported MIME type from `audio/xwave` to `audio/vnd.wave`.
+- Improvements to report of PDF indirect references with non-existent destination [[#123](https://github.com/openpreserve/jhove/pull/123)].
+- All JHOVE module error messages now factored as String constants in discrete message classes.
+- JHOVE core error messages factored as String constants in [`CoreMessageConstants`](https://github.com/openpreserve/jhove/blob/integration/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/CoreMessageConstants.java).
+- Improvements to WAVE module documentation [[#269](https://github.com/openpreserve/jhove/pull/269)]
 
 JHOVE 1.16.7
 ------------

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,13 +16,14 @@ JHOVE 1.18-RC
 
 - Installation of external modules is now optional [[#292][]]
 - Inaccessible files are now reported as "Unknown" instead of "Not well-formed" [[#257][]]
-- General improvements to error handling and uncaught module exceptions,
+- Improvements to error handling and uncaught module exceptions,
   increasing resilience during batch processing [[#257][], [#259][]]
 - Improved path handling, allowing installation locations and file paths to
-  contain spaces and more exotic characters [[#206][]]
+  contain spaces, and more exotic characters [[#206][]]
 - Error and informational messages have been consolidated into discrete message
   classes for easier maintenance and future improvement [[#120][], [#157][],
   [#283][]–[#285][], [#287][]–[#291][]]
+- Increased the minimum version of Java from 1.5 to 1.6 [[#273][]]
 
 ### JPEG Module
 
@@ -49,7 +50,7 @@ JHOVE 1.18-RC
 - Added support for reporting BWF v2 fields [[#273][]]
 - Simplified BWF profile detection, allowing detection of any future BWF
   versions. All BWF versions will now be reported as "BWF" instead of
-  "BWF version #", with any unrecognized versions being reported [[#273][]]
+  "BWF version #", with any unrecognized versions being flagged [[#273][]]
 - Reformatted the BWF UMID field into a hexadecimal string instead of a long
   sequence of numbers [[#273][]]
 - Fixed incorrectly reported format names and `ArrayIndexOutOfBoundsException`

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -15,7 +15,8 @@ JHOVE 1.18-RC
 ### General
 
 - Installation of external modules is now optional [[#292][]]
-- Inaccessible files are now reported as "Unknown" instead of "Not well-formed" [[#257][]]
+- Inaccessible files are now reported as of "Unknown" status instead of 
+  "Not well-formed" [[#257][]]
 - Improvements to error handling and uncaught module exceptions,
   increasing resilience during batch processing [[#257][], [#259][]]
 - Improved path handling, allowing installation locations and file paths to
@@ -53,6 +54,8 @@ JHOVE 1.18-RC
   "BWF version #", with any unrecognized versions being flagged [[#273][]]
 - Reformatted the BWF UMID field into a hexadecimal string instead of a long
   sequence of numbers [[#273][]]
+- Changed property label from "Originator Reference" to "OriginatorReference"
+  for consistency and predictability [[#273][]]
 - Fixed incorrectly reported format names and `ArrayIndexOutOfBoundsException`
   errors when processing certain non-PCM WAVE files [[#118][]]
 - Changed reported MIME type from `audio/x-wave` to `audio/vnd.wave` [[#257][]]

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.18-RC1</version>
+    <version>1.18-RC.0</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.18-RC1</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-bbt/scripts/create-1.18-RC-target.sh
+++ b/jhove-bbt/scripts/create-1.18-RC-target.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+testRoot="test-root"
+paramCandidateVersion=""
+paramBaselineVersion=""
+baselineRoot="${testRoot}/baselines"
+candidateRoot="${testRoot}/candidates"
+targetRoot="${testRoot}/targets"
+# Check the passed params to avoid disapointment
+checkParams () {
+	OPTIND=1	# Reset in case getopts previously used
+
+	while getopts "h?b:c:" opt; do	# Grab the options
+		case "$opt" in
+		h|\?)
+			showHelp
+			exit 0
+			;;
+		b)	paramBaselineVersion=$OPTARG
+			;;
+		c)	paramCandidateVersion=$OPTARG
+			;;
+		esac
+	done
+
+	if [ -z "$paramBaselineVersion" ] || [ -z "$paramCandidateVersion" ]
+	then
+		showHelp
+		exit 0
+	fi
+
+	baselineRoot="${baselineRoot}/${paramBaselineVersion}"
+	candidateRoot="${candidateRoot}/${paramCandidateVersion}"
+	targetRoot="${targetRoot}/${paramCandidateVersion}"
+}
+
+# Show usage message
+showHelp() {
+	echo "usage: create-target [-b <baselineVersion>] [-c <candidateVersion>] [-h|?]"
+	echo ""
+	echo "  baselineVersion  : The version number id for the baseline data."
+	echo "  candidateVersion : The version number id for the candidate data."
+	echo ""
+	echo "  -h|? : This message."
+}
+
+# Execution starts here
+checkParams "$@";
+if [[ -d "${targetRoot}" ]]; then
+	rm -rf "${targetRoot}"
+fi
+
+# Simply copy 1.16 for now we're not making any changes
+cp -R "${baselineRoot}" "${targetRoot}"
+
+# Use the new audit for gzip and warc modules since external signatures have been added
+if [[ -f "${candidateRoot}/examples/modules/audit-GZIP-kb.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-GZIP-kb.jhove.xml" "${targetRoot}/examples/modules/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/audit-WARC-kb.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-WARC-kb.jhove.xml" "${targetRoot}/examples/modules/"
+fi
+
+# Issue 62 add ICCProfileName
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/6mp_soft.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/6mp_soft.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/AA_Banner.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/AA_Banner.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi;
+
+# Copy over the fixed version for an encrypted file testRoot
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/AA_Banner.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-22-govdocs-000187.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi;
+
+# Sed fix for changed key encryption message
+find "${targetRoot}" -type f -name "pdf-hul-43-govdocs-486355.pdf.jhove.xml" -exec sed -i 's/Key greater than 40/40-bit or greater RC4 or AES/' {} \;
+
+# Copy over the fixed version for an encrypted file testRoot
+if [[ -f "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi;
+
+# Sed fix for change to WAV MIME type
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's/audio\/x-wave<\/mimeType>/audio\/vnd.wave<\/mimeType>/' {} \;
+
+# Add SaxParseException header to XML output messages
+find "${targetRoot}" -type f -name "jhoveconf.xml.jhove.xml" -exec sed -i 's/severity="error">Element type/severity="error">SaxParseException: Element type/' {} \;
+
+# Issue 60 add new file 20150213_140637.jpg with exif profile
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi;
+
+# Issue 60 add new audit for JPEG and TIFF since new documentation added
+if [[ -f "${candidateRoot}/examples/modules/audit-JPEG-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-JPEG-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi;
+
+if [[ -f "${candidateRoot}/examples/modules/audit-TIFF-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-TIFF-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi;
+
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.3">AIFF-hul<\/module>$/   <module release="1.4">AIFF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.9">PDF-hul<\/module>$/   <module release="1.10">PDF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.2">JPEG-hul<\/module>$/   <module release="1.3">JPEG-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.7">TIFF-hul<\/module>$/   <module release="1.8">TIFF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.4">WAVE-hul<\/module>$/   <module release="1.5">WAVE-hul<\/module>/' {} \;
+
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's%<release>1.9<\/release>%<release>1.10<\/release>%' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's%<date>2017-07-20<\/date>%<date>2017-10-31<\/date>%' {} \;
+find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's%<release>1.3<\/release>%<release>1.4<\/release>%' {} \;
+find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's%<date>2006-09-05<\/date>%<date>2017-10-31<\/date>%' {} \;
+find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's%<release>1.4<\/release>%<release>1.5<\/release>%' {} \;
+find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's%<date>2017-03-14<\/date>%<date>2017-10-31<\/date>%' {} \;
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.9" date="2017-07-20">PDF%<reportingModule release="1.10" date="2017-10-31">PDF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.9" date="2017-07-20">PDF%<reportingModule release="1.10" date="2017-10-31">PDF%' {} \;
+
+
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "*.tif.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "*.g3.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "bathy1.*.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "compos.*.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "*.jpg.jhove.xml" -exec sed -i 's%<reportingModule release="1.2" date="2007-02-13">JPEG%<reportingModule release="1.3" date="2017-05-11">JPEG%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.7" date="2012-08-12">TIFF%<reportingModule release="1.8" date="2017-05-11">TIFF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.2" date="2007-02-13">JPEG%<reportingModule release="1.3" date="2017-05-11">JPEG%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<reportingModule release="1.4" date="2017-03-14">WAVE%<reportingModule release="1.5" date="2017-10-31">WAVE%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%44100.0<\/aes:sampleRate>%44100<\/aes:sampleRate>%' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i "s%Chunk type 'id3 ' ignored%Ignored Chunk type: id3 %" {} \;

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.18-RC1</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.18-RC1</version>
+    <version>1.18-RC.0</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.18-RC1</version>
+    <version>1.18-RC.0</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.18-RC1</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.18-RC1</version>
+    <version>1.18-RC.0</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.18-RC1</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -53,6 +53,7 @@
     <panel classname="FinishPanel" id="finish"/>
   </panels>
 
+
   <packs>
     <pack name="JHOVE Application" required="yes">
       <description>JHOVE application JARs including the internal modules and configuration files.</description>
@@ -60,24 +61,27 @@
       <executable targetfile="$INSTALL_PATH/bin/jhove-apps-${project.version}.jar"/>
       <file targetdir="$INSTALL_PATH/conf"  override="true" src="config/jhove.conf"/>
       <parsable targetfile="$INSTALL_PATH/conf/jhove.conf" type="xml"/>
+      <updatecheck>
+        <include name="bin/**" />
+      </updatecheck>
     </pack>
     <pack name="JHOVE Shell Scripts" required="yes">
       <os family="unix"/>
       <description>Bash execution scripts for command line and GUI apps.</description>
-      <file targetdir="$INSTALL_PATH" src="scripts/jhove"/>
+      <file targetdir="$INSTALL_PATH" override="true" src="scripts/jhove"/>
       <parsable targetfile="$INSTALL_PATH/jhove" type="shell"/>
       <executable targetfile="$INSTALL_PATH/jhove"/>
-      <file targetdir="$INSTALL_PATH" src="scripts/jhove-gui"/>
+      <file targetdir="$INSTALL_PATH" override="true" src="scripts/jhove-gui"/>
       <parsable targetfile="$INSTALL_PATH/jhove-gui" type="shell"/>
       <executable targetfile="$INSTALL_PATH/jhove-gui"/>
     </pack>
     <pack name="JHOVE Batch Script" required="yes">
       <os family="windows"/>
       <description>DOS batch execution scripts for command line and GUI apps.</description>
-      <file targetdir="$INSTALL_PATH" src="scripts/jhove.bat"/>
+      <file targetdir="$INSTALL_PATH" override="true" src="scripts/jhove.bat"/>
       <parsable targetfile="$INSTALL_PATH/jhove.bat" type="plain"/>
       <executable targetfile="$INSTALL_PATH/jhove.bat"/>
-      <file targetdir="$INSTALL_PATH" src="scripts/jhove-gui.bat"/>
+      <file targetdir="$INSTALL_PATH" override="true" src="scripts/jhove-gui.bat"/>
       <parsable targetfile="$INSTALL_PATH/jhove-gui.bat" type="plain"/>
       <executable targetfile="$INSTALL_PATH/jhove-gui.bat"/>
     </pack>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.18-RC1</version>
+    <version>1.18-RC.0</version>
   </parent>
 
   <artifactId>jhove-modules</artifactId>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.17.0-SNAPSHOT</version>
+    <version>1.18-RC1</version>
   </parent>
 
   <artifactId>jhove-modules</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.17.0-SNAPSHOT</version>
+  <version>1.18-RC1</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.18-RC1</version>
+  <version>1.18-RC.0</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>


### PR DESCRIPTION
- created new Maven module for external JHOVE modules: `jhove-ext-modules`;
- moved GZIP, PNG, and WARC modules to `jhove-ext-modules`;
- moved Maven dependencies for external modules to `jhove-ext-modules`;
- added `jhove-ext-modules` as Maven dependecy for `jhove-installer`;
- added new optional installer pack for jhove external modules;
- added alternative config for external modules at `jhove-installer/src/main/config/ext-modules/jhove.conf`;
- classpath in executions scripts now `JHOVE_HOME/bin/*` rather than specific jar in order to pick up external modules jar.- bumped version number to 1.8-RC1;
- ensured that installer cleans up old files, avoiding update issues;
- added release notes;
- added minor version for testing scripts; and
- added candidate creation script for 1.18-RC.