### PR TITLE
WAVE: Fix parse error in Associated Data List

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/AssocDataListChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/AssocDataListChunk.java
@@ -53,6 +53,7 @@ public class AssocDataListChunk extends Superchunk {
         // this was intended to allow other list structures (don't ask
         // why), but any others will be considered non-conforming.
         String typeID = module.read4Chars(_dstream);
+        bytesLeft -= 4;
         if (!"adtl".equals (typeID)) {
             info.setMessage (new ErrorMessage (MessageConstants.ERR_LIST_TYPE_UNK, 
                     MessageConstants.SUB_MESS_TYPE + typeID,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SimpleTextChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SimpleTextChunk.java
@@ -45,7 +45,7 @@ public abstract class SimpleTextChunk extends Chunk {
         bytesLeft -= 4;
         byte[] buf = new byte[(int) bytesLeft];
         ModuleBase.readByteBuf (_dstream, buf, module);
-        String txt = new String (buf);
+        String txt = new String (buf).trim ();
         Property[] propArr = new Property[2];
         propArr[0] = new Property ("CuePointID",
                 PropertyType.LONG,


### PR DESCRIPTION
In JHOVE 1.18.1, validating a WAVE file that contains an Associated Data List chunk results in the status "Not well-formed" with error message "Unexpected end of file".

Consider this minimal example (binary version is attached) which constitutes a WAVE file without any audio data (empty Data chunk) but with an Associated Data List:

    # File header
    52494646 # "RIFF"
    64000000 # file size
    57415645 # "WAVE"

    # Format chunk
    666d7420 # chunkID "fmt "
    10000000 # chunkSize
    0100     # wFormatTag
    0100     # wChannels
    a0e9a002 # dwSamplesPerSec 44100k
    40d34105 # dwAvgBytesPerSec
    0200     # wBlockAlign
    1000     # wBitsPerSample

    # Data chunk (empty)
    64617461 # chunkID "data"
    00000000 # chunkSize

    # Cue chunk
    63756520 # chunkID "cue "
    1c000000 # chunkSize
    01000000 # dwCuePoints

    # CuePoint
    01000000 # dwIdentifier
    00000000 # dwPosition
    64617461 # fccChunk "data"
    00000000 # dwChunkStart
    00000000 # dwBlockStart
    00000000 # dwSampleOffset

    # Associated Data List
    6c697374 # chunkId "list"
    14000000 # chunkSize
    6164746c # typeID "adtl"

    # Label Chunk
    6c61626c # chunkID "labl"
    08000000 # chunkSize
    01000000 # dwIdentifier
    666f6f00 # dwText "foo\0"

The Associated Data List chunk (the chunk with ID "list") in this example has size 0x14 (little endian), meaning it holds 20 bytes of data. These 20 bytes include the list's type ID "adtl" and the nested sub-chunk (the chunk with ID "labl"): 4 bytes for the "adtl" string plus 16 bytes for the "labl" chunk.

When reading an Associated Data List's sub-chunks JHOVE eats bytes according to the value of the `bytesLeft` variable by calling the `getNextChunkHeader()` method. The `bytesLeft` variable is initialized with the Associated Data List's size. So in this example JHOVE tries to read 20 bytes worth of sub-chunks. But alas, JHOVE ignores the fact that the "adtl" type ID has a size of its own! It should not read 20 bytes of sub-chunks, but only 16 bytes, allowing for the 4 bytes that are consumed by the type ID. So JHOVE should subtract 4 bytes from the `bytesLeft` variable before it starts reading sub-chunks, just like it does in the ListInfoChunk class.

This pull request adjusts this behaviour.

[adtl.zip](https://github.com/openpreserve/jhove/files/1703549/adtl.zip)

