### PR TITLE
REL - Release 1.20

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,21 +1,83 @@
 RELEASE NOTES
 =============
-JHOVE - JSTOR/Harvard Object Validation Environment  
-Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.  
+JHOVE - JSTOR/Harvard Object Validation Environment
+Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.
 JHOVE is made available under the GNU Lesser General Public License (LGPL;
 see the file LICENSE for details).
 
-Versions 1.7 to 1.11 of JHOVE released independently.  
+Versions 1.7 to 1.11 of JHOVE released independently.
 Versions 1.12 onwards released by the Open Preservation Foundation.
 
-JHOVE 1.18-RC
+JHOVE 1.20-RC
 -------------
-2017-11-07
+2018-03-20
+
+### General
+
+- Removed obsolete subsitituion from izpack installer [[#300][]]
+
+### PDF Module
+
+- Header check for invalid PDF minor version (not > 7) [[#317][]]
+- Unit tests for PDF Header parsing conditions [[#317][]]
+- Check that document catalog dictionary key `\Type == Catalog` [[#318][]]
+- Test that document catalog XRef lookup retrieves the right object
+  number [[#319][]]
+- Unit tests for document catalog issues [[#318][]]
+- Test that page dictionary key `\Type == Pages`  [[#322][]]
+- Unit tests for page dictionary issues [[#322][]]
+- Improved handling of XRef lookup errors for document catalog and pages
+  dictonary [[#322][]]
+- Added synthetic test files created by @asciim0 for iPres as unit
+  test resources ([[#317][]-[#319][]])
+- Fixed assignment of `application/pdf` as MIME type for images embedded
+  in a PDF.
+- added method to derive MIME type from Filters and assign to NISO metatadata
+  and added String constants for Filter names.
+
+### WAVE Module
+
+- Fixed byte skipping issue when parsing Associated Data List [[#309][]]
+- Added support for parsing and validating RF64 files [[#308][]]
+- Made WAVE parser more resilient to unexpected chunk data [[#308][]]
+- Improved reporting of WAVE codecs in WAVEFORMATEXTENSIBLE files [[#308][]]
+- Avoids reporting file format and MIME type until signatures have been verified
+  and reports extended MIME type information, e.g. `audio/vnd.wave; codec=1`, as per RFC 2361 [[#308][]]
+- Subformat GUID's are now reported in their standard format, e.g.
+  `00000001-0000-0010-8000-00AA00389B71`, instead of as an
+  array of byte values [[#308][]]
+- Added check to verify the existence of Data chunks and to verify that
+  Format chunks appear before Data chunks [[#308][]]
+- Expanded WAVE example corpora to cover more formats and errors [[#308][]]
+- Improved truncation detection and reporting [[#308][]]
+- Fixed erroneous reporting of Cue Point values and renamed "Cue" report
+  property to "CuePoints" [[#308][]]
+
+### Text Handler
+
+- NISO MIX 1.0 output now includes MIME type as `FormatName:`.
+
+### XML Handler
+
+- NISO MIX 1.0 output now included mandatory `<FormatDesignation>` element.
+- Image MIME type output as mandatory `<FormatName>` element.
+
+[#300]: https://github.com/openpreserve/jhove/pull/300
+[#308]: https://github.com/openpreserve/jhove/pull/308
+[#317]: https://github.com/openpreserve/jhove/pull/317
+[#318]: https://github.com/openpreserve/jhove/pull/318
+[#319]: https://github.com/openpreserve/jhove/pull/319
+[#322]: https://github.com/openpreserve/jhove/pull/322
+
+
+JHOVE 1.18.1
+-------------
+2017-11-30
 
 ### General
 
 - Installation of external modules is now optional [[#292][]]
-- Inaccessible files are now reported as of "Unknown" status instead of 
+- Inaccessible files are now reported as of "Unknown" status instead of
   "Not well-formed" [[#257][]]
 - Improvements to error handling and uncaught module exceptions,
   increasing resilience during batch processing [[#257][], [#259][]]

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -54,7 +54,7 @@ JHOVE 1.20
 - Subformat GUID's are now reported in their standard format, e.g.
   `00000001-0000-0010-8000-00AA00389B71`, instead of as an
   array of byte values [[#308][]]
-- Added checks to verify the existence of Data chunks and their apperance 
+- Added checks to verify the existence of Data chunks and their appearance 
   after Format chunks [[#308][]]
 - Expanded WAVE example corpora to cover more formats and errors [[#308][]]
 - Improved truncation detection and reporting [[#308][]]

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,11 +1,11 @@
 RELEASE NOTES
 =============
-JHOVE - JSTOR/Harvard Object Validation Environment
-Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.
+JHOVE - JSTOR/Harvard Object Validation Environment  
+Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.  
 JHOVE is made available under the GNU Lesser General Public License (LGPL;
 see the file LICENSE for details).
 
-Versions 1.7 to 1.11 of JHOVE released independently.
+Versions 1.7 to 1.11 of JHOVE released independently.  
 Versions 1.12 onwards released by the Open Preservation Foundation.
 
 JHOVE 1.20
@@ -15,43 +15,47 @@ JHOVE 1.20
 ### General
 
 - Removed obsolete subsitituion from izpack installer [[#300][]]
+- Improved counting accuracy of skipped bytes, allowing better
+  EOF detection [[#308][]]
 
 ### JPEG Module
-- Fixed bug causing JHOVE to skip the wrong number of character in `APP0`
-  segments[[#303][]]
+
+- Fixed bug causing JHOVE to skip the wrong number of characters in `APP0`
+  segments [[#303][]]
 
 ### PDF Module
 
 - Header check for invalid PDF minor version (not > 7) [[#317][]]
 - Unit tests for PDF Header parsing conditions [[#317][]]
-- Check that document catalog dictionary key `\Type == Catalog` [[#318][]]
+- Check that document catalog dictionary key `\Type` equals `Catalog` [[#318][]]
 - Test that document catalog XRef lookup retrieves the right object
   number [[#319][]]
 - Unit tests for document catalog issues [[#318][]]
-- Test that page dictionary key `\Type == Pages`  [[#322][]]
+- Test that page dictionary key `\Type` equals `Pages` [[#322][]]
 - Unit tests for page dictionary issues [[#322][]]
 - Improved handling of XRef lookup errors for document catalog and pages
   dictonary [[#322][]]
 - Added synthetic test files created by @asciim0 for iPres as unit
   test resources ([[#317][]-[#319][]])
 - Fixed assignment of `application/pdf` as MIME type for images embedded
-  in a PDF. [[#324][]]
-- added method to derive MIME type from Filters and assign to NISO metatadata
-  and added String constants for Filter names. [[#324][]]
+  in a PDF [[#324][]]
+- Added method to derive MIME type from Filters and assign to NISO metatadata
+  and added String constants for Filter names [[#324][]]
 
 ### WAVE Module
 
-- Fixed byte skipping issue when parsing Associated Data List [[#309][]]
+- Fixed byte skipping issue when parsing Associated Data List chunks [[#309][]]
 - Added support for parsing and validating RF64 files [[#308][]]
 - Made WAVE parser more resilient to unexpected chunk data [[#308][]]
 - Improved reporting of WAVE codecs in WAVEFORMATEXTENSIBLE files [[#308][]]
 - Avoids reporting file format and MIME type until signatures have been verified
-  and reports extended MIME type information, e.g. `audio/vnd.wave; codec=1`, as per RFC 2361 [[#308][]]
+  and reports extended MIME type information, e.g. `audio/vnd.wave; codec=1`,
+  as per RFC 2361 [[#308][]]
 - Subformat GUID's are now reported in their standard format, e.g.
   `00000001-0000-0010-8000-00AA00389B71`, instead of as an
   array of byte values [[#308][]]
-- Added check to verify the existence of Data chunks and to verify that
-  Format chunks appear before Data chunks [[#308][]]
+- Added checks to verify the existence of Data chunks and their apperance 
+  after Format chunks [[#308][]]
 - Expanded WAVE example corpora to cover more formats and errors [[#308][]]
 - Improved truncation detection and reporting [[#308][]]
 - Fixed erroneous reporting of Cue Point values and renamed "Cue" report
@@ -59,13 +63,13 @@ JHOVE 1.20
 
 ### Text Handler
 
-- NISO MIX 1.0 output now includes MIME type as `FormatName:`. [[#323][]]
+- NISO MIX 1.0 output now includes MIME type as `FormatName` [[#323][]]
 
 ### XML Handler
 
 - NISO MIX 1.0 output now included mandatory `<FormatDesignation>`
-  element. [[#323][]]
-- Image MIME type output as mandatory `<FormatName>` element. [[#323][]]
+  element [[#323][]]
+- Image MIME type output as mandatory `<FormatName>` element [[#323][]]
 
 [#300]: https://github.com/openpreserve/jhove/pull/300
 [#303]: https://github.com/openpreserve/jhove/pull/303

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,13 +8,17 @@ see the file LICENSE for details).
 Versions 1.7 to 1.11 of JHOVE released independently.
 Versions 1.12 onwards released by the Open Preservation Foundation.
 
-JHOVE 1.20-RC
+JHOVE 1.20
 -------------
-2018-03-20
+2018-03-29
 
 ### General
 
 - Removed obsolete subsitituion from izpack installer [[#300][]]
+
+### JPEG Module
+- Fixed bug causing JHOVE to skip the wrong number of character in `APP0`
+  segments[[#303][]]
 
 ### PDF Module
 
@@ -31,9 +35,9 @@ JHOVE 1.20-RC
 - Added synthetic test files created by @asciim0 for iPres as unit
   test resources ([[#317][]-[#319][]])
 - Fixed assignment of `application/pdf` as MIME type for images embedded
-  in a PDF.
+  in a PDF. [[#324][]]
 - added method to derive MIME type from Filters and assign to NISO metatadata
-  and added String constants for Filter names.
+  and added String constants for Filter names. [[#324][]]
 
 ### WAVE Module
 
@@ -55,19 +59,24 @@ JHOVE 1.20-RC
 
 ### Text Handler
 
-- NISO MIX 1.0 output now includes MIME type as `FormatName:`.
+- NISO MIX 1.0 output now includes MIME type as `FormatName:`. [[#323][]]
 
 ### XML Handler
 
-- NISO MIX 1.0 output now included mandatory `<FormatDesignation>` element.
-- Image MIME type output as mandatory `<FormatName>` element.
+- NISO MIX 1.0 output now included mandatory `<FormatDesignation>`
+  element. [[#323][]]
+- Image MIME type output as mandatory `<FormatName>` element. [[#323][]]
 
 [#300]: https://github.com/openpreserve/jhove/pull/300
+[#303]: https://github.com/openpreserve/jhove/pull/303
 [#308]: https://github.com/openpreserve/jhove/pull/308
+[#309]: https://github.com/openpreserve/jhove/pull/309
 [#317]: https://github.com/openpreserve/jhove/pull/317
 [#318]: https://github.com/openpreserve/jhove/pull/318
 [#319]: https://github.com/openpreserve/jhove/pull/319
 [#322]: https://github.com/openpreserve/jhove/pull/322
+[#323]: https://github.com/openpreserve/jhove/pull/323
+[#324]: https://github.com/openpreserve/jhove/pull/324
 
 
 JHOVE 1.18.1

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.20-RC.0</version>
+    <version>1.20.0</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.20-RC.0</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-bbt/scripts/create-1.20-RC-target.sh
+++ b/jhove-bbt/scripts/create-1.20-RC-target.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+
+testRoot="test-root"
+paramCandidateVersion=""
+paramBaselineVersion=""
+baselineRoot="${testRoot}/baselines"
+candidateRoot="${testRoot}/candidates"
+targetRoot="${testRoot}/targets"
+# Check the passed params to avoid disapointment
+checkParams () {
+	OPTIND=1	# Reset in case getopts previously used
+
+	while getopts "h?b:c:" opt; do	# Grab the options
+		case "$opt" in
+		h|\?)
+			showHelp
+			exit 0
+			;;
+		b)	paramBaselineVersion=$OPTARG
+			;;
+		c)	paramCandidateVersion=$OPTARG
+			;;
+		esac
+	done
+
+	if [ -z "$paramBaselineVersion" ] || [ -z "$paramCandidateVersion" ]
+	then
+		showHelp
+		exit 0
+	fi
+
+	baselineRoot="${baselineRoot}/${paramBaselineVersion}"
+	candidateRoot="${candidateRoot}/${paramCandidateVersion}"
+	targetRoot="${targetRoot}/${paramCandidateVersion}"
+}
+
+# Show usage message
+showHelp() {
+	echo "usage: create-target [-b <baselineVersion>] [-c <candidateVersion>] [-h|?]"
+	echo ""
+	echo "  baselineVersion  : The version number id for the baseline data."
+	echo "  candidateVersion : The version number id for the candidate data."
+	echo ""
+	echo "  -h|? : This message."
+}
+
+# Execution starts here
+checkParams "$@";
+if [[ -d "${targetRoot}" ]]; then
+	rm -rf "${targetRoot}"
+fi
+
+# Simply copy baseline for now we're not making any changes
+cp -R "${baselineRoot}" "${targetRoot}"
+
+##
+# Output Handler version changes
+#
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/<outputHandler release="1.5">TEXT<\/outputHandler>/<outputHandler release="1.6-RC">TEXT<\/outputHandler>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/<outputHandler release="1.7">XML<\/outputHandler>/<outputHandler release="1.8-RC">XML<\/outputHandler>/' {} \;
+
+# PDF Module changes
+##
+# Add the Release Canidate PDF-HUL details
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.10">PDF-hul<\/module>$/   <module release="1.11-RC">PDF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <release>1.10<\/release>$/  <release>1.11-RC<\/release>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <date>2017-10-31<\/date>$/  <date>2018-03-19<\/date>/' {} \;
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11-RC" date="2018-03-19">PDF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11-RC" date="2018-03-19">PDF%' {} \;
+# Improved handling of inconsistent XRef table
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/corruptionOneByteMissing.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/corruptionOneByteMissing.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+
+##
+# WAV Module changes
+##
+# Copy over the new WAV module version audit file
+if [[ -f "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi;
+# Copy over the new WAV module version audit file
+if [[ -f "${candidateRoot}/errors/modules/audit-WAVE-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/audit-WAVE-hul.jhove.xml" "${targetRoot}/errors/modules/"
+fi;
+# New version details for WAV\ module
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.5">WAVE-hul<\/module>$/   <module release="1.6-RC">WAVE-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<reportingModule release="1.5" date="2017-10-31">WAVE%<reportingModule release="1.6-RC" date="2018-03-16">WAVE%' {} \;
+# New MIME type info for WAV
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<mimeType>audio/vnd.wave</mimeType>%<mimeType>audio/vnd.wave; codec=1</mimeType>%' {} \;
+# New message for WAV module ignored chunk types
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%>Ignored Chunk type:%>Ignored unrecognized chunk:%' {} \;
+# Finally copy the results files from candidate output for any major changes
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+
+##
+# NISO MIME output changes
+#
+# Add MIX format designation data
+fmtDesEleName="mix:FormatDesignation"
+fmtNameEleName="mix:formatName"
+fmtDesEleOpen="         <${fmtDesEleName}>"
+fmtDesEleClose="         <\/${fmtDesEleName}>"
+fmtNameEleOpen="          <${fmtNameEleName}>"
+fmtNameEleClose="<\/${fmtNameEleName}>"
+# For GIF
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/gif${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.gif.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For JPEG
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/jpeg${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.jpg.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For JP2
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/jp2${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.jpx.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For PNG
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/png${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.png.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For TIFF
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/tiff${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.tif.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# Now for PDFs with embedded images, just copy these over
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-1-govdocs-519846.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-1-govdocs-519846.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-10-govdocs-803945.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-10-govdocs-803945.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-22-govdocs-000187.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-22-govdocs-000187.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-43-govdocs-486355.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-43-govdocs-486355.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-49-32932439X.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-49-32932439X.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-51-govdocs-085551.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-51-govdocs-085551.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-52-govdocs-983827.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-52-govdocs-983827.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-79-govdocs-095305.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-79-govdocs-095305.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-81-govdocs-128112.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-81-govdocs-128112.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner-single.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/AA_Banner-single.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/bedfordcompressed.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/bedfordcompressed.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/fallforum03.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/fallforum03.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/imd.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/imd.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+# Same for JPEG indentation woes
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/GIF-hul/AA_Banner.gif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/GIF-hul/AA_Banner.gif.jhove.xml" "${targetRoot}/examples/modules/GIF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/GIF-hul/hul-banner.gif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/GIF-hul/hul-banner.gif.jhove.xml" "${targetRoot}/examples/modules/GIF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG2000-hul/monochrome.jp2.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG2000-hul/monochrome.jp2.jhove.xml" "${targetRoot}/examples/modules/JPEG2000-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/testpage-small.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/testpage-small.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/text.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/text.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-10-814778526.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-10-814778526.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-33-826355544.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-33-826355544.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-40-govdocs-088919.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-40-govdocs-088919.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-41-834460599.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-41-834460599.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-44-629642362.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-44-629642362.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-55-govdocs-616137.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-55-govdocs-616137.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-629642362.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-629642362.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-govdocs-681811.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-govdocs-681811.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-64-616615027.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-64-616615027.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-65-847453723.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-65-847453723.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi

--- a/jhove-bbt/scripts/create-1.20-target.sh
+++ b/jhove-bbt/scripts/create-1.20-target.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+testRoot="test-root"
+paramCandidateVersion=""
+paramBaselineVersion=""
+baselineRoot="${testRoot}/baselines"
+candidateRoot="${testRoot}/candidates"
+targetRoot="${testRoot}/targets"
+# Check the passed params to avoid disapointment
+checkParams () {
+	OPTIND=1	# Reset in case getopts previously used
+
+	while getopts "h?b:c:" opt; do	# Grab the options
+		case "$opt" in
+		h|\?)
+			showHelp
+			exit 0
+			;;
+		b)	paramBaselineVersion=$OPTARG
+			;;
+		c)	paramCandidateVersion=$OPTARG
+			;;
+		esac
+	done
+
+	if [ -z "$paramBaselineVersion" ] || [ -z "$paramCandidateVersion" ]
+	then
+		showHelp
+		exit 0
+	fi
+
+	baselineRoot="${baselineRoot}/${paramBaselineVersion}"
+	candidateRoot="${candidateRoot}/${paramCandidateVersion}"
+	targetRoot="${targetRoot}/${paramCandidateVersion}"
+}
+
+# Show usage message
+showHelp() {
+	echo "usage: create-target [-b <baselineVersion>] [-c <candidateVersion>] [-h|?]"
+	echo ""
+	echo "  baselineVersion  : The version number id for the baseline data."
+	echo "  candidateVersion : The version number id for the candidate data."
+	echo ""
+	echo "  -h|? : This message."
+}
+
+# Execution starts here
+checkParams "$@";
+if [[ -d "${targetRoot}" ]]; then
+	rm -rf "${targetRoot}"
+fi
+
+# Simply copy baseline for now we're not making any changes
+cp -R "${baselineRoot}" "${targetRoot}"
+
+##
+# Output Handler version changes
+#
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/<outputHandler release="1.5">TEXT<\/outputHandler>/<outputHandler release="1.6">TEXT<\/outputHandler>/' {} \;
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/<outputHandler release="1.7">XML<\/outputHandler>/<outputHandler release="1.8">XML<\/outputHandler>/' {} \;
+
+# Add the Release PDF-HUL details
+# PDF Module changes
+##
+# Add the Release PDF-HUL details
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.10">PDF-hul<\/module>$/   <module release="1.11">PDF-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <release>1.10<\/release>$/  <release>1.11<\/release>/' {} \;
+find "${targetRoot}" -type f -name "audit-PDF-hul.jhove.xml" -exec sed -i 's/^  <date>2017-10-31<\/date>$/  <date>2018-03-29<\/date>/' {} \;
+find "${targetRoot}" -type f -name "*.pdf.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11" date="2018-03-29">PDF%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.10" date="2017-10-31">PDF%<reportingModule release="1.11" date="2018-03-29">PDF%' {} \;
+# Improved handling of inconsistent XRef table
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/corruptionOneByteMissing.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/corruptionOneByteMissing.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+
+##
+# WAV Module changes
+##
+# Copy over the new WAV module version audit file
+if [[ -f "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/audit-WAVE-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi;
+# Copy over the new WAV module version audit file
+if [[ -f "${candidateRoot}/errors/modules/audit-WAVE-hul.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/audit-WAVE-hul.jhove.xml" "${targetRoot}/errors/modules/"
+fi;
+# New version details for WAV module
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.5">WAVE-hul<\/module>$/   <module release="1.6">WAVE-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<reportingModule release="1.5" date="2017-10-31">WAVE%<reportingModule release="1.6" date="2018-03-29">WAVE%' {} \;
+# New MIME type info for WAV
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%<mimeType>audio/vnd.wave</mimeType>%<mimeType>audio/vnd.wave; codec=1</mimeType>%' {} \;
+# New message for WAV module ignored chunk types
+find "${targetRoot}" -type f -name "*.wav.jhove.xml" -exec sed -i 's%>Ignored Chunk type:%>Ignored unrecognized chunk:%' {} \;
+# Finally copy the results files from candidate output for any major changes
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-before-fmt.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-data-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-multiple.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-final-chunk.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-riff.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-alaw-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-float-44khz-32bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-float-44khz-64bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-ds64-chunk-unnecessary.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-pcm-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/rf64-ulaw-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+if [[ -f "${candidateRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml" "${targetRoot}/examples/modules/WAVE-hul/wfe-pcm-44khz-8bit-mono-minimal.wav.jhove.xml"
+fi;
+
+##
+# JPEG Module changes
+#
+# New version details for WAV module
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.3">JPEG-hul<\/module>$/   <module release="1.4">JPEG-hul<\/module>/' {} \;
+find "${targetRoot}" -type f -name "audit-JPEG-hul.jhove.xml" -exec sed -i 's/<release>1.3<\/release>$/<release>1.4<\/release>/' {} \;
+find "${targetRoot}" -type f -name "audit-JPEG-hul.jhove.xml" -exec sed -i 's/<date>2017-05-11<\/date>$/<date>2018-03-29<\/date>/' {} \;
+find "${targetRoot}" -type f -name "*.jpg.jhove.xml" -exec sed -i 's%<reportingModule release="1.3" date="2017-05-11">JPEG%<reportingModule release="1.4" date="2018-03-29">JPEG%' {} \;
+find "${targetRoot}" -type f -name "README.jhove.xml" -exec sed -i 's%<reportingModule release="1.3" date="2017-05-11">JPEG%<reportingModule release="1.4" date="2018-03-29">JPEG%' {} \;
+
+##
+# NISO MIME output changes
+#
+# Add MIX format designation data
+fmtDesEleName="mix:FormatDesignation"
+fmtNameEleName="mix:formatName"
+fmtDesEleOpen="         <${fmtDesEleName}>"
+fmtDesEleClose="         <\/${fmtDesEleName}>"
+fmtNameEleOpen="          <${fmtNameEleName}>"
+fmtNameEleClose="<\/${fmtNameEleName}>"
+# For GIF
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/gif${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.gif.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For JPEG
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/jpeg${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.jpg.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For JP2
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/jp2${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.jpx.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For PNG
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/png${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.png.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# For TIFF
+fmtDesEle="<\/mix:ObjectIdentifier>\n${fmtDesEleOpen}\n${fmtNameEleOpen}image\/tiff${fmtNameEleClose}\n${fmtDesEleClose}"
+find "${targetRoot}" -type f -name "*.tif.jhove.xml" -exec sed -i "s/<\/mix:ObjectIdentifier>$/${fmtDesEle}/g" {} \;
+# Now for PDFs with embedded images, just copy these over
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-1-govdocs-519846.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-1-govdocs-519846.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-10-govdocs-803945.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-10-govdocs-803945.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-22-govdocs-000187.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-22-govdocs-000187.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-43-govdocs-486355.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-43-govdocs-486355.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-49-32932439X.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-49-32932439X.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-51-govdocs-085551.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-51-govdocs-085551.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-52-govdocs-983827.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-52-govdocs-983827.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-79-govdocs-095305.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-79-govdocs-095305.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-81-govdocs-128112.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-81-govdocs-128112.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner-single.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/AA_Banner-single.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/bedfordcompressed.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/bedfordcompressed.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/fallforum03.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/fallforum03.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/imd.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/PDF-hul/imd.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
+fi
+# Same for JPEG indentation woes
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner-progressive.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG-hul/AA_Banner.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/GIF-hul/AA_Banner.gif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/GIF-hul/AA_Banner.gif.jhove.xml" "${targetRoot}/examples/modules/GIF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/GIF-hul/hul-banner.gif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/GIF-hul/hul-banner.gif.jhove.xml" "${targetRoot}/examples/modules/GIF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/JPEG2000-hul/monochrome.jp2.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/JPEG2000-hul/monochrome.jp2.jhove.xml" "${targetRoot}/examples/modules/JPEG2000-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/testpage-small.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/testpage-small.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/text.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/text.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-10-814778526.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-10-814778526.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-33-826355544.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-33-826355544.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-40-govdocs-088919.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-40-govdocs-088919.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-41-834460599.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-41-834460599.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-44-629642362.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-44-629642362.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-55-govdocs-616137.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-55-govdocs-616137.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-629642362.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-629642362.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-govdocs-681811.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-59-govdocs-681811.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-64-616615027.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-64-616615027.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-65-847453723.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/pdf-hul-65-847453723.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/"
+fi

--- a/jhove-bbt/scripts/travis-test.sh
+++ b/jhove-bbt/scripts/travis-test.sh
@@ -71,7 +71,7 @@ installJhoveFromFile "${JHOVE_INSTALLER}" "${tempInstallLoc}"
 echo "Checking baseline data for target Jhove: ${MAJOR_MINOR_VER}."
 if [[ ! -d "${TARGET_ROOT}/${MAJOR_MINOR_VER}" ]]
 then
-	echo " - enerating the baseline for ${MAJOR_MINOR_VER} at: ${TARGET_ROOT}/${MAJOR_MINOR_VER}."
+	echo " - Generating the baseline for ${MAJOR_MINOR_VER} at: ${TARGET_ROOT}/${MAJOR_MINOR_VER}."
 	bash "$SCRIPT_DIR/baseline-jhove.sh" -j "${tempInstallLoc}" -c "${TEST_ROOT}/corpora" -o "${TEST_ROOT}/candidates/${MAJOR_MINOR_VER}"
 fi
 

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.20-RC.0</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.20-RC.0</version>
+    <version>1.20.0</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
@@ -35,8 +35,8 @@ public class TextHandler
      ******************************************************************/
 
     private static final String NAME = "TEXT";
-    private static final String RELEASE = "1.6-RC";
-    private static final int [] DATE = {2018, 03, 16};
+    private static final String RELEASE = "1.6";
+    private static final int [] DATE = {2018, 03, 29};
     private static final String NOTE = "This is the default JHOVE output " +
         "handler";
     private static final String RIGHTS =

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -56,10 +56,10 @@ public class XmlHandler
     private static final String NAME = "XML";
 
     /** Handler release identifier. */
-    private static final String RELEASE = "1.8-RC";
+    private static final String RELEASE = "1.8";
 
     /** Handler release date. */
-    private static final int [] DATE = {2018, 03, 16};
+    private static final int [] DATE = {2018, 03, 29};
 
     /** Handler informative note. */
     private static final String NOTE =

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.20-RC.0</version>
+    <version>1.20.0</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.20-RC.0</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.20-RC.0</version>
+    <version>1.20.0</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.20-RC.0</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.19.0-SNAPSHOT</version>
+    <version>1.20-RC.0</version>
   </parent>
 
   <artifactId>jhove-modules</artifactId>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.20-RC.0</version>
+    <version>1.20.0</version>
   </parent>
 
   <artifactId>jhove-modules</artifactId>

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -64,8 +64,8 @@ public class JpegModule extends ModuleBase {
      ******************************************************************/
     private static final String NISO_IMAGE_MD = "NisoImageMetadata";
     private static final String NAME = "JPEG-hul";
-    private static final String RELEASE = "1.3";
-    private static final int[] DATE = { 2017, 5, 11 };
+    private static final String RELEASE = "1.4";
+    private static final int[] DATE = { 2018, 03, 29 };
     private static final String[] FORMAT = { "JPEG", "ISO/IEC 10918-1:1994",
             "Joint Photographic Experts Group", "JFIF",
             "JPEG File Interchange Format", "SPIFF", "ISO/IEC 10918-3:1997",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -366,8 +366,8 @@ public class PdfModule extends ModuleBase {
      ******************************************************************/
 
     private static final String NAME = "PDF-hul";
-    private static final String RELEASE = "1.11-RC";
-    private static final int [] DATE = {2018, 03, 19};
+    private static final String RELEASE = "1.11";
+    private static final int[] DATE = { 2018, 03, 29 };
     private static final String [] FORMAT = {
         "PDF", "Portable Document Format"
     };

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -34,8 +34,8 @@ public class WaveModule extends ModuleBase {
 
     /* Module metadata */
     private static final String NAME = "WAVE-hul";
-    private static final String RELEASE = "1.6-RC";
-    private static final int[] DATE = { 2018, 03, 16 };
+    private static final String RELEASE = "1.6";
+    private static final int[] DATE = { 2018, 03, 29 };
     private static final String[] FORMATS = { "WAVE", "Audio for Windows",
             "EBU Technical Specification 3285", "Broadcast Wave Format", "BWF",
             "EBU Technical Specification 3306", "RF64" };

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -63,7 +63,17 @@ public final class PdfHeader {
 		try {
 			minorVersion = getMinorVersion(this.versionString);
 		} catch (NumberFormatException nfe) {
-			// TODO : Do nothing for now, the version number is still invalid.
+			// TODO : This currently catches non-numbers and
+			// returns false. This marks the version number
+			// as invalid and ensured existing JHOVE behaviour
+			// changed as little as possible for v1.20 March 2018.
+			// Really this should be thrown as it's own validation
+			// exception and be assigned its own message
+			// Version numbers need better handling as PDF1. is
+			// baked into JHOVE's header signature rather than
+			// as part of version parsing and validation.
+			// The arrival of PDF 2.0 in summer 2017 leaves
+			// this looking very dubious behaviour.
 		}
 		return minorVersion <= MAX_VALID_MAJOR_VERSION;
 	}

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PageTreeTests.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/PageTreeTests.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.harvard.hul.ois.jhove.module.pdf;
 
 import java.net.URISyntaxException;

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.20-RC.0</version>
+  <version>1.20.0</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.19.0-SNAPSHOT</version>
+  <version>1.20-RC.0</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>


### PR DESCRIPTION
- bumped minor version -> 1.20 for release;
- JPEG Module minor version bumped ->1.3;
- PDF Module minor version bumped ->1.11;
- WAVE Module minor version bumped ->1.6;
- XML Handler minor version bumped ->1.8;
- TEXT Handler minor version bumped ->1.6;
- added missing PR details to `RELEASENOTES`;
- added JPEG module changes to `RELEASENOTES`;
- fixed broken PR links in `RELEASENOTES`;
- created 1.20 baseline script `jhove-bbt/scripts/create-1.20-target.sh`; and
- fixed typo in testing script.