### PR TITLE
FIX - Document catalog type checking

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -199,6 +199,7 @@ public class PdfModule
 	private static final String DICT_KEY_LANG = "Lang";
 	private static final String DICT_KEY_PAGES = "Pages";
 	private static final String DICT_KEY_PAGE_LABELS = "PageLabels";
+	private static final String DICT_KEY_TYPE = "Type";
 	private static final String DICT_KEY_VERSION = "Version";
 	private static final String DICT_KEY_NAME = "Name";
 	private static final String DICT_KEY_NAMES = DICT_KEY_NAME + "s";
@@ -1663,6 +1664,27 @@ public class PdfModule
             return false;
         }
         try {
+            // Check that the catalog has a key type and the types value is catalog
+            PdfObject type = _docCatDict.get(DICT_KEY_TYPE);
+            if (type != null && type instanceof PdfSimpleObject) {
+                // If the type key is not null and is a simple object
+                String typeText = ((PdfSimpleObject) type).getStringValue();
+                if (!typeText.equals("Catalog")) {
+                    // If the type key value is not Catalog
+                    info.setWellFormed(false);
+                    info.setMessage(new ErrorMessage(MessageConstants.ERR_DOC_CAT_TYPE_NO_CAT, 0));
+                    return false;
+                }
+            } else {
+                // There's no type key or it's not a simple object
+                info.setWellFormed(false);
+                // Choose message depending on whether the value is null or of the wrong type
+                String message = (type == null) ?
+                    MessageConstants.ERR_DOC_CAT_NO_TYPE :
+                        MessageConstants.ERR_DOC_CAT_NOT_SIMPLE;
+                info.setMessage(new ErrorMessage(message, 0));
+                return false;
+            }
 
             PdfObject viewPref = _docCatDict.get(DICT_KEY_VIEWER_PREFS);
             viewPref = resolveIndirectObject(viewPref);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -248,6 +248,7 @@ public class PdfModule
 	private static final String DICT_KEY_FIRST = "First";
 	private static final String DICT_KEY_LAST = "Last";
 	private static final String DICT_KEY_FLAGS = "Flags";
+	private static final String KEY_VAL_CATALOG = "Catalog";
 	
 	
 	private static final String PROP_NAME_BASE_FONT = DICT_KEY_BASE_FONT;
@@ -1669,7 +1670,7 @@ public class PdfModule
             if (type != null && type instanceof PdfSimpleObject) {
                 // If the type key is not null and is a simple object
                 String typeText = ((PdfSimpleObject) type).getStringValue();
-                if (!typeText.equals("Catalog")) {
+                if (!KEY_VAL_CATALOG.equals(typeText)) {
                     // If the type key value is not Catalog
                     info.setWellFormed(false);
                     info.setMessage(new ErrorMessage(MessageConstants.ERR_DOC_CAT_TYPE_NO_CAT, 0));

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -77,6 +77,9 @@ public enum MessageConstants {
 	public static final String ERR_DICT_DELIMETERS_IMPROPERLY_NESTED = "Improperly nested dictionary delimiters";
 	public static final String ERR_DICT_MALFORMED = "Malformed dictionary";
 	public static final String ERR_DOC_CAT_DICT_MISSING = "No document catalog dictionary";
+	public static final String ERR_DOC_CAT_TYPE_NO_CAT = "Document catalog Type key must have value Catalog";
+	public static final String ERR_DOC_CAT_NO_TYPE = "Document catalog has no Type key or it has a null value.";
+	public static final String ERR_DOC_CAT_NOT_SIMPLE = "Document catalog Type key does not have a simple String value.";
 	public static final String ERR_DOC_CAT_VERSION_INVALID = "Invalid Version in document catalog";
 	public static final String ERR_DOC_NODE_DICT_MISSING = "Missing dictionary in document node";
 	public static final String ERR_DOC_STRUCT_ATT_INVALID = "Invalid attribute in document structure";

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfModuleTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfModuleTest.java
@@ -1,0 +1,105 @@
+/**
+ * 
+ */
+package edu.harvard.hul.ois.jhove.module.pdf;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.net.URISyntaxException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.module.PdfModule;
+
+/**
+ * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ *
+ * @version 0.1
+ * 
+ * Created 13 Mar 2018:18:17:45
+ */
+
+public class PdfModuleTest {
+	private static final String pdfResourcePath = "/edu/harvard/hul/ois/jhove/module/pdf/";
+	private static final String minimalPdfPath = pdfResourcePath
+			+ "T01_000_minimal.pdf";
+	private static final String invalidCatTypePath = pdfResourcePath
+			+ "T02-01_006_document-catalog-wrong-type-key.pdf";
+	
+	private PdfModule module;
+
+	@Before
+	public void setUp() throws Exception {
+		this.module = new PdfModule();
+		JhoveBase je = new JhoveBase();
+		this.module.setBase(je);
+	}
+
+	/**
+	 * Test method for
+	 * {@link edu.harvard.hul.ois.jhove.module.pdf.PdfModule#getCatalogDict()}.
+	 */
+	@Test
+	public final void testValidCatType()
+			throws URISyntaxException {
+		File validCatType = new File(
+				PdfModuleTest.class.getResource(minimalPdfPath).toURI());
+
+		RepInfo info = parseTestFile(validCatType);
+
+		// Major version number < 8 should be well formed
+		assertEquals("Should be well formed.", RepInfo.TRUE, info.getWellFormed());
+		// Major version number < 8 should be invalid
+		assertEquals("Should be valid.", RepInfo.TRUE, info.getValid());
+	}
+
+
+	/**
+	 * Test method for
+	 * {@link edu.harvard.hul.ois.jhove.module.pdf.PdfModule#getCatalogDict()}.
+	 */
+	@Test
+	public final void testInvalidCatType()
+			throws URISyntaxException {
+		File invalidCatType = new File(
+				PdfModuleTest.class.getResource(invalidCatTypePath).toURI());
+
+		RepInfo info = parseTestFile(invalidCatType);
+
+		// Doc catalog type not Catalog, should not be well formed 
+		assertEquals("Should NOT be well formed.", RepInfo.FALSE, info.getWellFormed());
+		// Doc catalog type not Catalog, should be invalid
+		assertEquals("Should NOT be valid.", RepInfo.FALSE, info.getValid());
+	}
+
+	private RepInfo parseTestFile(final File toTest) {
+		RepInfo info = new RepInfo(toTest.getName());
+		RandomAccessFile raf = null;
+		try {
+			raf = new RandomAccessFile(toTest, "r");
+			this.module.parse(raf, info);
+		} catch (FileNotFoundException excep) {
+			excep.printStackTrace();
+			fail("Couldn't find file to test: " + toTest.getName());
+		} catch (IOException excep) {
+			excep.printStackTrace();
+			fail("IOException Reading: " + toTest.getName());
+		}
+		try {
+			if (raf != null) {
+				raf.close();
+			}
+		} catch (@SuppressWarnings("unused") IOException excep) {
+			// We don't care about this..
+		}
+		return info;
+	}
+}

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfModuleTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PdfModuleTest.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.harvard.hul.ois.jhove.module.pdf;
 
 import static org.junit.Assert.*;

--- a/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_000_minimal.pdf
+++ b/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T01_000_minimal.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Resources 3 0 R
+/Type /Page
+/Contents [4 0 R]
+>>
+endobj 
+3 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+endobj 
+4 0 obj 
+<<
+/Length 68
+>>
+stream
+1. 0. 0. 1. 50. 700. cm
+BT
+/F0 36. Tf
+(Hello PDF-world!) Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Pages 1 0 R
+/Type /Catalog
+>>
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000182 00000 n 
+0000000281 00000 n 
+0000000402 00000 n 
+trailer
+
+<<
+/Root 5 0 R
+/Size 6
+>>
+startxref
+452
+%%EOF

--- a/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T02-01_006_document-catalog-wrong-type-key.pdf
+++ b/jhove-modules/src/test/resources/edu/harvard/hul/ois/jhove/module/pdf/T02-01_006_document-catalog-wrong-type-key.pdf
@@ -1,0 +1,65 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj 
+<<
+/Kids [2 0 R]
+/Type /Pages
+/Count 1
+>>
+endobj 
+2 0 obj 
+<<
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Resources 3 0 R
+/Type /Page
+/Contents [4 0 R]
+>>
+endobj 
+3 0 obj 
+<<
+/Font 
+<<
+/F0 
+<<
+/BaseFont /Times-Italic
+/Subtype /Type1
+/Type /Font
+>>
+>>
+>>
+endobj 
+4 0 obj 
+<<
+/Length 68
+>>
+stream
+1. 0. 0. 1. 50. 700. cm
+BT
+/F0 36. Tf
+(Hello PDF-world!) Tj
+ET
+
+endstream 
+endobj 
+5 0 obj 
+<<
+/Pages 1 0 R
+/Type /Font
+>>
+endobj xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000182 00000 n 
+0000000281 00000 n 
+0000000402 00000 n 
+trailer
+<<
+/Root 5 0 R
+/Size 6
+>>
+startxref
+452
+%%EOF


### PR DESCRIPTION
- added test for document catalog `Type` key to `PdfModule`;
- added `MessageConstants` entries for catalog type checking errors;
- unit tests and test resources for functionality.
Closes #210