### PR TITLE
Further migration to Java 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ JHOVE is currently being maintained by the
 
 Pre-requisites
 --------------
- 1. Java JRE 1.6
+ 1. Java JRE 1.8  
     Version 1.20 of JHOVE is built and tested against Oracle JDK 8,
-    and OpenJDK 7 & 8 on Travis. Releases are built using Oracle JDK 7
+    and OpenJDK 8 on Travis. Releases are built using Oracle JDK 8
     from the [OPF's Jenkins server](http://jenkins.openpreservation.org/).
 
  2. If you would like to build JHOVE from source, then life will be easiest if
@@ -240,16 +240,6 @@ For now we're producing:
    who doesn't want to use the new installer; and
  * a simple cross-platform installer that installs the application JAR, support
    scripts, etc.
-
-Currently all options, including the installer, require Java 1.6 or above to be
-pre-installed. Supporting 1.5 is no longer realistic, Oracle ceased support for
-its own 1.6 distribution in 2012. We've kept to 1.6 as a transition towards
-moving to 1.7. If you really need a 1.5-compatible build then you can override
-the target version for the Maven build, e.g.:
-
-    mvn clean install -Djava.target.version=1.5
-
-This also produces an installer that will work on 1.5 JREs.
 
 Usage
 -----

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/CoreMessageConstants.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/CoreMessageConstants.java
@@ -19,7 +19,7 @@ public enum CoreMessageConstants {
 	public static final String EXC_CONF_FILE_UNPRS = "Error parsing configuration file: ";
 	public static final String EXC_FILE_OPEN = "Cannot open output file: ";
 	public static final String EXC_HNDL_INST_FAIL = "Cannot instantiate handler: ";
-	public static final String EXC_JAVA_VER_INCMPT = "Java 1.6 or higher is required";
+	public static final String EXC_JAVA_VER_INCMPT = "Java 1.8 or higher is required";
 	public static final String EXC_MODL_INST_FAIL = "Cannot instantiate module: ";
 	public static final String EXC_PRV_CNSTRCT = "Entered private constructor for: ";
 	public static final String EXC_PROP_VAL_NULL = "Null value not permitted or property: ";

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -138,7 +138,7 @@ public class JhoveBase {
      * Instantiates a <code>JhoveBase</code> object.
      * 
      * @throws JhoveException
-     *             if invoked with a JVM lower than 1.6
+     *             if invoked with a JVM lower than 1.8
      */
     public JhoveBase() throws JhoveException {
 
@@ -147,7 +147,7 @@ public class JhoveBase {
 
         // Make sure we have a satisfactory version of Java.
         String version = System.getProperty("java.vm.version");
-        if (version.compareTo("1.6.0") < 0) {
+        if (version.compareTo("1.8.0") < 0) {
             _logger.severe(CoreMessageConstants.EXC_JAVA_VER_INCMPT);
             throw new JhoveException(CoreMessageConstants.EXC_JAVA_VER_INCMPT);
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -379,7 +379,7 @@ public class WaveModule extends ModuleBase {
                     if (riffSize == LOOKUP_EXTENDED_DATA_SIZE) {
                         // Even though RF64 can support files larger than
                         // Long.MAX_VALUE, this module currently does not.
-                        if (compareUnsignedLongs(extendedRiffSize, Long.MAX_VALUE) > 0) {
+                        if (Long.compareUnsigned(extendedRiffSize, Long.MAX_VALUE) > 0) {
                             info.setMessage(new InfoMessage(
                                     MessageConstants.INF_FILE_TOO_LARGE));
                             info.setWellFormed(RepInfo.UNDETERMINED);
@@ -580,21 +580,6 @@ public class WaveModule extends ModuleBase {
     }
 
     /**
-     * A copy of Java 8's <code>Long.compareUnsigned</code> method to preserve
-     * compatibility with Java 6. This should be replaced once Java 8 is supported.
-     *
-     * @param  x  the first <code>long</code> to compare
-     * @param  y  the second <code>long</code> to compare
-     * @return    the value <code>0</code> if <code>x == y</code>;
-     *            a value less than <code>0</code> if <code>x < y</code>; and
-     *            a value greater than <code>0</code> if <code>x > y</code>
-     */
-    private int compareUnsignedLongs(long x, long y) {
-        x += Long.MIN_VALUE; y += Long.MIN_VALUE;
-        return (x < y) ? -1 : ((x == y) ? 0 : 1);
-    }
-
-    /**
      * One-argument version of <code>readSignedLong</code>. WAVE is always
      * little-endian, so we can unambiguously drop its endian argument.
      */
@@ -755,7 +740,7 @@ public class WaveModule extends ModuleBase {
         bytesRemaining -= CHUNK_HEADER_LENGTH;
 
         // Check if the chunk size is greater than the RIFF's remaining length
-        if (compareUnsignedLongs(bytesRemaining, chunkSize) < 0) {
+        if (Long.compareUnsigned(bytesRemaining, chunkSize) < 0) {
             info.setMessage(new ErrorMessage(MessageConstants.ERR_CHUNK_SIZE_INVAL, _nByte));
             return false;
         }


### PR DESCRIPTION
This updates internal version checks, messages, and documentation to match the updated Java version requirement, and replaces a duplicate method with its Java 1.8 equivalent.

Closes #372