### PR TITLE
FIX - PDF minor version number checking.

### DIFF
--- a/jhove-bbt/scripts/create-1.19-target.sh
+++ b/jhove-bbt/scripts/create-1.19-target.sh
@@ -52,3 +52,10 @@ fi
 
 # Simply copy baseline for now we're not making any changes
 cp -R "${baselineRoot}" "${targetRoot}"
+
+# Add the Release Canidate PDF-HUL details
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.10">PDF-hul<\/module>$/   <module release="1.11-RC">PDF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <release>1.10<\/release>$/  <release>1.11-RC<\/release>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <date>2017-10-31<\/date>$/  <date>2018-03-16<\/date>/' {} \;
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11-RC" date="2018-03-16">PDF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11-RC" date="2018-03-16">PDF%' {} \;

--- a/jhove-bbt/scripts/travis-test.sh
+++ b/jhove-bbt/scripts/travis-test.sh
@@ -79,5 +79,9 @@ echo " - applying the baseline patches for ${MAJOR_MINOR_VER} at: ${TARGET_ROOT}
 bash "${SCRIPT_DIR}/create-${MAJOR_MINOR_VER}-target.sh" -b "${BASELINE_VERSION}" -c "${MAJOR_MINOR_VER}"
 
 echo "Black box testing ${MAJOR_MINOR_VER}."
+echo " - using development JHOVE installer: ${TEST_ROOT}/targets/${MAJOR_MINOR_VER}."
 bash "${SCRIPT_DIR}/bbt-jhove.sh" -b "${TEST_ROOT}/targets/${MAJOR_MINOR_VER}" -c "${TEST_ROOT}/corpora" -j . -o "${TEST_ROOT}/candidates" -k "dev-${MAJOR_MINOR_VER}" -i
-exit $?
+echo " - test comparison key is: dev-${MAJOR_MINOR_VER}."
+exitStatus=$?
+echo " - BB Testing output is: ${exitStatus}"
+exit $exitStatus

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1063,20 +1063,20 @@ public class PdfModule
 
     protected boolean parseHeader(RepInfo info) throws IOException
     {
-    	PdfHeader header = PdfHeader.parseHeader(_parser);
-    	if (header == null) {
+        PdfHeader header = PdfHeader.parseHeader(_parser);
+        if (header == null) {
             info.setWellFormed(false);
             info.setMessage(new ErrorMessage(MessageConstants.ERR_PDF_HEADER_MISSING, 0L));
             return false;
         }
-		if (!header.isVersionValid()) {
-			info.setValid(false);
-			info.setMessage(new ErrorMessage(MessageConstants.ERR_PDF_MINOR_INVALID, 0L));
-		}
-		_version = header.getVersionString();
-		_pdfACompliant = header.isPdfACompliant();
+        if (!header.isVersionValid()) {
+            info.setValid(false);
+            info.setMessage(new ErrorMessage(MessageConstants.ERR_PDF_MINOR_INVALID, 0L));
+        }
+        _version = header.getVersionString();
+        _pdfACompliant = header.isPdfACompliant();
         info.setSigMatch(_name);
-		return true;
+        return true;
     }
 
 

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -86,6 +86,7 @@ import edu.harvard.hul.ois.jhove.module.pdf.Parser;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfArray;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfDictionary;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfException;
+import edu.harvard.hul.ois.jhove.module.pdf.PdfHeader;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfIndirectObj;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfInvalidException;
 import edu.harvard.hul.ois.jhove.module.pdf.PdfMalformedException;
@@ -113,9 +114,6 @@ public class PdfModule
 	public static final String MIME_TYPE = "application/pdf";
 	public static final String EXT = ".pdf";
 	
-	private static final String PDF_VER1_HEADER_PREFIX = "PDF-1.";
-	private static final String PDF_SIG_HEADER = "%" + PDF_VER1_HEADER_PREFIX;
-	private static final String POSTSCRIPT_HEADER_PREFIX = "!PS-Adobe-";
 	private static final String ENCODING_PREFIX = "ENC=";
 //	private static final String NO_HEADER = "No PDF header";
 
@@ -638,7 +636,7 @@ public class PdfModule
         _signature.add(new ExternalSignature(EXT,
                                         SignatureType.EXTENSION,
                                         SignatureUseType.OPTIONAL));
-        _signature.add(new InternalSignature(PDF_SIG_HEADER,
+        _signature.add(new InternalSignature(PdfHeader.PDF_SIG_HEADER,
                                         SignatureType.MAGIC,
                                         SignatureUseType.MANDATORY,
                                         0));
@@ -1088,7 +1086,7 @@ public class PdfModule
             }
             if (token instanceof Comment) {
                 value = ((Comment) token).getValue();
-                if (value.indexOf(PDF_VER1_HEADER_PREFIX) == 0) {
+                if (value.indexOf(PdfHeader.PDF_VER1_HEADER_PREFIX) == 0) {
                     foundSig = true;
                     _version = value.substring(4, 7);
                     /* If we got this far, take note that the signature is OK. */
@@ -1097,10 +1095,10 @@ public class PdfModule
                 }
                 // The implementation notes (though not the spec)
                 // allow an alternative signature of %!PS-Adobe-N.n PDF-M.m
-                if (value.indexOf(POSTSCRIPT_HEADER_PREFIX) == 0) {
+                if (value.indexOf(PdfHeader.POSTSCRIPT_HEADER_PREFIX) == 0) {
                     // But be careful: that much by itself is the standard
                     // PostScript signature.
-                    int n = value.indexOf(PDF_VER1_HEADER_PREFIX);
+                    int n = value.indexOf(PdfHeader.PDF_VER1_HEADER_PREFIX);
                     if (n >= 11) {
                         foundSig = true;
                         _version = value.substring(n + 4);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -360,8 +360,8 @@ public class PdfModule
      ******************************************************************/
 
     private static final String NAME = "PDF-hul";
-    private static final String RELEASE = "1.10";
-    private static final int [] DATE = {2017, 10, 31};
+    private static final String RELEASE = "1.11-RC";
+    private static final int [] DATE = {2018, 03, 16};
     private static final String [] FORMAT = {
         "PDF", "Portable Document Format"
     };
@@ -1069,6 +1069,10 @@ public class PdfModule
             info.setMessage(new ErrorMessage(MessageConstants.ERR_PDF_HEADER_MISSING, 0L));
             return false;
         }
+		if (!header.isVersionValid()) {
+			info.setValid(false);
+			info.setMessage(new ErrorMessage(MessageConstants.ERR_PDF_MINOR_INVALID, 0L));
+		}
 		_version = header.getVersionString();
 		_pdfACompliant = header.isPdfACompliant();
         info.setSigMatch(_name);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -123,6 +123,7 @@ public enum MessageConstants {
 	public static final String ERR_PAGE_TREE_NODE_INVALID = "Invalid page tree node";
 	public static final String ERR_PAGE_TREE_TRIMBOX_MALFORMED = "Malformed TrimBox in page tree";
 	public static final String ERR_PDF_HEADER_MISSING = "No PDF header";
+	public static final String ERR_PDF_MINOR_INVALID = "PDF minor version number is greater than 7.";
 	public static final String ERR_PDF_TRAILER_MISSING = "No PDF trailer";
 	public static final String ERR_PREV_OFFSET_TRAILER_DICT_INVALID = "Invalid Prev offset in trailer dictionary";
 	public static final String ERR_RESOURCES_ENTRY_INVALID = "Invalid Resources Entry in document";

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -6,6 +6,11 @@ package edu.harvard.hul.ois.jhove.module.pdf;
 import java.io.IOException;
 
 /**
+ * Simple class that is the a prototype of a proper header parser class. The aim
+ * was to introduce a simple version check for the PDF/A minor version number,
+ * see {@link PdfHeader#isVersionValid()}, while not changing anything else
+ * through over ambition.
+ * 
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
  * @version 0.1 Created 8 Mar 2018:00:46:39
@@ -15,6 +20,7 @@ public final class PdfHeader {
 	public static final String PDF_VER1_HEADER_PREFIX = "PDF-1."; //$NON-NLS-1$
 	public static final String PDF_SIG_HEADER = "%" + PDF_VER1_HEADER_PREFIX; //$NON-NLS-1$
 	public static final String POSTSCRIPT_HEADER_PREFIX = "!PS-Adobe-"; //$NON-NLS-1$
+	public static final int MAX_VALID_MAJOR_VERSION = 7;
 
 	private final String versionString;
 	private final boolean isPdfACompilant;
@@ -43,6 +49,51 @@ public final class PdfHeader {
 	}
 
 	/**
+	 * Performs a very simple version number validity check. Given version
+	 * number is a String of form 1.x, x is the minor version number. This
+	 * method parses the minor version number from the version String and tests
+	 * whether it is less than or equal to
+	 * {@link PdfHeader#MAX_VALID_MAJOR_VERSION}.
+	 * 
+	 * @return true if an integer minor version number can be parsed from the
+	 *         version string AND it is less than or equal to
+	 *         {@link PdfHeader#MAX_VALID_MAJOR_VERSION}. Otherwise false.
+	 */
+	public boolean isVersionValid() {
+		// Set minor version to one larger than maximum so invalid if parse
+		// fails
+		int minorVersion = MAX_VALID_MAJOR_VERSION + 1;
+		try {
+			minorVersion = getMinorVersion(this.versionString);
+		} catch (NumberFormatException nfe) {
+			// TODO : Do nothing for now, the version number is still invalid.
+		}
+		return minorVersion <= MAX_VALID_MAJOR_VERSION;
+	}
+
+	/**
+	 * Creates a new {@link PdfHeader} instance using the passed parameters.
+	 * 
+	 * @param versionString
+	 *            the version number from the PDF Header, should be of form
+	 *            <code>1.x</code> where x should be of the range 0-7.
+	 * @param isPdfaCompliant
+	 *            boolean flag indicating if the PDF/A is compliant or non
+	 *            compliant with JHOVE's PDF/A profile.
+	 * @return a {@link PdfHeader} instance initialised using
+	 *         <code>versionString</code> and <code>isPdfaCompliant</code>.
+	 * @throws NullPointerException
+	 *             when parameter <code>versionString</code> is null.
+	 */
+	static PdfHeader fromValues(final String versionString,
+			final boolean isPdfaCompliant) {
+		if (versionString == null)
+			throw new NullPointerException(
+					"Parameter versionString can not be null.");
+		return new PdfHeader(versionString, isPdfaCompliant);
+	}
+
+	/**
 	 * Factory method for {@link PdfHeader} that parses a new instance using the
 	 * supplied {@link Parser} instance.
 	 * 
@@ -53,7 +104,7 @@ public final class PdfHeader {
 	 *         {@link Parser} or <code>null</code> when no header could be found
 	 *         and parsed.
 	 */
-	public static PdfHeader parseHeader(final Parser _parser) {
+	public static PdfHeader parseHeader(final Parser parser) {
 		Token token = null;
 		String value = null;
 		boolean isPdfACompliant = false;
@@ -61,16 +112,17 @@ public final class PdfHeader {
 
 		/* Parse file header. */
 		for (;;) {
-			if (_parser.getOffset() > 1024) {
+			if (parser.getOffset() > 1024) {
 				return null;
 			}
 			try {
 				token = null;
-				token = _parser.getNext(1024L);
+				token = parser.getNext(1024L);
 			} catch (IOException ee) {
 				return null;
 			} catch (Exception e) {
-			} // fall through
+				// fall through
+			}
 
 			if (token == null) {
 				return null;
@@ -99,26 +151,37 @@ public final class PdfHeader {
 		if (version == null) {
 			return null;
 		}
-		// Check for PDF/A conformance. The next item must be
-		// a comment with four characters, each greater than 127
+
 		try {
-			token = _parser.getNext();
-			String cmt = ((Comment) token).getValue();
-			char[] cmtArray = cmt.toCharArray();
-			int ctlcnt = 0;
-			for (int i = 0; i < 4; i++) {
-				if (cmtArray[i] > 127) {
-					ctlcnt++;
-				}
-			}
-			if (ctlcnt < 4) {
-				isPdfACompliant = false;
-			}
-		} catch (Exception e) {
+			isPdfACompliant = isTokenPdfACompliant(parser.getNext());
+		} catch (Exception excep) {
 			// Most likely a ClassCastException on a non-comment
 			isPdfACompliant = false;
 		}
+		// Check for PDF/A conformance. The next item must be
+		// a comment with four characters, each greater than 127
 		return new PdfHeader(version, isPdfACompliant);
 	}
 
+	private static int getMinorVersion(final String version) {
+		double doubleVer = Double.parseDouble(version);
+		double fractPart = doubleVer % 1;
+		int minor = (int) (10L * fractPart);
+		return minor;
+	}
+
+	private static boolean isTokenPdfACompliant(final Token token) {
+		String cmt = ((Comment) token).getValue();
+		char[] cmtArray = cmt.toCharArray();
+		int ctlcnt = 0;
+		for (int i = 0; i < 4; i++) {
+			if (cmtArray[i] > 127) {
+				ctlcnt++;
+			}
+		}
+		if (ctlcnt < 4) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -179,9 +179,6 @@ public final class PdfHeader {
 				ctlcnt++;
 			}
 		}
-		if (ctlcnt < 4) {
-			return false;
-		}
-		return true;
+		return (ctlcnt > 3);
 	}
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -1,0 +1,115 @@
+/**
+ * 
+ */
+package edu.harvard.hul.ois.jhove.module.pdf;
+
+import java.io.IOException;
+
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.RepInfo;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 8 Mar 2018:00:46:39
+ */
+
+public final class PdfHeader {
+	public static final String PDF_VER1_HEADER_PREFIX = "PDF-1.";
+	public static final String PDF_SIG_HEADER = "%" + PDF_VER1_HEADER_PREFIX;
+	public static final String POSTSCRIPT_HEADER_PREFIX = "!PS-Adobe-";
+	
+	private final int majorVersion;
+	private final int minorVersion;
+
+	
+	/**
+	 * 
+	 */
+	private PdfHeader(final int majorVersion, final int minorVersion) {
+		this.majorVersion = majorVersion;
+		this.minorVersion = minorVersion;
+	}
+
+	public static boolean parseHeader(final RepInfo info, final Parser _parser, final String _name) throws IOException {
+		Token token = null;
+		String value = null;
+
+		/* Parse file header. */
+
+		boolean foundSig = false;
+		for (;;) {
+			if (_parser.getOffset() > 1024) {
+				break;
+			}
+			try {
+				token = null;
+				token = _parser.getNext(1024L);
+			} catch (IOException ee) {
+				break;
+			} catch (Exception e) {
+			} // fall through
+			if (token == null) {
+				break;
+			}
+			if (token instanceof Comment) {
+				value = ((Comment) token).getValue();
+				if (value.indexOf(PDF_VER1_HEADER_PREFIX) == 0) {
+					foundSig = true;
+					_version = value.substring(4, 7);
+					/*
+					 * If we got this far, take note that the signature is OK.
+					 */
+					info.setSigMatch(_name);
+					break;
+				}
+				// The implementation notes (though not the spec)
+				// allow an alternative signature of %!PS-Adobe-N.n PDF-M.m
+				if (value.indexOf(POSTSCRIPT_HEADER_PREFIX) == 0) {
+					// But be careful: that much by itself is the standard
+					// PostScript signature.
+					int n = value.indexOf(PDF_VER1_HEADER_PREFIX);
+					if (n >= 11) {
+						foundSig = true;
+						_version = value.substring(n + 4);
+						// However, this is not PDF-A compliant.
+						_pdfACompliant = false;
+						info.setSigMatch(_name);
+						break;
+					}
+				}
+			}
+
+			// If we don't find it right at the beginning, we aren't
+			// PDF/A compliant.
+			_pdfACompliant = false;
+		}
+		if (!foundSig) {
+			info.setWellFormed(false);
+			info.setMessage(new ErrorMessage(
+					MessageConstants.ERR_PDF_HEADER_MISSING, 0L));
+			return false;
+		}
+		// Check for PDF/A conformance. The next item must be
+		// a comment with four characters, each greater than 127
+		try {
+			token = _parser.getNext();
+			String cmt = ((Comment) token).getValue();
+			char[] cmtArray = cmt.toCharArray();
+			int ctlcnt = 0;
+			for (int i = 0; i < 4; i++) {
+				if (cmtArray[i] > 127) {
+					ctlcnt++;
+				}
+			}
+			if (ctlcnt < 4) {
+				_pdfACompliant = false;
+			}
+		} catch (Exception e) {
+			// Most likely a ClassCastException on a non-comment
+			_pdfACompliant = false;
+		}
+		return true;
+	}
+
+}

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.harvard.hul.ois.jhove.module.pdf;
 
 import java.io.IOException;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -5,9 +5,6 @@ package edu.harvard.hul.ois.jhove.module.pdf;
 
 import java.io.IOException;
 
-import edu.harvard.hul.ois.jhove.ErrorMessage;
-import edu.harvard.hul.ois.jhove.RepInfo;
-
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
@@ -15,52 +12,74 @@ import edu.harvard.hul.ois.jhove.RepInfo;
  */
 
 public final class PdfHeader {
-	public static final String PDF_VER1_HEADER_PREFIX = "PDF-1.";
-	public static final String PDF_SIG_HEADER = "%" + PDF_VER1_HEADER_PREFIX;
-	public static final String POSTSCRIPT_HEADER_PREFIX = "!PS-Adobe-";
-	
-	private final int majorVersion;
-	private final int minorVersion;
+	public static final String PDF_VER1_HEADER_PREFIX = "PDF-1."; //$NON-NLS-1$
+	public static final String PDF_SIG_HEADER = "%" + PDF_VER1_HEADER_PREFIX; //$NON-NLS-1$
+	public static final String POSTSCRIPT_HEADER_PREFIX = "!PS-Adobe-"; //$NON-NLS-1$
 
-	
+	private final String versionString;
+	private final boolean isPdfACompilant;
+
 	/**
 	 * 
 	 */
-	private PdfHeader(final int majorVersion, final int minorVersion) {
-		this.majorVersion = majorVersion;
-		this.minorVersion = minorVersion;
+	private PdfHeader(final String versionString,
+			final boolean isPdfaCompliant) {
+		this.versionString = versionString;
+		this.isPdfACompilant = isPdfaCompliant;
 	}
 
-	public static boolean parseHeader(final RepInfo info, final Parser _parser, final String _name) throws IOException {
+	/**
+	 * @return the version string parsed from the PDF Header
+	 */
+	public String getVersionString() {
+		return this.versionString;
+	}
+
+	/**
+	 * @return true if the header is considered PDF/A compliant, otherwise false
+	 */
+	public boolean isPdfACompliant() {
+		return this.isPdfACompilant;
+	}
+
+	/**
+	 * Factory method for {@link PdfHeader} that parses a new instance using the
+	 * supplied {@link Parser} instance.
+	 * 
+	 * @param _parser
+	 *            the {@link Parser} instance that will be used to parse header
+	 *            details
+	 * @return a new {@link PdfHeader} instance derived using the supplied
+	 *         {@link Parser} or <code>null</code> when no header could be found
+	 *         and parsed.
+	 */
+	public static PdfHeader parseHeader(final Parser _parser) {
 		Token token = null;
 		String value = null;
+		boolean isPdfACompliant = false;
+		String version = null;
 
 		/* Parse file header. */
-
-		boolean foundSig = false;
 		for (;;) {
 			if (_parser.getOffset() > 1024) {
-				break;
+				return null;
 			}
 			try {
 				token = null;
 				token = _parser.getNext(1024L);
 			} catch (IOException ee) {
-				break;
+				return null;
 			} catch (Exception e) {
 			} // fall through
+
 			if (token == null) {
-				break;
+				return null;
 			}
 			if (token instanceof Comment) {
 				value = ((Comment) token).getValue();
 				if (value.indexOf(PDF_VER1_HEADER_PREFIX) == 0) {
-					foundSig = true;
-					_version = value.substring(4, 7);
-					/*
-					 * If we got this far, take note that the signature is OK.
-					 */
-					info.setSigMatch(_name);
+					version = value.substring(4, 7);
+					isPdfACompliant = true;
 					break;
 				}
 				// The implementation notes (though not the spec)
@@ -70,25 +89,15 @@ public final class PdfHeader {
 					// PostScript signature.
 					int n = value.indexOf(PDF_VER1_HEADER_PREFIX);
 					if (n >= 11) {
-						foundSig = true;
-						_version = value.substring(n + 4);
-						// However, this is not PDF-A compliant.
-						_pdfACompliant = false;
-						info.setSigMatch(_name);
+						version = value.substring(n + 4);
 						break;
 					}
 				}
 			}
-
-			// If we don't find it right at the beginning, we aren't
-			// PDF/A compliant.
-			_pdfACompliant = false;
 		}
-		if (!foundSig) {
-			info.setWellFormed(false);
-			info.setMessage(new ErrorMessage(
-					MessageConstants.ERR_PDF_HEADER_MISSING, 0L));
-			return false;
+
+		if (version == null) {
+			return null;
 		}
 		// Check for PDF/A conformance. The next item must be
 		// a comment with four characters, each greater than 127
@@ -103,13 +112,13 @@ public final class PdfHeader {
 				}
 			}
 			if (ctlcnt < 4) {
-				_pdfACompliant = false;
+				isPdfACompliant = false;
 			}
 		} catch (Exception e) {
 			// Most likely a ClassCastException on a non-comment
-			_pdfACompliant = false;
+			isPdfACompliant = false;
 		}
-		return true;
+		return new PdfHeader(version, isPdfACompliant);
 	}
 
 }

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeaderTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeaderTest.java
@@ -1,0 +1,101 @@
+/**
+ * 
+ */
+package edu.harvard.hul.ois.jhove.module.pdf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.net.URISyntaxException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.module.PdfModule;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 13 Mar 2018:11:28:10
+ */
+@SuppressWarnings("static-method")
+public class PdfHeaderTest {
+	private static final String pdfResourcePath = "/edu/harvard/hul/ois/jhove/module/pdf/";
+	private static final String minimalPdfPath = pdfResourcePath
+			+ "T01_000_minimal.pdf";
+	private static final String invalidMinorPath = pdfResourcePath
+			+ "T01_002_header-invalid-minor-version.pdf";
+	
+	private PdfModule module;
+
+	@Before
+	public void setUp() throws Exception {
+		this.module = new PdfModule();
+		JhoveBase je = new JhoveBase();
+		this.module.setBase(je);
+	}
+
+	/**
+	 * Test method for
+	 * {@link edu.harvard.hul.ois.jhove.module.pdf.PdfHeader#getVersionString()}.
+	 */
+	@Test
+	public final void testMinorVersion()
+			throws URISyntaxException {
+		File validMinor = new File(
+				PdfHeaderTest.class.getResource(minimalPdfPath).toURI());
+
+		RepInfo info = parseTestFile(validMinor);
+
+		// Major version number < 8 should be well formed
+		assertEquals("Should be well formed.", RepInfo.TRUE, info.getWellFormed());
+		// Major version number < 8 should be invalid
+		assertEquals("Should be valid.", RepInfo.TRUE, info.getValid());
+	}
+
+	/**
+	 * Test method for
+	 * {@link edu.harvard.hul.ois.jhove.module.pdf.PdfHeader#getVersionString()}.
+	 */
+	@Test
+	public final void testInvalidMinorVersion()
+			throws URISyntaxException {
+		File invalidMajor = new File(
+				PdfHeaderTest.class.getResource(invalidMinorPath).toURI());
+
+		RepInfo info = parseTestFile(invalidMajor);
+
+		// Major version number > 7 should be well formed
+		assertEquals("Should be well formed.", RepInfo.TRUE, info.getWellFormed());
+		assertEquals("Should NOT be valid.", RepInfo.FALSE, info.getValid());
+	}
+	
+	private RepInfo parseTestFile(final File toTest) {
+		RepInfo info = new RepInfo(toTest.getName());
+		RandomAccessFile raf = null;
+		try {
+			raf = new RandomAccessFile(toTest, "r");
+			this.module.parse(raf, info);
+		} catch (FileNotFoundException excep) {
+			excep.printStackTrace();
+			fail("Couldn't find file to test: " + toTest.getName());
+		} catch (IOException excep) {
+			excep.printStackTrace();
+			fail("IOException Reading: " + toTest.getName());
+		}
+		try {
+			if (raf != null) {
+				raf.close();
+			}
+		} catch (@SuppressWarnings("unused") IOException excep) {
+			// We don't care about this..
+		}
+		return info;
+	}
+}

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeaderTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeaderTest.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.harvard.hul.ois.jhove.module.pdf;
 
 import static org.junit.Assert.assertEquals;

--- a/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_000_minimal.pdf
+++ b/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_000_minimal.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Resources 3 0 R
+/Type /Page
+/Contents [4 0 R]
+>>
+endobj 
+3 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+endobj 
+4 0 obj 
+<<
+/Length 68
+>>
+stream
+1. 0. 0. 1. 50. 700. cm
+BT
+/F0 36. Tf
+(Hello PDF-world!) Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000182 00000 n 
+0000000281 00000 n 
+0000000402 00000 n 
+trailer
+
+<<
+/Root 5 0 R
+/Size 6
+>>
+startxref
+452
+%%EOF

--- a/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_001_header-invalid-major-version.pdf
+++ b/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_001_header-invalid-major-version.pdf
@@ -1,0 +1,66 @@
+%PDF-2.4
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Resources 3 0 R
+/Type /Page
+/Contents [4 0 R]
+>>
+endobj 
+3 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+endobj 
+4 0 obj 
+<<
+/Length 68
+>>
+stream
+1. 0. 0. 1. 50. 700. cm
+BT
+/F0 36. Tf
+(Hello PDF-world!) Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000182 00000 n 
+0000000281 00000 n 
+0000000402 00000 n 
+trailer
+
+<<
+/Root 5 0 R
+/Size 6
+>>
+startxref
+452
+%%EOF

--- a/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_002_header-invalid-minor-version.pdf
+++ b/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_002_header-invalid-minor-version.pdf
@@ -1,0 +1,66 @@
+%PDF-1.9
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Resources 3 0 R
+/Type /Page
+/Contents [4 0 R]
+>>
+endobj 
+3 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+endobj 
+4 0 obj 
+<<
+/Length 68
+>>
+stream
+1. 0. 0. 1. 50. 700. cm
+BT
+/F0 36. Tf
+(Hello PDF-world!) Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000182 00000 n 
+0000000281 00000 n 
+0000000402 00000 n 
+trailer
+
+<<
+/Root 5 0 R
+/Size 6
+>>
+startxref
+452
+%%EOF


### PR DESCRIPTION
- added test for invalid minor version number;
- added MessageConstant for invalid minor version;
- bumped PDF Module release details for release candidate;
- refactored `PdfHeader` class;
- JavaDoc for `PdfHeader`;
- unit tests and test resources for `PdfHeader`;
- added JHOVE RC PDF Module details to baseline; and
- improved result logging for Travis tests.
Closes #207