### PR TITLE
WAVE: Report "Not well-formed" if chunk exceeds RIFF length

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -742,6 +742,7 @@ public class WaveModule extends ModuleBase {
         // Check if the chunk size is greater than the RIFF's remaining length
         if (Long.compareUnsigned(bytesRemaining, chunkSize) < 0) {
             info.setMessage(new ErrorMessage(MessageConstants.ERR_CHUNK_SIZE_INVAL, _nByte));
+            info.setWellFormed(false);
             return false;
         }
 


### PR DESCRIPTION
This was an existing check which failed to set an appropriate status.

Fixes #366 