### PR TITLE
jhove goes up to 11, java11 🚀🎸🎶⑪⑾⒒⓫

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Gemfile.lock
 **/.settings
 **/.project
 **/.classpath
+
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: java
 jdk:
   - openjdk8
   - oraclejdk8
+  - openjdk11
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: java
 jdk:
   - openjdk8
   - oraclejdk8
-  - openjdk11
 
 branches:
   except:

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/AppInfoWindow.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/AppInfoWindow.java
@@ -5,13 +5,19 @@
 
 package edu.harvard.hul.ois.jhove.viewer;
 
-import java.awt.*;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
-import java.util.*;
+import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.OutputHandler;
+
 import javax.swing.*;
-import java.io.*;
-import edu.harvard.hul.ois.jhove.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  *   This window is for presenting information about the JHOVE
@@ -25,13 +31,7 @@ public class AppInfoWindow extends InfoWindow
     public AppInfoWindow (App app, JhoveBase jbase)
     {
         super ("Application Info", app, jbase);
-        setSaveActionListener ( 
-            new ActionListener() {
-                @Override
-                public void actionPerformed (ActionEvent e) {
-                    saveInfo ();
-                }
-            });
+        setSaveActionListener (e -> saveInfo ());
         
         texta = new JTextArea ();
 	texta.setColumns (72);
@@ -87,13 +87,11 @@ public class AppInfoWindow extends InfoWindow
 	if (saxClass != null) {
 	    texta.append ("SAX parser: " + saxClass + eol);
 	}
-	Iterator<String> iter = jbase.getModuleMap ().keySet ().iterator ();
-	while (iter.hasNext ()) {
-	    //Module module = jbase.getModuleMap ((String) iter.next ());
-            Map<String, Module> moduleMap = jbase.getModuleMap ();
-            Module module = moduleMap.get (iter.next ());
-	    texta.append (" Module: " + module.getName () + " " +
-			  module.getRelease () + eol);
+	for (String s : jbase.getModuleMap().keySet()) {
+		Map<String, Module> moduleMap = jbase.getModuleMap();
+		Module module = moduleMap.get(s);
+		texta.append(" Module: " + module.getName() + " " +
+				module.getRelease() + eol);
 	}
 	// Reporting Handlers makes no sense in the viewer app; skip
 	String rights = app.getRights ();

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ModuleInfoWindow.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ModuleInfoWindow.java
@@ -5,21 +5,27 @@
 
 package edu.harvard.hul.ois.jhove.viewer;
 
-import java.awt.Font;
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import java.io.*;
+import edu.harvard.hul.ois.jhove.Agent;
+import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.Document;
+import edu.harvard.hul.ois.jhove.Identifier;
+import edu.harvard.hul.ois.jhove.InternalSignature;
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.OutputHandler;
+import edu.harvard.hul.ois.jhove.Signature;
+import edu.harvard.hul.ois.jhove.SignatureType;
+
 import javax.swing.*;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
-import edu.harvard.hul.ois.jhove.*;
+import java.awt.*;
+import java.io.PrintWriter;
 
 /**
  *   This window is for presenting information about the selected
  *   module.  If no module is selected, a brief message is
  *   put into the window.
  */
-public class ModuleInfoWindow extends InfoWindow{
+public class ModuleInfoWindow extends InfoWindow {
 
     private JTextArea texta;
     private int _level;
@@ -36,13 +42,7 @@ public class ModuleInfoWindow extends InfoWindow{
     {
         super ("Module Info", app, base);
         _module = module;
-        setSaveActionListener ( 
-            new ActionListener() {
-                @Override
-                public void actionPerformed (ActionEvent e) {
-                    saveInfo ();
-                }
-            });
+        setSaveActionListener (e -> saveInfo ());
         
         texta = new JTextArea ();
 	texta.setColumns (72);
@@ -104,7 +104,7 @@ public class ModuleInfoWindow extends InfoWindow{
                 texta.append (margin + "MIMEtype: " + ss[0]);
                 for (int i=1; i<ss.length; i++) {
                     texta.append (", " + ss[i]);
-                };
+                }
                 texta.append (eol);
             }
             for (Signature sig : module.getSignature()) {

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/PrefsWindow.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/PrefsWindow.java
@@ -47,25 +47,17 @@ public class PrefsWindow extends JDialog
         getContentPane ().add (bottomPanel, BorderLayout.SOUTH);
         JButton okButton = new JButton ("OK");
         okButton.addActionListener (
-            new ActionListener () {
-                @Override
-                public void actionPerformed (ActionEvent e) 
-                {
+                e -> {
                     setPrefsFromDialog ();
-                    hide ();
+                    setVisible (false);
                 }
-            }
         );
         JButton cancelButton = new JButton ("Cancel");
         cancelButton.addActionListener (
-            new ActionListener () {
-                @Override
-                public void actionPerformed (ActionEvent e) 
-                {
-                    hide ();
+                e -> {
+                    setVisible (false);
                     restore ();
                 }
-            }
         );
         bottomPanel.add (new JLabel (""));
         bottomPanel.add (cancelButton);
@@ -84,7 +76,7 @@ public class PrefsWindow extends JDialog
     {
         saveRawOutput = rawCheckBox.isSelected ();
         saveChecksum = checksumCheckBox.isSelected ();
-        show ();
+        setVisible(true);
     }
     
     private void restore ()

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -5,10 +5,28 @@
 
 package edu.harvard.hul.ois.jhove.viewer;
 
-import java.util.*;
+import edu.harvard.hul.ois.jhove.AESAudioMetadata;
+import edu.harvard.hul.ois.jhove.Checksum;
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.InfoMessage;
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.Message;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.NisoImageMetadata;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.Rational;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.TextMDMetadata;
+
+import javax.swing.tree.DefaultMutableTreeNode;
 import java.text.DateFormat;
-import javax.swing.tree.*;
-import edu.harvard.hul.ois.jhove.*;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *  This subclass of DefaultMutableTreeNode simply adds a
@@ -261,7 +279,8 @@ public class RepTreeRoot extends DefaultMutableTreeNode
         String wfStr;
         switch (_info.getWellFormed ()) {
             case RepInfo.TRUE:
-                wfStr = "Well-Formed";                break;
+                wfStr = "Well-Formed";
+                break;
             case RepInfo.FALSE:
                 wfStr = "Not well-formed";
                 break;

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ViewHandler.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ViewHandler.java
@@ -5,8 +5,13 @@
 
 package edu.harvard.hul.ois.jhove.viewer;
 
-import edu.harvard.hul.ois.jhove.*;
-//import javax.swing.*;
+import edu.harvard.hul.ois.jhove.Agent;
+import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.HandlerBase;
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.OutputHandler;
+import edu.harvard.hul.ois.jhove.RepInfo;
 
 /**
  * This is an output handler which connects JHOVE output to the
@@ -133,10 +138,10 @@ public class ViewHandler extends HandlerBase {
             if (viewWinYPos > viewWinOrigYPos + 160) {
                 viewWinYPos = viewWinOrigYPos;
             }
-            _viewWin.show ();
+            _viewWin.setVisible (true);
         }
         _viewWin.expandRows ();
-        _viewWin.show ();
+        _viewWin.setVisible (true);
     }
 
     /**

--- a/jhove-bbt/scripts/bbt-jhove.sh
+++ b/jhove-bbt/scripts/bbt-jhove.sh
@@ -124,7 +124,7 @@ showHelp() {
 checkParams "$@";
 candidate="${paramOutputLoc:?}/${paramKey}"
 tempInstallLoc="/tmp/to-test";
-sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.7.9\/org\.jacoco.agent-0\.7\.9-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -classpath "$CP" Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
+sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.8.2\/org\.jacoco.agent-0\.8\.2-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -classpath "$CP" Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
 bash "$SCRIPT_DIR/baseline-jhove.sh" -j "${tempInstallLoc}" -c "${paramCorpusLoc}" -o "${candidate}"
 
 if [ "$paramIgnoreRelease" =  true ] ;

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -27,11 +27,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>1.5.1</version>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -311,7 +311,7 @@ public class JhoveBase {
             List<String> param = params.get(i);
             try {
                 Class<?> cl = Class.forName(modInfo.clas);
-                Module module = (Module) cl.newInstance();
+                Module module = (Module) cl.getDeclaredConstructor().newInstance();
                 module.init(modInfo.init);
                 module.setDefaultParams(param);
 
@@ -331,7 +331,7 @@ public class JhoveBase {
             List<String> param = params.get(i);
             try {
                 Class<?> cl = Class.forName(tuple[0]);
-                OutputHandler handler = (OutputHandler) cl.newInstance();
+                OutputHandler handler = (OutputHandler) cl.getDeclaredConstructor().newInstance();
                 handler.setDefaultParams(param);
 
                 _handlerList.add(handler);

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -890,7 +890,7 @@ public abstract class ModuleBase
             }
         }
         if (prop == null) {
-            prop = new Property(name, PropertyType.INTEGER, new Integer(value));
+            prop = new Property(name, PropertyType.INTEGER, Integer.valueOf(value));
         }
 
         return prop;
@@ -918,7 +918,7 @@ public abstract class ModuleBase
             }
         }
         return new Property (name, PropertyType.INTEGER,
-                 new Integer (value));
+                 Integer.valueOf(value));
     }
 
     /**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/AuditHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/AuditHandler.java
@@ -20,9 +20,19 @@
 
 package edu.harvard.hul.ois.jhove.handler;
 
-import edu.harvard.hul.ois.jhove.*;
-import edu.harvard.hul.ois.jhove.handler.audit.*;
-import java.util.*;
+import edu.harvard.hul.ois.jhove.Checksum;
+import edu.harvard.hul.ois.jhove.ChecksumType;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.handler.audit.AuditCount;
+import edu.harvard.hul.ois.jhove.handler.audit.AuditState;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
 
 /**
  * JHOVE audit output handler, derived from the standard JHOVE XML
@@ -131,8 +141,7 @@ public class AuditHandler
     /**
      * Local extension to the standard callback indicating a directory is
      * finished being processed.
-     * @param state Audit handler state
-     */
+	 */
     public void endDirectoryImpl ()
     {
     }
@@ -198,8 +207,7 @@ public class AuditHandler
      * Local extension to the standard callback that outputs the
      * information contained in a RepInfo object
      * @param info Object representation information
-     * @param state Audit handler state
-     */
+	 */
     public void showImpl (RepInfo info)
     {
 	String status = null;
@@ -346,8 +354,7 @@ public class AuditHandler
      * This should be in a suitable format for
      * including multiple files between the header and the footer, and
      * the XML of the header and footer must balance out.
-     * @param state Audit handler state
-     */
+	 */
     public void showFooterImpl ()
     {
 	if (_nAudit > 0) {

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
@@ -20,9 +20,36 @@
 
 package edu.harvard.hul.ois.jhove.handler;
 
-import edu.harvard.hul.ois.jhove.*;
-import java.text.*;
-import java.util.*;
+import edu.harvard.hul.ois.jhove.AESAudioMetadata;
+import edu.harvard.hul.ois.jhove.Agent;
+import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.Checksum;
+import edu.harvard.hul.ois.jhove.Document;
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.HandlerBase;
+import edu.harvard.hul.ois.jhove.Identifier;
+import edu.harvard.hul.ois.jhove.InfoMessage;
+import edu.harvard.hul.ois.jhove.InternalSignature;
+import edu.harvard.hul.ois.jhove.Message;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.NisoImageMetadata;
+import edu.harvard.hul.ois.jhove.OutputHandler;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.Rational;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.Signature;
+import edu.harvard.hul.ois.jhove.SignatureType;
+import edu.harvard.hul.ois.jhove.TextMDMetadata;
+
+import java.text.NumberFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *  OutputHandler for plain text output.

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -20,10 +20,37 @@
 
 package edu.harvard.hul.ois.jhove.handler;
 
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.AESAudioMetadata;
+import edu.harvard.hul.ois.jhove.Agent;
+import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.Checksum;
+import edu.harvard.hul.ois.jhove.Document;
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.HandlerBase;
+import edu.harvard.hul.ois.jhove.Identifier;
+import edu.harvard.hul.ois.jhove.InfoMessage;
+import edu.harvard.hul.ois.jhove.InternalSignature;
+import edu.harvard.hul.ois.jhove.Message;
+import edu.harvard.hul.ois.jhove.Module;
+import edu.harvard.hul.ois.jhove.NisoImageMetadata;
+import edu.harvard.hul.ois.jhove.OutputHandler;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.Rational;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import edu.harvard.hul.ois.jhove.Signature;
+import edu.harvard.hul.ois.jhove.SignatureType;
+import edu.harvard.hul.ois.jhove.TextMDMetadata;
 
 import java.text.NumberFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *  OutputHandler for XML output.

--- a/jhove-ext-modules/src/test/java/edu/harvard/hul/ois/jhove/module/GzipModuleTest.java
+++ b/jhove-ext-modules/src/test/java/edu/harvard/hul/ois/jhove/module/GzipModuleTest.java
@@ -1,30 +1,29 @@
 package edu.harvard.hul.ois.jhove.module;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import edu.harvard.hul.ois.jhove.Message;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.jwat.common.DiagnosisType;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.DataFormatException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.jwat.common.DiagnosisType;
-
-import edu.harvard.hul.ois.jhove.Message;
-import edu.harvard.hul.ois.jhove.Property;
-import edu.harvard.hul.ois.jhove.PropertyArity;
-import edu.harvard.hul.ois.jhove.PropertyType;
-import edu.harvard.hul.ois.jhove.RepInfo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class GzipModuleTest {
@@ -39,7 +38,7 @@ public class GzipModuleTest {
         
         assertEquals(RepInfo.TRUE, info.getWellFormed());
         assertEquals(RepInfo.TRUE, info.getValid());
-        assertEquals(Arrays.asList(gzm.getName()), info.getSigMatch());
+        assertEquals(Collections.singletonList(gzm.getName()), info.getSigMatch());
         
         assertEquals(0, info.getMessage().size());
         
@@ -61,7 +60,7 @@ public class GzipModuleTest {
         
         assertEquals(RepInfo.TRUE, info.getWellFormed());
         assertEquals(GzipModule.class, info.getModule().getClass());
-        assertEquals(Arrays.asList(gzm.getName()), info.getSigMatch());
+        assertEquals(Collections.singletonList(gzm.getName()), info.getSigMatch());
     }
     
     @Test
@@ -75,7 +74,7 @@ public class GzipModuleTest {
         
         assertEquals(RepInfo.TRUE, info.getWellFormed());
         assertEquals(RepInfo.TRUE, info.getValid());
-        assertEquals(Arrays.asList(gzm.getName()), info.getSigMatch());
+        assertEquals(Collections.singletonList(gzm.getName()), info.getSigMatch());
         
         assertEquals(0, info.getMessage().size());
         
@@ -95,7 +94,7 @@ public class GzipModuleTest {
         
         assertEquals(RepInfo.TRUE, info.getWellFormed());
         assertEquals(GzipModule.class, info.getModule().getClass());
-        assertEquals(Arrays.asList(gzm.getName()), info.getSigMatch());
+        assertEquals(Collections.singletonList(gzm.getName()), info.getSigMatch());
     }
     
     @Test
@@ -209,7 +208,7 @@ public class GzipModuleTest {
     }
     
     private Map<String, Integer> extractMessages(Collection<Message> messages) {
-		Map<String, Integer> res = new HashMap<String, Integer>();
+		Map<String, Integer> res = new HashMap<>();
 		for(Message m : messages) {
 			if(res.containsKey(m.getMessage())) {
 				res.put(m.getMessage(), res.get(m.getMessage()) + 1);

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -110,31 +110,6 @@
         </executions>
       </plugin>
 
-      <!-- force maven to ignore the dependency that java11 can't retrieve from the maven repo -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
-        <executions>
-          <execution>
-            <id>enforce-exclusions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <exclude>javax.media:jai-core</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <!--
       We need to tell the izpack-maven-plugin what to use as the base
       directory (this is our staging area), and also tell it the install
@@ -171,18 +146,6 @@
             <groupId>org.codehaus.izpack</groupId>
             <artifactId>izpack-panel</artifactId>
             <version>${izpack.version}</version>
-            <exclusions>
-              <!-- this is excluded in the izpack pom file (but the artifactId is jai_core)
-                   maven tries to download the dependency but the server replies with a response
-                   that java11 does not like: "extension (10) should not be presented in server_hello"
-                   see https://bugs.openjdk.java.net/browse/JDK-8210005
-                   this will be fixed in the Jan2019 release of java11
-               -->
-              <exclusion>
-                <groupId>javax.media</groupId>
-                <artifactId>jai-core</artifactId>
-              </exclusion>
-            </exclusions>
           </dependency>
         </dependencies>
       </plugin>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -146,6 +146,18 @@
             <groupId>org.codehaus.izpack</groupId>
             <artifactId>izpack-panel</artifactId>
             <version>${izpack.version}</version>
+            <exclusions>
+              <!-- this is excluded in the izpack pom file (but the artifactId is jai_core)
+                   maven tries to download the dependency but the server replies with a response
+                   that java11 does not like: "extension (10) should not be presented in server_hello"
+                   see https://bugs.openjdk.java.net/browse/JDK-8210005
+                   this will be fixed in the Jan2019 release of java11
+               -->
+              <exclusion>
+                <groupId>javax.media</groupId>
+                <artifactId>jai-core</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
         </dependencies>
       </plugin>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <installer.output.filename>jhove-xplt-installer-${project.version}.jar</installer.output.filename>
-    <izpack.version>5.0.10</izpack.version>
+    <izpack.version>5.1.3</izpack.version>
     <izpack.staging>${project.build.directory}/staging</izpack.staging>
     <izpack.target>${project.build.directory}</izpack.target>
     <izpack.scripts>${project.build.scriptSourceDirectory}</izpack.scripts>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -110,6 +110,31 @@
         </executions>
       </plugin>
 
+      <!-- force maven to ignore the dependency that java11 can't retrieve from the maven repo -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-exclusions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.media:jai-core</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!--
       We need to tell the izpack-maven-plugin what to use as the base
       directory (this is our staging area), and also tell it the install

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <installer.output.filename>jhove-xplt-installer-${project.version}.jar</installer.output.filename>
-    <izpack.version>5.1.3</izpack.version>
+    <izpack.version>5.0.10</izpack.version>
     <izpack.staging>${project.build.directory}/staging</izpack.staging>
     <izpack.target>${project.build.directory}</izpack.target>
     <izpack.scripts>${project.build.scriptSourceDirectory}</izpack.scripts>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -22,9 +22,11 @@
       <artifactId>jhove-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
@@ -210,10 +210,10 @@ public class AsciiModule extends ModuleBase {
                 }
                 /* Track what control characters are used. */
                 if (ch < 0x20 && ch != 0x0D && ch != 0x0A) {
-                    _controlCharMap.put(new Integer(ch),
+                    _controlCharMap.put(Integer.valueOf(ch),
                             controlCharMnemonics[ch]);
                 } else if (ch == 0x7F) {
-                    _controlCharMap.put(new Integer(ch), "DEL (0x7F)");
+                    _controlCharMap.put(Integer.valueOf(ch), "DEL (0x7F)");
                 }
 
                 /* Determine the line ending type(s). */
@@ -292,13 +292,13 @@ public class AsciiModule extends ModuleBase {
             LinkedList<String> propList = new LinkedList<String>();
             String mnem;
             for (int i = 0; i < 0x20; i++) {
-                mnem = _controlCharMap.get(new Integer(i));
+                mnem = _controlCharMap.get(Integer.valueOf(i));
                 if (mnem != null) {
                     propList.add(mnem);
                 }
             }
             /* need to check separately for DEL */
-            mnem = _controlCharMap.get(new Integer(0x7F));
+            mnem = _controlCharMap.get(Integer.valueOf(0x7F));
             if (mnem != null) {
                 propList.add(mnem);
             }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
@@ -343,7 +343,7 @@ public class GifModule extends ModuleBase
                                  // which we can't calculate yet
         metaArray[0] = new Property ("GraphicRenderingBlocks",
                 PropertyType.INTEGER,
-                new Integer (_numGraphicBlocks));
+                Integer.valueOf(_numGraphicBlocks));
         if (_xmpProp != null) {
             metaArray[2] = _xmpProp;
         }
@@ -412,17 +412,17 @@ public class GifModule extends ModuleBase
         int width = readUnsignedShort (_dstream);
         propVec.add (new Property ("LogicalScreenWidth",
                 PropertyType.INTEGER,
-                new Integer (width)));
+                Integer.valueOf(width)));
         int height = readUnsignedShort (_dstream);
         propVec.add (new Property ("LogicalScreenHeight",
                 PropertyType.INTEGER,
-                new Integer (height)));
+                Integer.valueOf(height)));
         int packedFields = readUnsignedByte (_dstream, this);
         _globalColorTableFlag = (packedFields & 0X80) != 0;
         int bitsPerColor = ((packedFields & 0X70) >> 4) + 1;
         propVec.add (new Property ("ColorResolution",
                 PropertyType.INTEGER,
-                new Integer (bitsPerColor)));
+                Integer.valueOf(bitsPerColor)));
         boolean sortFlag = (packedFields & 0X8) != 0;
         int rawGlobalColorTableSize = packedFields & 0X7;
         if (_globalColorTableFlag) {
@@ -433,13 +433,13 @@ public class GifModule extends ModuleBase
         int bgColorIndex = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("BackgroundColorIndex",
                 PropertyType.INTEGER,
-                new Integer (bgColorIndex)));
+                Integer.valueOf(bgColorIndex)));
         int pixAspectRatio = readUnsignedByte (_dstream, this);
         // The pixel aspect ratio is turned into a real aspect
         // ratio by a formula, but we just report the raw number.
         propVec.add (new Property ("PixelAspectRatio",
                 PropertyType.SHORT,
-                new Short ((short) pixAspectRatio)));
+                Short.valueOf((short) pixAspectRatio)));
         propVec.add (addByteProperty ("GlobalColorTableFlag",
                 _globalColorTableFlag ? 1 : 0,
                 GifStrings.GLOBAL_COLOR_TABLE_FLAG));
@@ -448,7 +448,7 @@ public class GifModule extends ModuleBase
                 GifStrings.COLOR_TABLE_SORT_FLAG));
         propVec.add (new Property ("GlobalColorTableSize",
                 PropertyType.SHORT,
-                new Short ((short) rawGlobalColorTableSize)));
+                Short.valueOf((short) rawGlobalColorTableSize)));
         Property prop = new Property ("LogicalScreenDescriptor",
                 PropertyType.PROPERTY,
                 PropertyArity.ARRAY,
@@ -561,11 +561,11 @@ public class GifModule extends ModuleBase
         int leftPos = readUnsignedShort (_dstream);
         propVec.add (new Property ("ImageLeftPosition",
                 PropertyType.INTEGER,
-                new Integer (leftPos)));
+                Integer.valueOf(leftPos)));
         int topPos = readUnsignedShort (_dstream);
         propVec.add (new Property ("ImageTopPosition",
                 PropertyType.INTEGER,
-                new Integer (topPos)));
+                Integer.valueOf(topPos)));
         int width = readUnsignedShort (_dstream);
         niso.setImageWidth (width);
         int height = readUnsignedShort (_dstream);
@@ -587,7 +587,7 @@ public class GifModule extends ModuleBase
         int rawLocalColorTableSize = packedFields & 0X7;
         propVec.add (new Property ("LocalColorTableSize",
                 PropertyType.SHORT,
-                new Short ((short) rawLocalColorTableSize)));
+                Short.valueOf((short) rawLocalColorTableSize)));
         propVec.add (nisoProp);
         if (localColorTableFlag != 0) {
             localColorTableSize =
@@ -668,7 +668,7 @@ public class GifModule extends ModuleBase
         }
         propVec.add (new Property ("ApplicationDataSize",
                 PropertyType.INTEGER,
-                new Integer (appDataSize)));
+                Integer.valueOf(appDataSize)));
 
         Property prop = new Property ("ApplicationExtension",
                 PropertyType.PROPERTY,
@@ -731,42 +731,42 @@ public class GifModule extends ModuleBase
         int textLeft = readUnsignedShort (_dstream);
         propVec.add (new Property ("TextGridLeftPosition",
                 PropertyType.INTEGER,
-                new Integer (textLeft)));
+                Integer.valueOf(textLeft)));
 
         int textTop = readUnsignedShort (_dstream);
         propVec.add (new Property ("TextGridTopPosition",
                 PropertyType.INTEGER,
-                new Integer (textTop)));
+                Integer.valueOf(textTop)));
 
         int textGWidth = readUnsignedShort (_dstream);
         propVec.add (new Property ("TextGridWidth",
                 PropertyType.INTEGER,
-                new Integer (textGWidth)));
+                Integer.valueOf(textGWidth)));
 
         int textGHeight = readUnsignedShort (_dstream);
         propVec.add (new Property ("TextGridHeight",
                 PropertyType.INTEGER,
-                new Integer (textGHeight)));
+                Integer.valueOf(textGHeight)));
 
         int charCWidth = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("CharacterCellWidth",
                 PropertyType.SHORT,
-                new Short ((short) charCWidth)));
+                Short.valueOf((short) charCWidth)));
 
         int charCHeight = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("CharacterCellHeight",
                 PropertyType.SHORT,
-                new Short ((short) charCHeight)));
+                Short.valueOf((short) charCHeight)));
 
         int textFgIdx = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("TextForegroundColorIndex",
                 PropertyType.SHORT,
-                new Short ((short) textFgIdx)));
+                Short.valueOf((short) textFgIdx)));
 
         int textBgIdx = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("TextBackgroundColorIndex",
                 PropertyType.SHORT,
-                new Short ((short) textBgIdx)));
+                Short.valueOf((short) textBgIdx)));
 
         // Read the text data.  The GIF recommendation states that
         // characters less than 0X20 or greater than 0XF7 (why F7?
@@ -837,11 +837,11 @@ public class GifModule extends ModuleBase
         int delayTime = readUnsignedShort(_dstream);
         propVec.add (new Property ("DelayTime",
                 PropertyType.INTEGER,
-                new Integer (delayTime)));
+                Integer.valueOf(delayTime)));
         int transIndex = readUnsignedByte (_dstream, this);
         propVec.add (new Property ("TransparentColorIndex",
                 PropertyType.SHORT,
-                new Short ((short) transIndex)));
+                Short.valueOf((short) transIndex)));
         // Skip the block terminator.
         readUnsignedByte (_dstream, this);
 
@@ -973,7 +973,7 @@ public class GifModule extends ModuleBase
                 // fall through
             }
         }
-        return new Property (name, PropertyType.BYTE, new Byte ((byte) value));
+        return new Property (name, PropertyType.BYTE, Byte.valueOf((byte) value));
     }
 
 

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -686,9 +686,9 @@ public class JpegModule extends ModuleBase {
         if (_units == 0) {
             List<Property> list = new ArrayList<Property>();
             list.add(new Property("PixelAspectRatioX", PropertyType.INTEGER,
-                    new Integer(_xDensity)));
+                    Integer.valueOf(_xDensity)));
             list.add(new Property("PixelAspectRatioY", PropertyType.INTEGER,
-                    new Integer(_yDensity)));
+                    Integer.valueOf(_yDensity)));
             _primaryImageList.add(new Property("PixelAspectRatio",
                     PropertyType.PROPERTY, PropertyArity.LIST, list));
         }
@@ -703,10 +703,10 @@ public class JpegModule extends ModuleBase {
         }
         if (_restartInterval >= 0) {
             _primaryImageList.add(new Property("RestartInterval",
-                    PropertyType.INTEGER, new Integer(_restartInterval)));
+                    PropertyType.INTEGER, Integer.valueOf(_restartInterval)));
         }
         _primaryImageList.add(new Property("Scans", PropertyType.INTEGER,
-                new Integer(_numScans)));
+                Integer.valueOf(_numScans)));
         if (!_quantTables.isEmpty()) {
             List<Property> qpl = new LinkedList<Property>();
             ListIterator<QuantizationTable> iter = _quantTables.listIterator();
@@ -800,7 +800,7 @@ public class JpegModule extends ModuleBase {
          */
         List<Property> list = new ArrayList<Property>();
         list.add(new Property("Number", PropertyType.INTEGER,
-                PropertyArity.SCALAR, new Integer(_imageList.size())));
+                PropertyArity.SCALAR, Integer.valueOf(_imageList.size())));
         Iterator<Property> iter = _imageList.iterator();
         while (iter.hasNext()) {
             Property prop = iter.next();
@@ -1550,7 +1550,7 @@ public class JpegModule extends ModuleBase {
             List<Property> capList = new ArrayList<Property>(3);
             if (_je.getShowRawFlag()) {
                 cap0Prop = new Property("Version0", PropertyType.INTEGER,
-                        new Integer(_capability0));
+                        Integer.valueOf(_capability0));
             } else {
                 cap0Prop = new Property("Version0", PropertyType.STRING,
                         JpegStrings.CAPABILITY_V0[_capability0]);
@@ -1560,7 +1560,7 @@ public class JpegModule extends ModuleBase {
             if (_capability1 >= 0) {
                 if (_je.getShowRawFlag()) {
                     Property cap1Prop = new Property("Version1",
-                            PropertyType.INTEGER, new Integer(_capability1));
+                            PropertyType.INTEGER, Integer.valueOf(_capability1));
                     capList.add(cap1Prop);
                 } else {
                     // Capability 1 entails 2 strings, one for the
@@ -1592,19 +1592,19 @@ public class JpegModule extends ModuleBase {
             int tilingType = _tiling.getTilingType();
             if (_je.getShowRawFlag()) {
                 propArr[0] = new Property("TilingType", PropertyType.INTEGER,
-                        new Integer(tilingType));
+                        Integer.valueOf(tilingType));
             } else {
                 propArr[0] = new Property("TilingType", PropertyType.STRING,
                         JpegStrings.TILING_TYPE[tilingType]);
             }
             propArr[1] = new Property("VerticalScale", PropertyType.INTEGER,
-                    new Integer(_tiling.getVertScale()));
+                    Integer.valueOf(_tiling.getVertScale()));
             propArr[2] = new Property("HorizontalScale", PropertyType.INTEGER,
-                    new Integer(_tiling.getHorScale()));
+                    Integer.valueOf(_tiling.getHorScale()));
             propArr[3] = new Property("RefGridHeight", PropertyType.LONG,
-                    new Long(_tiling.getRefGridHeight()));
+                    Long.valueOf(_tiling.getRefGridHeight()));
             propArr[4] = new Property("RefGridWidth", PropertyType.LONG,
-                    new Long(_tiling.getRefGridWidth()));
+                    Long.valueOf(_tiling.getRefGridWidth()));
             propArr[5] = _tiling.buildTileListProp();
             return new Property("Tiling", PropertyType.PROPERTY,
                     PropertyArity.ARRAY, propArr);
@@ -1626,9 +1626,9 @@ public class JpegModule extends ModuleBase {
             boolean[] lhlv = iter.next();
             Property[] lhlvProp = new Property[2];
             lhlvProp[0] = new Property("Horizontal", PropertyType.BOOLEAN,
-                    new Boolean(lhlv[0]));
+                    Boolean.valueOf(lhlv[0]));
             lhlvProp[1] = new Property("Vertical", PropertyType.BOOLEAN,
-                    new Boolean(lhlv[1]));
+                    Boolean.valueOf(lhlv[1]));
             plist.add(new Property("Expansion", PropertyType.PROPERTY,
                     PropertyArity.ARRAY, lhlvProp));
         }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -863,13 +863,13 @@ public class PdfModule extends ModuleBase {
         info.setVersion(_version);
         metadataList.add(new Property(PROP_NAME_OBJECTS,
                                         PropertyType.INTEGER,
-                                        new Integer(_numObjects)));
+                                        Integer.valueOf(_numObjects)));
         metadataList.add(new Property(PROP_NAME_FREE_OBJECTS,
                                         PropertyType.INTEGER,
-                                        new Integer(_numFreeObjects)));
+                                        Integer.valueOf(_numFreeObjects)));
         metadataList.add(new Property(PROP_NAME_INC_UPDATES,
                                         PropertyType.INTEGER,
-                                        new Integer(_numTrailers)));
+                                        Integer.valueOf(_numTrailers)));
         if (_docCatalogList != null) {
             metadataList.add(new Property(PROP_NAME_DOC_CATALOG,
                                         PropertyType.PROPERTY,
@@ -1783,7 +1783,7 @@ public class PdfModule extends ModuleBase {
                     if (_je != null && _je.getShowRawFlag()) {
                         p = new Property(PROP_NAME_ALGORITHM,
                                 PropertyType.INTEGER,
-                                new Integer(algValue));
+                                Integer.valueOf(algValue));
                     }
                     else {
                         try {
@@ -1813,7 +1813,7 @@ public class PdfModule extends ModuleBase {
                 if (_je != null) {
                         p = new Property(PROP_NAME_KEY_LENGTH,
                                 PropertyType.INTEGER,
-                                new Integer(keyLen));
+                                Integer.valueOf(keyLen));
                         _encryptList.add(p);
                     }
             }
@@ -1843,7 +1843,7 @@ public class PdfModule extends ModuleBase {
 
                     stdList.add(new Property(PROP_NAME_REVISION,
                         PropertyType.INTEGER,
-                        new Integer(rev)));
+                        Integer.valueOf(rev)));
                 }
                 PdfObject oObj = dict.get("O");
                 if (oObj != null) {
@@ -2343,7 +2343,7 @@ public class PdfModule extends ModuleBase {
                                         Iterator<PdfObject> diter = dcdvec.iterator();
                                         while (diter.hasNext()) {
                                             PdfSimpleObject d = (PdfSimpleObject) diter.next();
-                                            dcdlst.add(new Integer(d.getIntValue()));
+                                            dcdlst.add(Integer.valueOf(d.getIntValue()));
                                         }
                                         imgList.add(new Property(PROP_NAME_DECODE,
                                             PropertyType.INTEGER,
@@ -2499,7 +2499,7 @@ public class PdfModule extends ModuleBase {
             subtypeStr = subtype.getStringValue();
             if (FONT_TYPE0.equals(subtypeStr)) {
                 _type0FontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
                 // If the font is Type 0, we must go
                 // through its descendant fonts
@@ -2516,32 +2516,32 @@ public class PdfModule extends ModuleBase {
             }
             else if (FONT_TYPE1.equals(subtypeStr)) {
                 _type1FontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             else if (FONT_MM_TYPE1.equals(subtypeStr)) {
                 _mmFontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             else if (FONT_TYPE3.equals(subtypeStr)) {
                 _type3FontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             else if (FONT_TRUE_TYPE.equals(subtypeStr)) {
                 _trueTypeFontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             else if (FONT_CID_TYPE0.equals(subtypeStr)) {
                 _cid0FontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             else if (FONT_CID_TYPE2.equals(subtypeStr)) {
                 _cid2FontsMap.put(
-                    new Integer(font.getObjNumber()),
+                    Integer.valueOf(font.getObjNumber()),
                     font);
             }
             return subtypeStr;
@@ -2862,8 +2862,8 @@ public class PdfModule extends ModuleBase {
                     break;
                 }
                 _pageSeqMap.put(
-                        new Integer(page.getDict().getObjNumber()),
-                        new Integer(pageIndex + 1));
+                        Integer.valueOf(page.getDict().getObjNumber()),
+                        Integer.valueOf(pageIndex + 1));
             }
             _docTreeRoot.startWalk();
             for (;;) {
@@ -2920,7 +2920,7 @@ public class PdfModule extends ModuleBase {
                 // there is no label.  Make it 1-based.
                 pagePropList.add(new Property(PROP_NAME_SEQUENCE,
                                 PropertyType.INTEGER,
-                                new Integer(idx + 1)));
+                                Integer.valueOf(idx + 1)));
 
             }
         }
@@ -2982,7 +2982,7 @@ public class PdfModule extends ModuleBase {
             if (rot != null && rot.getIntValue() != 0) {
                 pagePropList.add(new Property(PROP_NAME_ROTATE,
                         PropertyType.INTEGER,
-                        new Integer(rot.getIntValue())));
+                        Integer.valueOf(rot.getIntValue())));
             }
 
             // UserUnit property (1.6), not inheritable
@@ -2990,7 +2990,7 @@ public class PdfModule extends ModuleBase {
             if (uu != null) {
                 pagePropList.add(new Property(PROP_NAME_USER_UNIT,
                         PropertyType.DOUBLE,
-                        new Double(rot.getDoubleValue())));
+                        Double.valueOf(rot.getDoubleValue())));
             }
             // Viewport dictionaries (1.6), not inheritable
             PdfArray vp = (PdfArray) page.get(DICT_KEY_VIEWPORT, false);
@@ -3330,7 +3330,7 @@ public class PdfModule extends ModuleBase {
                 List<Double> clList = new ArrayList<Double>(6);
                 while (iter.hasNext()) {
                     PdfSimpleObject clItem = (PdfSimpleObject) iter.next();
-                    clList.add(new Double(clItem.getDoubleValue()));
+                    clList.add(Double.valueOf(clItem.getDoubleValue()));
                 }
                 propList.add(new Property(PROP_NAME_CALLOUT_LINE,
                         PropertyType.DOUBLE,
@@ -3373,7 +3373,7 @@ public class PdfModule extends ModuleBase {
                     else {
                         propList.add(new Property(propName,
                                     PropertyType.INTEGER,
-                                    new Integer(pageObjNum)));
+                                    Integer.valueOf(pageObjNum)));
                     }
                 }
             }
@@ -3382,7 +3382,7 @@ public class PdfModule extends ModuleBase {
     	            return;      // can't get the page object number
     	        }
         		int pageObjNum = dest.getPageDestObjNumber();
-        		Integer destPg = _pageSeqMap.get(new Integer(pageObjNum));
+        		Integer destPg = _pageSeqMap.get(Integer.valueOf(pageObjNum));
         		if (destPg != null) {
         		    propList.add(new Property(propName,
         						PropertyType.INTEGER,
@@ -3503,7 +3503,7 @@ public class PdfModule extends ModuleBase {
             try {
                 int firstChar = ((PdfSimpleObject) firstCharObj).getIntValue();
                 prop = new Property(PROP_NAME_FIRST_CHAR, PropertyType.INTEGER,
-				     new Integer(firstChar));
+				     Integer.valueOf(firstChar));
                 fontPropList.add(prop);
             }
             catch (Exception e) {}
@@ -3515,7 +3515,7 @@ public class PdfModule extends ModuleBase {
             try {
                 int lastChar = ((PdfSimpleObject) lastCharObj).getIntValue();
                 prop = new Property(PROP_NAME_LAST_CHAR, PropertyType.INTEGER,
-				     new Integer(lastChar));
+				     Integer.valueOf(lastChar));
                 fontPropList.add(prop);
             }
             catch (Exception e) {}
@@ -3707,7 +3707,7 @@ public class PdfModule extends ModuleBase {
             int suppvalue = ((PdfSimpleObject) supp).getIntValue();
             subprop = new Property(PROP_NAME_SUPPLEMENT,
                 PropertyType.INTEGER,
-                new Integer(suppvalue));
+                Integer.valueOf(suppvalue));
             propList.add(subprop);
             }
             catch (Exception e) {}
@@ -3999,7 +3999,7 @@ public class PdfModule extends ModuleBase {
 //            }
             int listCount = 0;          // Guard against looping
             while (item != null) {
-                Integer onum = new Integer(item.getObjNumber());
+                Integer onum = Integer.valueOf(item.getObjNumber());
                 Property p = buildOutlineItemProperty((PdfDictionary) item, info);
                 itemList.add(p);
                 item = resolveIndirectObject(((PdfDictionary) item).get(DICT_KEY_NEXT));
@@ -4095,7 +4095,7 @@ public class PdfModule extends ModuleBase {
                 }
                 else {
                     int pageObjNum = dest.getPageDestObjNumber();
-                    Integer destPg = _pageSeqMap.get(new Integer(pageObjNum));
+                    Integer destPg = _pageSeqMap.get(Integer.valueOf(pageObjNum));
                     if (destPg != null) {
                         itemList.add(new Property(PROP_NAME_DESTINATION,
                             PropertyType.INTEGER,
@@ -4116,7 +4116,7 @@ public class PdfModule extends ModuleBase {
                 // on the list just to be safe.
                 int listCount = 0;
                 while (child != null) {
-                    Integer onum = new Integer(child.getObjNumber());
+                    Integer onum = Integer.valueOf(child.getObjNumber());
                     if (_visitedOutlineNodes.contains(onum)) {
                         /* We have recursion! */
                         if (!_recursionWarned) {
@@ -4307,7 +4307,7 @@ public class PdfModule extends ModuleBase {
         if (_je != null && _je.getShowRawFlag()) {
             return new Property(name,
                         PropertyType.INTEGER,
-                        new Integer(val));
+                        Integer.valueOf(val));
         }
         List<String> slist = new LinkedList<String>();
            try {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -467,7 +467,7 @@ public class TiffModule extends ModuleBase {
             Property ifdsProp = new Property("IFDs", PropertyType.PROPERTY,
                     PropertyArity.LIST, ifdsList);
             ifdsList.add(new Property("Number", PropertyType.INTEGER,
-                    new Integer(ifds.size())));
+                    Integer.valueOf(ifds.size())));
 
             /* Build the IFD property list, for each of the IFDs. */
             ListIterator<IFD> iter = ifds.listIterator();

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
@@ -304,10 +304,10 @@ public class Utf8Module extends ModuleBase {
 
                 /* Track what control characters are used. */
                 if (ch < 0x20 && ch != 0x0D && ch != 0x0A) {
-                    _controlCharMap.put(new Integer(ch),
+                    _controlCharMap.put(Integer.valueOf(ch),
                             controlCharMnemonics[ch]);
                 } else if (ch == 0x7F) {
-                    _controlCharMap.put(new Integer(ch), "DEL (0x7F)");
+                    _controlCharMap.put(Integer.valueOf(ch), "DEL (0x7F)");
                 }
 
                 /* Character values U+000..U+001f,U+007f aren't printable. */
@@ -366,7 +366,7 @@ public class Utf8Module extends ModuleBase {
                 PropertyArity.LIST, metadataList));
 
         Property property = new Property("Characters", PropertyType.LONG,
-                new Long(nChar));
+                Long.valueOf(nChar));
         metadataList.add(property);
 
         property = blockMarker.getBlocksUsedProperty("UnicodeBlocks");
@@ -398,13 +398,13 @@ public class Utf8Module extends ModuleBase {
             LinkedList<String> propList = new LinkedList<String>();
             String mnem;
             for (int i = 0; i < 0x20; i++) {
-                mnem = _controlCharMap.get(new Integer(i));
+                mnem = _controlCharMap.get(Integer.valueOf(i));
                 if (mnem != null) {
                     propList.add(mnem);
                 }
             }
             /* need to check separately for DEL */
-            mnem = _controlCharMap.get(new Integer(0x7F));
+            mnem = _controlCharMap.get(Integer.valueOf(0x7F));
             if (mnem != null) {
                 propList.add(mnem);
             }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/CommonChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/CommonChunk.java
@@ -84,7 +84,7 @@ public class CommonChunk extends Chunk {
         aes.setDuration (numSampleFrames);
         module.addAiffProperty (new Property ("SampleFrames",
                 PropertyType.LONG,
-                new Long (numSampleFrames)));
+                Long.valueOf(numSampleFrames)));
         // Proper handling of compression type should depend
         // on whether raw output is set
         if (compressionType != null) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/InstrumentChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/InstrumentChunk.java
@@ -57,25 +57,25 @@ public class InstrumentChunk extends Chunk {
         List propList = new ArrayList (9);
         propList.add (new Property ("BaseNote",
                 PropertyType.INTEGER,
-                new Integer (baseNote)));
+                Integer.valueOf(baseNote)));
         propList.add (new Property ("Detune",
                 PropertyType.INTEGER,
-                new Integer (detune)));
+                Integer.valueOf(detune)));
         propList.add (new Property ("LowNote",
                 PropertyType.INTEGER,
-                new Integer (lowNote)));
+                Integer.valueOf(lowNote)));
         propList.add (new Property ("HighNote",
                 PropertyType.INTEGER,
-                new Integer (highNote)));
+                Integer.valueOf(highNote)));
         propList.add (new Property ("LowVelocity",
                 PropertyType.INTEGER,
-                new Integer (lowVelocity)));
+                Integer.valueOf(lowVelocity)));
         propList.add (new Property ("HighVelocity",
                 PropertyType.INTEGER,
-                new Integer (highVelocity)));
+                Integer.valueOf(highVelocity)));
         propList.add (new Property ("Gain",
                 PropertyType.INTEGER,
-                new Integer (gain)));
+                Integer.valueOf(gain)));
         propList.add (sustainLoop.loopProp("SustainLoop"));
         propList.add (releaseLoop.loopProp("ReleaseLoop"));
         module.addAiffProperty(new Property ("Instrument",
@@ -115,10 +115,10 @@ public class InstrumentChunk extends Chunk {
                     AiffStrings.LOOP_TYPE);
             propArr[1] = new Property ("BeginLoop",
                     PropertyType.INTEGER,
-                    new Integer (beginLoop));
+                    Integer.valueOf(beginLoop));
             propArr[2] = new Property ("EndLoop",
                     PropertyType.INTEGER,
-                    new Integer (endLoop));
+                    Integer.valueOf(endLoop));
             return new Property (name,
                     PropertyType.PROPERTY,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/MarkerChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/MarkerChunk.java
@@ -55,10 +55,10 @@ public class MarkerChunk extends Chunk {
             Property[] mArr = new Property[3];
             mArr[0] = new Property ("ID",
                     PropertyType.INTEGER,
-                    new Integer (id));
+                    Integer.valueOf(id));
             mArr[1] = new Property ("Position",
                     PropertyType.LONG,
-                    new Long (position));
+                    Long.valueOf(position));
             mArr[2] = new Property ("Name",
                     PropertyType.STRING,
                     markerName);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/SaxelChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/SaxelChunk.java
@@ -70,10 +70,10 @@ public class SaxelChunk extends Chunk {
             // Build the property to add to the saxel list.
             propArr[0] = new Property ("ID",
                     PropertyType.INTEGER,
-                    new Integer (id));
+                    Integer.valueOf(id));
             propArr[1] = new Property ("Size",
                     PropertyType.INTEGER,
-                    new Integer (size));
+                    Integer.valueOf(size));
             module.addSaxel (new Property ("Saxel",
                     PropertyType.PROPERTY,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/SoundDataChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/SoundDataChunk.java
@@ -48,11 +48,11 @@ public class SoundDataChunk extends Chunk {
         long offset = module.readUnsignedInt (_dstream);
         long blockSize = module.readUnsignedInt (_dstream);
         propArray[0] = new Property ("Offset", PropertyType.LONG,
-				     new Long (offset));
+				     Long.valueOf(offset));
         propArray[1] = new Property ("BlockSize", PropertyType.LONG,
-				     new Long (blockSize));
+				     Long.valueOf(blockSize));
         propArray[2] = new Property ("DataLength", PropertyType.LONG,
-				     new Long (bytesLeft - 8));
+				     Long.valueOf(bytesLeft - 8));
         module.addAiffProperty(new Property ("SoundData",
 					     PropertyType.PROPERTY,
 					     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/CharStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/CharStream.java
@@ -30,6 +30,7 @@ public interface CharStream {
    * @deprecated 
    * @see #getEndColumn
    */
+  @Deprecated
   int getColumn();
 
   /**
@@ -37,6 +38,7 @@ public interface CharStream {
    * @deprecated 
    * @see #getEndLine
    */
+  @Deprecated
   int getLine();
 
   /**

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlCharStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlCharStream.java
@@ -226,7 +226,7 @@ public class HtmlCharStream implements CharStream
    * @deprecated 
    * @see #getEndColumn
    */
-
+  @Deprecated
   public int getColumn() {
      return bufcolumn[bufpos];
   }
@@ -235,7 +235,7 @@ public class HtmlCharStream implements CharStream
    * @deprecated 
    * @see #getEndLine
    */
-
+  @Deprecated
   public int getLine() {
      return bufline[bufpos];
   }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/JHOpenTag.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/JHOpenTag.java
@@ -351,12 +351,12 @@ public class JHOpenTag extends JHElement {
         if (height >= 0) {
             plist.add (new Property ("Height",
                     PropertyType.INTEGER,
-                    new Integer (height)));
+                    Integer.valueOf(height)));
         }
         if (width >= 0) {
             plist.add (new Property ("Width",
                     PropertyType.INTEGER,
-                    new Integer (width)));
+                    Integer.valueOf(width)));
         }
         if (!plist.isEmpty ()) {
             mdata.addImage(new Property ("Image",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/SimpleCharStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/html/SimpleCharStream.java
@@ -196,7 +196,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndColumn
    */
-
+  @Deprecated
   public int getColumn() {
      return bufcolumn[bufpos];
   }
@@ -205,7 +205,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndLine
    */
-
+  @Deprecated
   public int getLine() {
      return bufline[bufpos];
   }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/ArithConditioning.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/ArithConditioning.java
@@ -38,7 +38,7 @@ public class ArithConditioning {
         if (raw) {
             parray[0] = new Property ("TableClass",
                     PropertyType.INTEGER,
-                    new Integer (_tableClass));
+                    Integer.valueOf(_tableClass));
         }
         else {
             String prec = "Undefined";
@@ -52,7 +52,7 @@ public class ArithConditioning {
         }
         parray[1] = new Property ("DestinationIdentifier",
                 PropertyType.INTEGER,
-                new Integer (_destIdentifier));
+                Integer.valueOf(_destIdentifier));
         return new Property ("ArithmeticConditioning",
                 PropertyType.PROPERTY,
                 PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/QuantizationTable.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/QuantizationTable.java
@@ -38,7 +38,7 @@ public class QuantizationTable {
         if (raw) {
             parray[0] = new Property ("Precision",
                     PropertyType.INTEGER,
-                    new Integer (_precision));
+                    Integer.valueOf(_precision));
         }
         else {
             String prec = "Undefined";
@@ -52,7 +52,7 @@ public class QuantizationTable {
         }
         parray[1] = new Property ("DestinationIdentifier",
                 PropertyType.INTEGER,
-                new Integer (_destIdentifier));
+                Integer.valueOf(_destIdentifier));
         return new Property ("QuantizationTable",
                 PropertyType.PROPERTY,
                 PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/SRS.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/SRS.java
@@ -6,7 +6,9 @@
 
 package edu.harvard.hul.ois.jhove.module.jpeg;
 
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
 
 /**
  * Encapsulation of an SRS (selectively refined scan) entry for a JPEG image.
@@ -43,16 +45,16 @@ public class SRS {
         Property[] parray = new Property[4];
         parray[0] = new Property ("VerticalOffset",
                 PropertyType.INTEGER,
-                new Integer (_vertOffset));
+                Integer.valueOf(_vertOffset));
         parray[1] = new Property ("HorizontalOffset",
                 PropertyType.INTEGER,
-                new Integer (_horOffset));
+                Integer.valueOf(_horOffset));
         parray[2] = new Property ("VerticalSize",
                 PropertyType.INTEGER,
-                new Integer (_vertSize));
+                Integer.valueOf(_vertSize));
         parray[3] = new Property ("HorizontalSize",
                 PropertyType.INTEGER,
-                new Integer (_horSize));
+                Integer.valueOf(_horSize));
         return new Property ("SelectivelyRefinedScan",
                 PropertyType.PROPERTY,
                 PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/Tiling.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/Tiling.java
@@ -31,7 +31,7 @@ public class Tiling {
      *  Constructor.
      */
     public Tiling() {
-        tileList = new LinkedList<long[]> ();
+        tileList = new LinkedList<>();
     }
     
     /**
@@ -64,16 +64,16 @@ public class Tiling {
             Property[] tProp = new Property[4];
             tProp[0] = new Property ("VerticalScale",
                         PropertyType.LONG,
-                        new Long (tile[0]));
+                        Long.valueOf(tile[0]));
             tProp[1] = new Property ("HorizontalScale",
                         PropertyType.LONG,
-                        new Long (tile[1]));
+                        Long.valueOf(tile[1]));
             tProp[2] = new Property ("VerticalOffsret",
                         PropertyType.LONG,
-                        new Long (tile[2]));
+                        Long.valueOf(tile[2]));
             tProp[3] = new Property ("HorizontalOffset",
                         PropertyType.LONG,
-                        new Long (tile[3]));
+                        Long.valueOf(tile[3]));
             tpList.add (new Property ("Tile",
                         PropertyType.PROPERTY,
                         PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/COCMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/COCMarkerSegment.java
@@ -6,9 +6,15 @@
 
 package edu.harvard.hul.ois.jhove.module.jpeg2000;
 
-import java.io.*;
-import java.util.*;
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 //import edu.harvard.hul.ois.jhove.module.Jpeg2000Module;
 
 /**
@@ -91,22 +97,22 @@ public class COCMarkerSegment extends MarkerSegment {
         List<Property> propList = new ArrayList<Property> (10);
         propList.add (new Property ("CodingStyle",
                     PropertyType.INTEGER,
-                    new Integer (codeStyle)));
+                    Integer.valueOf(codeStyle)));
         propList.add (new Property ("NumberDecompositionLevels",
                     PropertyType.INTEGER,
-                    new Integer (nDecomp)));
+                    Integer.valueOf(nDecomp)));
         propList.add (new Property ("CodeBlockWidth",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockWid)));
+                    Integer.valueOf(codeBlockWid)));
         propList.add (new Property ("CodeBlockHeight",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockHt)));
+                    Integer.valueOf(codeBlockHt)));
         propList.add (new Property ("CodeBlockStyle",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockStyle)));
+                    Integer.valueOf(codeBlockStyle)));
         propList.add (new Property ("Transformation",
                     PropertyType.INTEGER,
-                    new Integer (xform)));
+                    Integer.valueOf(xform)));
         propList.add (new Property ("PrecinctSize",
                     PropertyType.INTEGER,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CODMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CODMarkerSegment.java
@@ -5,9 +5,14 @@
 
 package edu.harvard.hul.ois.jhove.module.jpeg2000;
 
-import java.io.*;
-import java.util.*;
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 //import edu.harvard.hul.ois.jhove.module.Jpeg2000Module;
 
 /**
@@ -24,9 +29,6 @@ public class CODMarkerSegment extends MarkerSegment {
     public CODMarkerSegment ()
     {
     }
-
-
-
 
     /**
      * Processes the marker segment.  The DataInputStream
@@ -75,31 +77,31 @@ public class CODMarkerSegment extends MarkerSegment {
         List propList = new ArrayList (12);
         propList.add (new Property ("CodingStyle",
                     PropertyType.INTEGER,
-                    new Integer (codeStyle)));
+                    Integer.valueOf(codeStyle)));
         propList.add (new Property ("ProgressionOrder",
                     PropertyType.INTEGER,
-                    new Integer (progOrder)));
+                    Integer.valueOf(progOrder)));
         propList.add (new Property ("NumberOfLayers",
                     PropertyType.INTEGER,
-                    new Integer (nLayers)));
+                    Integer.valueOf(nLayers)));
         propList.add (new Property ("MultipleComponentTransformation",
                     PropertyType.INTEGER,
-                    new Integer (mcTrans)));
+                    Integer.valueOf(mcTrans)));
         propList.add (new Property ("NumberDecompositionLevels",
                     PropertyType.INTEGER,
-                    new Integer (nDecomp)));
+                    Integer.valueOf(nDecomp)));
         propList.add (new Property ("CodeBlockWidth",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockWid)));
+                    Integer.valueOf(codeBlockWid)));
         propList.add (new Property ("CodeBlockHeight",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockHt)));
+                    Integer.valueOf(codeBlockHt)));
         propList.add (new Property ("CodeBlockStyle",
                     PropertyType.INTEGER,
-                    new Integer (codeBlockStyle)));
+                    Integer.valueOf(codeBlockStyle)));
         propList.add (new Property ("Transformation",
                     PropertyType.INTEGER,
-                    new Integer (xform)));
+                    Integer.valueOf(xform)));
         if (precSize != null) {
             propList.add (new Property ("PrecinctSize",
                     PropertyType.INTEGER,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ChannelDefBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ChannelDefBox.java
@@ -53,7 +53,7 @@ public class ChannelDefBox extends JP2Box {
             int cidx = _module.readUnsignedShort (_dstrm);
             cprop[0] = new Property ("ChannelIndex",
                         PropertyType.INTEGER,
-                        new Integer (cidx));
+                        Integer.valueOf(cidx));
             int typ = _module.readUnsignedShort (_dstrm);
             cprop[1] = _module.addIntegerProperty ("ChannelType", typ,
                     JP2Strings.ctypStr,
@@ -66,7 +66,7 @@ public class ChannelDefBox extends JP2Box {
             // an integer.
             cprop[2] = new Property ("ChannelAssociation",
                         PropertyType.INTEGER,
-                        new Integer (assoc));
+                        Integer.valueOf(assoc));
             chans[i] = new Property ("Channel",
                         PropertyType.PROPERTY,
                         PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/Codestream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/Codestream.java
@@ -193,7 +193,7 @@ public class Codestream extends MainOrTile {
     /** Add a PPM tilepart header length to the list of lengths */
     public void addPPMLength (long len)
     {
-        _ppmLengthList.add (new Long (len));
+        _ppmLengthList.add (Long.valueOf(len));
     }
 
     

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CodestreamRegBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CodestreamRegBox.java
@@ -44,10 +44,10 @@ public class CodestreamRegBox extends JP2Box {
         Property[] propArray = new Property[3];
         propArray[0] = new Property ("HorizontalGridSize",
                     PropertyType.INTEGER,
-                    new Integer (_module.readUnsignedShort (_dstrm)));
+                    Integer.valueOf(_module.readUnsignedShort (_dstrm)));
         propArray[1] = new Property ("VerticalGridSize",
                     PropertyType.INTEGER,
-                    new Integer (_module.readUnsignedShort (_dstrm)));
+                    Integer.valueOf(_module.readUnsignedShort (_dstrm)));
         int bytesLeft = (int) _boxHeader.getDataLength() - 4;
         
         // Each codestream entry is 6 bytes long (a short and 4 bytes)
@@ -58,19 +58,19 @@ public class CodestreamRegBox extends JP2Box {
             Property[] csProp = new Property[5];
             csProp[0] = new Property ("CodestreamNumber",
                     PropertyType.INTEGER,
-                    new Integer (_module.readUnsignedShort (_dstrm)));
+                    Integer.valueOf(_module.readUnsignedShort (_dstrm)));
             csProp[1] = new Property ("HorizontalResolution",
                     PropertyType.INTEGER,
-                    new Integer (ModuleBase.readUnsignedByte (_dstrm, _module)));
+                    Integer.valueOf(ModuleBase.readUnsignedByte (_dstrm, _module)));
             csProp[2] = new Property ("VerticalResolution",
                     PropertyType.INTEGER,
-                    new Integer (ModuleBase.readUnsignedByte (_dstrm, _module)));
+                    Integer.valueOf(ModuleBase.readUnsignedByte (_dstrm, _module)));
             csProp[3] = new Property ("HorizontalOffset",
                     PropertyType.INTEGER,
-                    new Integer (ModuleBase.readUnsignedByte (_dstrm, _module)));
+                    Integer.valueOf(ModuleBase.readUnsignedByte (_dstrm, _module)));
             csProp[4] = new Property ("VerticalOffset",
                     PropertyType.INTEGER,
-                    new Integer (ModuleBase.readUnsignedByte (_dstrm, _module)));
+                    Integer.valueOf(ModuleBase.readUnsignedByte (_dstrm, _module)));
 
             streamsProp[i] = new Property ("Codestreams",
                     PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ColorSpecBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ColorSpecBox.java
@@ -63,7 +63,7 @@ public class ColorSpecBox extends JP2Box {
         int prec = ModuleBase.readUnsignedByte (_dstrm, _module);
         subProps.add (new Property ("Precedence",
                     PropertyType.INTEGER,
-                    new Integer (prec)));
+                    Integer.valueOf(prec)));
         
         // The approx field provides a litmus test for distinguishing
         // a JP2 file from a JPX.  JP2 may have only 0 for this value;
@@ -73,7 +73,7 @@ public class ColorSpecBox extends JP2Box {
             _module.setJPXCompliant (false);
             subProps.add (new Property ("Approx",
                     PropertyType.INTEGER,
-                    new Integer (0)));
+                    Integer.valueOf(0)));
         }
         else {
             _module.setJP2Compliant (false);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ComponentMapBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ComponentMapBox.java
@@ -60,14 +60,14 @@ public class ComponentMapBox extends JP2Box {
             int index = _module.readUnsignedShort (_dstrm);
             cprop[0] = new Property ("ComponentIndex",
                         PropertyType.INTEGER,
-                        new Integer (index));
+                        Integer.valueOf(index));
             int mtyp = ModuleBase.readUnsignedByte (_dstrm, _module);
             cprop[1] = _module.addIntegerProperty ("MTyp", mtyp,
                         JP2Strings.mtypStr);
             int pcol = ModuleBase.readUnsignedByte (_dstrm, _module);
             cprop[2] = new Property ("PaletteComponent",
                         PropertyType.INTEGER,
-                        new Integer (pcol));
+                        Integer.valueOf(pcol));
             parray[i] = new Property ("Component",
                         PropertyType.PROPERTY,
                         PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CompositionBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/CompositionBox.java
@@ -111,13 +111,13 @@ public class CompositionBox extends JP2Box {
         List<Property> propList = new ArrayList<Property> (4);
         propList.add (new Property ("Width",
                 PropertyType.LONG,
-                new Long (_width)));
+                Long.valueOf(_width)));
         propList.add (new Property ("Height",
                 PropertyType.LONG,
-                new Long (_height)));
+                Long.valueOf(_height)));
         propList.add (new Property ("Loop",
                 PropertyType.INTEGER,
-                new Integer (_loop)));
+                Integer.valueOf(_loop)));
         if (!instSets.isEmpty ()) {
             propList.add (new Property ("InstructionSets",
                 PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DDResolutionBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DDResolutionBox.java
@@ -5,9 +5,15 @@
 
 package edu.harvard.hul.ois.jhove.module.jpeg2000;
 
-import java.io.*;
-import java.util.*;
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Default Display Resolution Box.
@@ -53,22 +59,22 @@ public class DDResolutionBox extends JP2Box {
         List hresList = new ArrayList(3);
         vresList.add (new Property ("Numerator",
                 PropertyType.INTEGER,
-                new Integer (_module.readUnsignedShort (_dstrm))));
+                Integer.valueOf(_module.readUnsignedShort (_dstrm))));
         vresList.add (new Property ("Denominator",
                 PropertyType.INTEGER,
-                new Integer (_module.readUnsignedShort (_dstrm))));
+                Integer.valueOf(_module.readUnsignedShort (_dstrm))));
         hresList.add (new Property ("Numerator",
                 PropertyType.INTEGER,
-                new Integer (_module.readUnsignedShort (_dstrm))));
+                Integer.valueOf(_module.readUnsignedShort (_dstrm))));
         hresList.add (new Property ("Denominator",
                 PropertyType.INTEGER,
-                new Integer (_module.readUnsignedShort (_dstrm))));
+                Integer.valueOf(_module.readUnsignedShort (_dstrm))));
         vresList.add (new Property ("Exponent",
                 PropertyType.INTEGER,
-                new Integer (ModuleBase.readSignedByte (_dstrm, _module))));
+                Integer.valueOf(ModuleBase.readSignedByte (_dstrm, _module))));
         hresList.add (new Property ("Exponent",
                 PropertyType.INTEGER,
-                new Integer (ModuleBase.readSignedByte (_dstrm, _module))));
+                Integer.valueOf(ModuleBase.readSignedByte (_dstrm, _module))));
         // The three properties for each direction are subsumed into
         // a property.
         Property hres = new Property ("HorizResolution",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DataEntryURLBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DataEntryURLBox.java
@@ -58,7 +58,7 @@ public class DataEntryURLBox extends JP2Box {
             if (b == 0) {
                 break;
             }
-            byteList.add (new Byte ((byte) b));
+            byteList.add (Byte.valueOf((byte) b));
         }
         // Turn the Byte List into a byte array.  (Is there a better
         // way to do this?)

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DigSignatureBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/DigSignatureBox.java
@@ -78,10 +78,10 @@ public class DigSignatureBox extends JP2Box {
             len = _module.readSignedLong (_dstrm);
             propList.add (new Property ("Offset",
                     PropertyType.LONG,
-                    new Long (off)));
+                    Long.valueOf(off)));
             propList.add (new Property ("Length",
                     PropertyType.LONG,
-                    new Long (len)));
+                    Long.valueOf(len)));
             sizeLeft -= 8;
         }
         
@@ -98,7 +98,7 @@ public class DigSignatureBox extends JP2Box {
                 }
                 propList.add (new Property ("Valid",
                     PropertyType.BOOLEAN,
-                    new Boolean (isSigValid 
+                    Boolean.valueOf(isSigValid
                         (styp, off, len, data))));
             }
             catch (NoSuchAlgorithmException e) { 

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FileTypeBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/FileTypeBox.java
@@ -63,7 +63,7 @@ public class FileTypeBox extends JP2Box {
         long minv = _module.readUnsignedInt(_dstrm);
         _module.addProperty (new Property ("MinorVersion",
                 PropertyType.LONG,
-                new Long (minv)));
+                Long.valueOf(minv)));
         // 16 bytes have been read
         
         // Read the compatibility list.  It takes up the rest

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/GTSOBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/GTSOBox.java
@@ -49,7 +49,7 @@ public class GTSOBox extends JP2Box {
         long propSize = _boxHeader.getDataLength ();
         Property sizeProp = new Property ("ProfileLength",
                 PropertyType.LONG,
-                new Long (propSize));
+                Long.valueOf(propSize));
         _module.addProperty (new Property 
                 ("GraphicsTechnologyStandardOutput",
                  PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ImageHeaderBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ImageHeaderBox.java
@@ -94,7 +94,7 @@ public class ImageHeaderBox extends JP2Box {
         int unk = ModuleBase.readUnsignedByte (_dstrm, _module);
         _module.addProperty (new Property ("ColorspaceUnknown",
                 PropertyType.BOOLEAN,
-                new Boolean (unk != 0)));
+                Boolean.valueOf(unk != 0)));
         
         int ipr = ModuleBase.readUnsignedByte (_dstrm, _module);
         // This just says whether there is an IPR box.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/InstructionSetBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/InstructionSetBox.java
@@ -5,9 +5,14 @@
 
 package edu.harvard.hul.ois.jhove.module.jpeg2000;
 
-import edu.harvard.hul.ois.jhove.*;
-import java.io.*;
-import java.util.*;
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyType;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Instruction Set Box (JPX).
@@ -81,19 +86,19 @@ public class InstructionSetBox extends JP2Box {
                 if (hasXO_YO) {
                     long xo = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("HorizontalOffset",
-                            PropertyType.LONG, new Long (xo)));
+                            PropertyType.LONG, Long.valueOf(xo)));
                     long yo = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("VerticalOffset",
-                            PropertyType.LONG, new Long (yo)));
+                            PropertyType.LONG, Long.valueOf(yo)));
                     sizeLeft -= 8;
                 }
                 if (hasWid_Ht) {
                     long width = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("Width",
-                            PropertyType.LONG, new Long (width)));
+                            PropertyType.LONG, Long.valueOf(width)));
                     long height = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("Height",
-                            PropertyType.LONG, new Long (height)));
+                            PropertyType.LONG, Long.valueOf(height)));
                     sizeLeft -= 8;
                 }
                 if (hasAnimation) {
@@ -101,31 +106,31 @@ public class InstructionSetBox extends JP2Box {
                     // The high bit of life is the persistence flag
                     boolean persist = ((life & 0X80000000) != 0);
                     instProps.add (new Property ("Persist",
-                            PropertyType.BOOLEAN, new Boolean (persist)));
+                            PropertyType.BOOLEAN, Boolean.valueOf(persist)));
                     life &= 0X7FFFFFFF;
                     instProps.add (new Property ("Life",
-                            PropertyType.LONG, new Long (life)));
+                            PropertyType.LONG, Long.valueOf(life)));
 
                     // Sloppy documentation: I'm assuming that N
                     // and NEXT-USE are the same thing.
                     long nextuse = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("NextUse",
-                            PropertyType.LONG, new Long (nextuse)));
+                            PropertyType.LONG, Long.valueOf(nextuse)));
                     sizeLeft -= 8;
                 }
                 if (hasCrop) {
                     long xc = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("HorizontalCropOffset",
-                            PropertyType.LONG, new Long (xc)));
+                            PropertyType.LONG, Long.valueOf(xc)));
                     long yc = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("VerticalCropOffset",
-                            PropertyType.LONG, new Long (yc)));
+                            PropertyType.LONG, Long.valueOf(yc)));
                     long wc = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("CroppedWidth",
-                            PropertyType.LONG, new Long (wc)));
+                            PropertyType.LONG, Long.valueOf(wc)));
                     long hc = _module.readUnsignedInt (_dstrm);
                     instProps.add (new Property ("CroppedHeight",
-                            PropertyType.LONG, new Long (hc)));
+                            PropertyType.LONG, Long.valueOf(hc)));
                     sizeLeft -= 16;
                 }
                 if (sizeLeft < 0) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/MainOrTile.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/MainOrTile.java
@@ -117,6 +117,6 @@ public abstract class MainOrTile {
         if (_packetLengthList == null) {
             _packetLengthList = new LinkedList<Long> ();
         }
-        _packetLengthList.add (new Long (len));
+        _packetLengthList.add (Long.valueOf(len));
     }
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/NumberListBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/NumberListBox.java
@@ -59,7 +59,7 @@ public class NumberListBox extends JP2Box {
                         JP2Strings.numberListTypeStr);
                 p[1] = new Property ("Value",
                         PropertyType.INTEGER,
-                        new Integer (numValue));
+                        Integer.valueOf(numValue));
                 propArray[i] = new Property ("Number",
                         PropertyType.PROPERTY,
                         PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/POCMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/POCMarkerSegment.java
@@ -79,19 +79,19 @@ public class POCMarkerSegment extends MarkerSegment {
             Property[] propArr = new Property[5];
             propArr[0] = new Property ("StartResolutionLevelIndex",
                         PropertyType.INTEGER,
-                        new Integer (rspoc));
+                        Integer.valueOf(rspoc));
             propArr[1] = new Property ("ComponentIndex",
                         PropertyType.INTEGER,
-                        new Integer (cspoc));
+                        Integer.valueOf(cspoc));
             propArr[2] = new Property ("LayerIndex",
                         PropertyType.INTEGER,
-                        new Integer (lyepoc));
+                        Integer.valueOf(lyepoc));
             propArr[3] = new Property ("EndResolutionLevelIndex",
                         PropertyType.INTEGER,
-                        new Integer (cepoc));
+                        Integer.valueOf(cepoc));
             propArr[4] = new Property ("ProgressionOrder",
                         PropertyType.INTEGER,
-                        new Integer (ppoc));
+                        Integer.valueOf(ppoc));
             changes[i] = new Property ("Change",
                         PropertyType.PROPERTY,
                         PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/PaletteBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/PaletteBox.java
@@ -60,13 +60,13 @@ public class PaletteBox extends JP2Box {
         }
         Property[] subProp = new Property[4];
         subProp[0] = new Property ("Entries", PropertyType.INTEGER,
-                new Integer (ne));
+                Integer.valueOf(ne));
         
         int nc = ModuleBase.readUnsignedByte (_dstrm, _module);
         // 3 bytes have been read
         int bytesRead = 3;
         subProp[1] = new Property ("Components", PropertyType.INTEGER,
-                new Integer (nc));
+                Integer.valueOf(nc));
 
         // Each component can, in principle, have a different bit depth,
         // and each can separately be signed or unsigned.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/QCCMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/QCCMarkerSegment.java
@@ -97,7 +97,7 @@ public class QCCMarkerSegment extends MarkerSegment {
         List propList = new ArrayList (2);
         propList.add (new Property ("QuantizationStyle",
                     PropertyType.INTEGER,
-                    new Integer (sqcc)));
+                    Integer.valueOf(sqcc)));
         propList.add (new Property ("StepValue",
                     PropertyType.INTEGER,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/QCDMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/QCDMarkerSegment.java
@@ -73,7 +73,7 @@ public class QCDMarkerSegment extends MarkerSegment {
         List propList = new ArrayList (2);
         propList.add (new Property ("QuantizationStyle",
                     PropertyType.INTEGER,
-                    new Integer (sqcd)));
+                    Integer.valueOf(sqcd)));
         propList.add (new Property ("StepValue",
                     PropertyType.INTEGER,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/RGNMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/RGNMarkerSegment.java
@@ -59,10 +59,10 @@ public class RGNMarkerSegment extends MarkerSegment {
         List propList = new ArrayList (2);
         propList.add (new Property ("ROIStyle", 
                     PropertyType.INTEGER,
-                    new Integer (srgn)));
+                    Integer.valueOf(srgn)));
         propList.add (new Property ("ROIParameter",
                     PropertyType.INTEGER,
-                    new Integer (sprgn)));
+                    Integer.valueOf(sprgn)));
         cs.setCompProperty (compIdx,
                     new Property ("RegionOfInterest",
                             PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ROIBox.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ROIBox.java
@@ -70,24 +70,24 @@ public class ROIBox extends JP2Box {
             int rcp = ModuleBase.readUnsignedByte (_dstrm, _module);
             roiPropList.add (new Property ("CodingPriority",
                         PropertyType.INTEGER,
-                        new Integer (rcp)));
+                        Integer.valueOf(rcp)));
             
             long lcx = _module.readUnsignedInt (_dstrm);
             roiPropList.add (new Property ("HorizontalLocation",
                         PropertyType.LONG,
-                        new Long (lcx)));
+                        Long.valueOf(lcx)));
             long lcy = _module.readUnsignedInt (_dstrm);
             roiPropList.add (new Property ("HorizontalLocation",
                         PropertyType.LONG,
-                        new Long (lcy)));
+                        Long.valueOf(lcy)));
             long wdt = _module.readUnsignedInt (_dstrm);
             roiPropList.add (new Property ("Width",
                         PropertyType.LONG,
-                        new Long (wdt)));
+                        Long.valueOf(wdt)));
             long hth = _module.readUnsignedInt (_dstrm);
             roiPropList.add (new Property ("Height",
                         PropertyType.LONG,
-                        new Long (hth)));
+                        Long.valueOf(hth)));
 
             propList.add (new Property ("ROI",
                     PropertyType.PROPERTY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/SIZMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/SIZMarkerSegment.java
@@ -87,34 +87,34 @@ public class SIZMarkerSegment extends MarkerSegment {
         List plist = new ArrayList (13);
         plist.add (new Property ("Capabilities",
                 PropertyType.INTEGER,
-                new Integer (rsiz)));
+                Integer.valueOf(rsiz)));
         plist.add (new Property ("XSize",
                 PropertyType.INTEGER,
-                new Integer (xsiz)));
+                Integer.valueOf(xsiz)));
         plist.add (new Property ("YSize",
                 PropertyType.INTEGER,
-                new Integer (ysiz)));
+                Integer.valueOf(ysiz)));
         plist.add (new Property ("XOSize",
                 PropertyType.INTEGER,
-                new Integer (xosiz)));
+                Integer.valueOf(xosiz)));
         plist.add (new Property ("YOSize",
                 PropertyType.INTEGER,
-                new Integer (yosiz)));
+                Integer.valueOf(yosiz)));
         plist.add (new Property ("XTSize",
                 PropertyType.INTEGER,
-                new Integer (xtsiz)));
+                Integer.valueOf(xtsiz)));
         plist.add (new Property ("YTSize",
                 PropertyType.INTEGER,
-                new Integer (ytsiz)));
+                Integer.valueOf(ytsiz)));
         plist.add (new Property ("XTOSize",
                 PropertyType.INTEGER,
-                new Integer (xtosiz)));
+                Integer.valueOf(xtosiz)));
         plist.add (new Property ("YTOSize",
                 PropertyType.INTEGER,
-                new Integer (ytosiz)));
+                Integer.valueOf(ytosiz)));
         plist.add (new Property ("CSize",
                 PropertyType.INTEGER,
-                new Integer (csiz)));
+                Integer.valueOf(csiz)));
         plist.add (new Property ("SSize",
                 PropertyType.INTEGER,
                 PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/TLMMarkerSegment.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/TLMMarkerSegment.java
@@ -78,7 +78,7 @@ public class TLMMarkerSegment extends MarkerSegment {
                 }
                 tpList.add (new Property ("Index",
                             PropertyType.INTEGER,
-                            new Integer (ttlm)));
+                            Integer.valueOf(ttlm)));
             }
             int length;
             if (sp == 1) {
@@ -89,7 +89,7 @@ public class TLMMarkerSegment extends MarkerSegment {
             }
             tpList.add (new Property ("Length",
                             PropertyType.INTEGER,
-                            new Integer (length)));
+                            Integer.valueOf(length)));
             _cs.addTileLength (new Property ("TilePartLength",
                             PropertyType.PROPERTY,
                             PropertyArity.LIST,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/Tile.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/Tile.java
@@ -48,7 +48,7 @@ public class Tile extends MainOrTile {
     /** Adds a PPM tilepart header length to the list of lengths */
     public void addPPTLength (long len)
     {
-        _pptLengthList.add (new Long (len));
+        _pptLengthList.add (Long.valueOf(len));
     }
 
     /** Returns a Property describing the tile.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/TilePart.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/TilePart.java
@@ -47,10 +47,10 @@ public class TilePart {
     {
         Property indexProp = new Property ("Index",
                 PropertyType.INTEGER,
-                new Integer (_index));
+                Integer.valueOf(_index));
         Property lengthProp = new Property ("Length",
                 PropertyType.LONG,
-                new Long (_length));
+                Long.valueOf(_length));
         List propList = new ArrayList (2);
         propList.add (indexProp);
         propList.add (lengthProp);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Hexadecimal.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Hexadecimal.java
@@ -13,7 +13,8 @@ package edu.harvard.hul.ois.jhove.module.pdf;
  *
  *  @deprecated
  */
- public class Hexadecimal
+@Deprecated
+public class Hexadecimal
     extends Literal
 {
     /** Creates an instance of a hexadecimal string literal */

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Literal.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Literal.java
@@ -119,7 +119,7 @@ public class Literal
             _rawBytes = new Vector<> (32);
         }
         if (haveHi) {
-            _rawBytes.add(new Integer (hexToInt (hi, ch)));
+            _rawBytes.add(Integer.valueOf(hexToInt (hi, ch)));
             haveHi = false;
         }
         else {
@@ -160,7 +160,7 @@ public class Literal
                 throw new EOFException (MessageConstants.ERR_LITERAL_UNTERMINATED); // PDF-HUL-10
             }
             offset++;
-            _rawBytes.add (new Integer (ch));
+            _rawBytes.add (Integer.valueOf(ch));
 
             if (_state == State.LITERAL) {
                 // We are still in a state of flux, determining the encoding
@@ -309,7 +309,7 @@ public class Literal
             StringBuffer localBuffer = new StringBuffer();
             // If a high byte is left hanging, complete it with a '0'
             if (haveHi) {
-                _rawBytes.add(new Integer(hexToInt(hi, '0')));
+                _rawBytes.add(Integer.valueOf(hexToInt(hi, '0')));
             }
             if (_rawBytes.size() >= 2 && rawByte(0) == 0XFE &&
                     rawByte(1) == 0XFF) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/ObjectStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/ObjectStream.java
@@ -107,8 +107,8 @@ public class ObjectStream {
              * I don't know what the restrictions, if any, are on
              * the white space.
              */
-            Integer onum = new Integer (strm.readAsciiInt ());
-            Integer offset = new Integer (strm.readAsciiInt ());
+            Integer onum = Integer.valueOf(strm.readAsciiInt ());
+            Integer offset = Integer.valueOf(strm.readAsciiInt ());
             _index.put (onum, offset);
         }
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfIndirectObj.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfIndirectObj.java
@@ -42,7 +42,7 @@ public class PdfIndirectObj extends PdfObject
         }
         long key = ((long) _objNumber << 32) +
             (_genNumber & 0XFFFFFFFFL);
-        _cachedObject = _objectMap.get (new Long (key));
+        _cachedObject = _objectMap.get (Long.valueOf(key));
         return _cachedObject;
     }
 }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/ExifIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/ExifIFD.java
@@ -328,11 +328,11 @@ public class ExifIFD
         }
         if (_pixelXDimension != NULL) {
             entries.add (new Property ("PixelXDimension", PropertyType.LONG,
-                                       new Long (_pixelXDimension)));
+                                       Long.valueOf(_pixelXDimension)));
         }
         if (_pixelYDimension != NULL) {
             entries.add (new Property ("PixelYDimension", PropertyType.LONG,
-                                       new Long (_pixelYDimension)));
+                                       Long.valueOf(_pixelYDimension)));
         }
         if (_makerNote != null) {
             entries.add (new Property ("MakerNote", PropertyType.INTEGER,
@@ -516,7 +516,7 @@ public class ExifIFD
         if (_focalLengthIn35mmFilm != NULL) {
             entries.add (new Property ("FocalLengthIn35mmFilm",
                                        PropertyType.INTEGER,
-                                       new Integer (_focalLengthIn35mmFilm)));
+                                       Integer.valueOf(_focalLengthIn35mmFilm)));
         }
         if (_sceneCaptureType != NULL) {
             entries.add (addIntegerProperty ("SceneCaptureType",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/GPSInfoIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/GPSInfoIFD.java
@@ -390,7 +390,7 @@ public class GPSInfoIFD
 				       PropertyArity.ARRAY, _gpsLongitude));
 	}
 	entries.add(new Property("GPSAltitudeRef", PropertyType.INTEGER,
-				   new Integer(_gpsAltitudeRef)));
+				   Integer.valueOf(_gpsAltitudeRef)));
 	if (_gpsAltitude != null) {
 	    entries.add(new Property("GPSAltitude", PropertyType.RATIONAL,
 				       _gpsAltitude));
@@ -496,7 +496,7 @@ public class GPSInfoIFD
 				       _gpsDateStamp));
 	}
 	entries.add(new Property("GPSDifferential", PropertyType.INTEGER,
-				   new Integer(_gpsDifferential)));
+				   Integer.valueOf(_gpsDifferential)));
 
 	return propertyHeader("GPSInfo", entries);
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/GlobalParametersIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/GlobalParametersIFD.java
@@ -113,7 +113,7 @@ public class GlobalParametersIFD extends IFD {
         if (_modeNumber != NULL) {
             entries.add (new Property ("ModeNumber",
                             PropertyType.INTEGER,
-                            new Integer (_modeNumber)));
+                            Integer.valueOf(_modeNumber)));
         }
         return propertyHeader ("GlobalParameterIFD", entries);
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
@@ -374,7 +374,7 @@ public abstract class IFD
                                 PropertyArity.LIST, list);
         }
         if (prop == null) {
-            prop = new Property(name, PropertyType.LONG, new Long(value));
+            prop = new Property(name, PropertyType.LONG, Long.valueOf(value));
         }
 
         return prop;
@@ -403,7 +403,7 @@ public abstract class IFD
         }
         if (prop == null) {
             prop = new Property(name, PropertyType.INTEGER,
-                                 new Integer(value));
+                                 Integer.valueOf(value));
         }
 
         return prop;
@@ -441,7 +441,7 @@ public abstract class IFD
         }
         if (prop == null) {
             prop = new Property(name, PropertyType.INTEGER,
-                                 new Integer(value));
+                                 Integer.valueOf(value));
         }
 
         return prop;
@@ -534,7 +534,7 @@ public abstract class IFD
     {
         Property [] array = new Property [3];
         array[0] = new Property("Offset", PropertyType.LONG,
-                                 new Long(_offset));
+                                 Long.valueOf(_offset));
         array[1] = new Property("Type", PropertyType.STRING, type);
         array[2] = new Property("Entries", PropertyType.PROPERTY,
                                  PropertyArity.LIST, entries);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
@@ -1380,7 +1380,7 @@ public class TiffIFD
         else {
             // if 0, always report as a raw number
             entries.add (new Property ("NewSubfileType", PropertyType.LONG,
-                                    new Long (_newSubfileType)));
+                                    Long.valueOf (_newSubfileType)));
         }
         if (_subfileType != NULL && (_subfileType != 0 || rawOutput)) {
             entries.add (addIntegerProperty ("SubfileType", _subfileType - 1,
@@ -1389,7 +1389,7 @@ public class TiffIFD
         else if (_subfileType != NULL) {
             // if 0, always report as a raw number
             entries.add (new Property ("SubfileType", PropertyType.LONG,
-                                    new Long (_subfileType)));
+                                    Long.valueOf (_subfileType)));
         }
         if (_documentName != null) {
             entries.add (new Property ("DocmentName", PropertyType.STRING,
@@ -1435,7 +1435,7 @@ public class TiffIFD
         }
         if (_numberOfInks != NULL) {
             entries.add (new Property ("NumberOfInks", PropertyType.INTEGER,
-                                   new Integer (_numberOfInks)));
+                                   Integer.valueOf (_numberOfInks)));
         }
         if (_inkNames != null) {
             entries.add (new Property ("InkNames", PropertyType.STRING,
@@ -1455,33 +1455,33 @@ public class TiffIFD
         }
         if (_cellLength != NULL) {
             entries.add (new Property ("CellLength", PropertyType.INTEGER,
-                                   new Integer (_cellLength)));
+                                   Integer.valueOf(_cellLength)));
         }
         if (_cellWidth != NULL) {
             entries.add (new Property ("CellWidth", PropertyType.INTEGER,
-                                   new Integer (_cellWidth)));
+                                   Integer.valueOf(_cellWidth)));
         }
         if (_transferFunction) {
             entries.add (new Property ("TransferFunction", PropertyType.BOOLEAN,
-                                   new Boolean (true)));
+                                   Boolean.valueOf(true)));
         }
         if (_transferRange != null) {
             entries.add (new Property ("TransferRange", PropertyType.INTEGER,
                                    PropertyArity.ARRAY, _transferRange));
         }
         entries.add (new Property ("Threshholding", PropertyType.INTEGER,
-                                   new Integer (_threshholding)));
+                                   Integer.valueOf(_threshholding)));
         if (_predictor != NULL) {
             entries.add (addIntegerProperty ("Predictor", _predictor,
                                          PREDICTOR_L, rawOutput));
         }
         if (_t4Options != NULL) {
             entries.add (new Property ("T4Options", PropertyType.LONG,
-                                   new Long (_t4Options)));
+                                   Long.valueOf(_t4Options)));
         }
         if (_t6Options != NULL) {
             entries.add (new Property ("T6Options", PropertyType.LONG,
-                                   new Long (_t6Options)));
+                                   Long.valueOf(_t6Options)));
         }
         if (_jpegProc != NULL) {
             entries.add (addIntegerProperty ("JPEGProc", _jpegProc,
@@ -1491,17 +1491,17 @@ public class TiffIFD
         if (_jpegInterchangeFormat != NULL) {
             entries.add (new Property ("JPEGInterchangeFormat",
                                        PropertyType.LONG,
-                                       new Long (_jpegInterchangeFormat)));
+                                       Long.valueOf(_jpegInterchangeFormat)));
         }
         if (_jpegInterchangeFormatLength != NULL) {
             entries.add (new Property ("JPEGInterchangeFormatLength",
                                        PropertyType.LONG,
-                                       new Long (_jpegInterchangeFormatLength)));
+                                       Long.valueOf(_jpegInterchangeFormatLength)));
         }
         if (_jpegRestartInterval != NULL) {
             entries.add (new Property ("JPEGRestartInterval",
                                        PropertyType.INTEGER,
-                                       new Integer (_jpegRestartInterval)));
+                                       Integer.valueOf(_jpegRestartInterval)));
         }
         if (_jpegLosslessPredictors != null) {
             entries.add (addIntegerArrayProperty ("JPEGLosslessPredictors",
@@ -1549,24 +1549,24 @@ public class TiffIFD
         }
         if (_xClipPathUnits != NULL) {
             entries.add (new Property ("XClipPathUnits", PropertyType.LONG,
-                                       new Long (_xClipPathUnits)));
+                                       Long.valueOf(_xClipPathUnits)));
         }
         if (_yClipPathUnits != NULL) {
             entries.add (new Property ("YClipPathUnits", PropertyType.LONG,
-                                       new Long (_yClipPathUnits)));
+                                       Long.valueOf(_yClipPathUnits)));
         }
         if (_cleanFaxData != NULL) {
             entries.add (new Property ("CleanFaxData", PropertyType.LONG,
-                                       new Long (_cleanFaxData)));
+                                       Long.valueOf(_cleanFaxData)));
         }
         if (_badFaxLines != NULL) {
             entries.add (new Property ("BadFaxLines", PropertyType.LONG,
-                                       new Long (_badFaxLines)));
+                                       Long.valueOf(_badFaxLines)));
         }
         if (_consecutiveBadFaxLines != NULL) {
             entries.add (new Property ("ConsecutiveBadFaxLines",
                                        PropertyType.LONG,
-                                       new Long (_consecutiveBadFaxLines)));
+                                       Long.valueOf(_consecutiveBadFaxLines)));
         }
         if (_freeByteCounts != null) {
             entries.add (new Property ("FreeByteCounts", PropertyType.LONG,
@@ -1597,7 +1597,7 @@ public class TiffIFD
         if (_backgroundColorValue != NULL) {
             itList.add (new Property ("BackgroundColorValue",
                                       PropertyType.INTEGER,
-                                      new Integer (_backgroundColorValue)));
+                                      Integer.valueOf(_backgroundColorValue)));
         }
         itList.add (addIntegerProperty ("ImageColorIndicator",
                                         _imageColorIndicator,
@@ -1607,7 +1607,7 @@ public class TiffIFD
                                         TRANSPARENCYINDICATOR_L, rawOutput));
         if (_imageColorValue != NULL) {
             itList.add (new Property ("ImageColorValue", PropertyType.INTEGER,
-                                      new Integer (_imageColorValue)));
+                                      Integer.valueOf(_imageColorValue)));
         }
         if (_colorCharacterization != null) {
             itList.add (new Property ("ColorCharacterization",
@@ -1635,10 +1635,10 @@ public class TiffIFD
         itList.add (addIntegerProperty ("RasterPadding", _rasterPadding,
                                         RASTERPADDING_L, rawOutput));
         itList.add (new Property ("BitsPerRunLength", PropertyType.INTEGER,
-                                  new Integer (_bitsPerRunLength)));
+                                  Integer.valueOf(_bitsPerRunLength)));
         itList.add (new Property ("BitsPerExtendedRunLength",
                                   PropertyType.INTEGER,
-                                  new Integer (_bitsPerExtendedRunLength)));
+                                  Integer.valueOf(_bitsPerExtendedRunLength)));
         entries.add (new Property ("TIFFITProperties", PropertyType.PROPERTY,
                                    PropertyArity.LIST, itList));
     }
@@ -1692,7 +1692,7 @@ public class TiffIFD
         }
         if (_interlace != NULL)  {
             epList.add (new Property ("Interlace", PropertyType.INTEGER,
-                                      new Integer (_interlace)));
+                                      Integer.valueOf(_interlace)));
         }
         if (_timeZoneOffset != null)  {
             epList.add (new Property ("TimeZoneOffset", PropertyType.INTEGER,
@@ -1700,7 +1700,7 @@ public class TiffIFD
         }
         if (_selfTimerMode != NULL)  {
             epList.add (new Property ("SelfTimerMode", PropertyType.INTEGER,
-                                      new Integer (_selfTimerMode)));
+                                      Integer.valueOf(_selfTimerMode)));
         }
         if (_compressedBitsPerPixel != null)  {
             epList.add (addRationalProperty ("CompressedBitsPerPixel",
@@ -1751,7 +1751,7 @@ public class TiffIFD
         }
         if (_imageNumber != NULL) {
             epList.add (new Property ("ImageNumber", PropertyType.LONG,
-                                      new Long (_imageNumber)));
+                                      Long.valueOf(_imageNumber)));
         }
         if (_securityClassification != null) {
             epList.add (new Property ("SecurityClassification",
@@ -1791,12 +1791,12 @@ public class TiffIFD
         List<Property> dirList = new LinkedList<Property> ();
         if (_geoKeyDirectoryTag != null) {
             dirList.add (new Property ("Version", PropertyType.INTEGER,
-                                       new Integer (_geoKeyDirectoryTag[0])));
+                                       Integer.valueOf(_geoKeyDirectoryTag[0])));
             dirList.add (new Property ("Revision", PropertyType.STRING,
                                Integer.toString (_geoKeyDirectoryTag[1]) + "."+
                                Integer.toString (_geoKeyDirectoryTag[2])));
             dirList.add (new Property ("NumberOfKeys", PropertyType.INTEGER,
-                                       new Integer (_geoKeyDirectoryTag[3])));
+                                       Integer.valueOf(_geoKeyDirectoryTag[3])));
             for (int i=0; i<_geoKeyDirectoryTag[3]; i++) {
                 int j = i*4 + 4;
                 int key      = _geoKeyDirectoryTag[j];
@@ -1863,7 +1863,7 @@ public class TiffIFD
                 else if (key == GEOGPRIMEMERIDIANLONGGEOKEY) {
                     dirList.add (new Property ("GeogPrimeMeridianLong",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGLINEARUNITSGEOKEY) {
                     dirList.add (addIntegerProperty ("GeogLinearUnits", ival,
@@ -1874,7 +1874,7 @@ public class TiffIFD
                 else if (key == GEOGLINEARUNITSIZEGEOKEY) {
                     dirList.add (new Property ("GeogLinearUnitSize",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGANGULARUNITSGEOKEY) {
                     dirList.add (addIntegerProperty ("GeogAngularUnits", ival,
@@ -1885,7 +1885,7 @@ public class TiffIFD
                 else if (key == GEOGANGULARUNITSIZEGEOKEY) {
                     dirList.add (new Property ("GeogAngularUnitSize",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGELLIPSOIDGEOKEY) {
                     dirList.add (addIntegerProperty ("GeogEllipsoid", ival,
@@ -1896,17 +1896,17 @@ public class TiffIFD
                 else if (key == GEOGSEMIMAJORAXISGEOKEY) {
                     dirList.add (new Property ("GeogSemiMajorAxis",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGSEMIMINORAXISGEOKEY) {
                     dirList.add (new Property ("GeogSemiMinorAxis",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGINVFLATTENINGGEOKEY) {
                     dirList.add (new Property ("GeogInvFlattening",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == GEOGAZIMUTHUNITSGEOKEY) {
                     dirList.add (addIntegerProperty ("GeogAzimuthUnits", ival,
@@ -1945,93 +1945,93 @@ public class TiffIFD
                 else if (key == PROJLINEARUNITSIZEGEOKEY) {
                     dirList.add (new Property ("ProjLinearUnitSize",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJSTDPARALLEL1GEOKEY) {
                     dirList.add (new Property ("ProjStdParallel1",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJSTDPARALLEL2GEOKEY) {
                     dirList.add (new Property ("ProjStdParallel2",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJNATORIGINLONGGEOKEY) {
                     dirList.add (new Property ("ProjNatOriginLong",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJNATORIGINLATGEOKEY) {
                     dirList.add (new Property ("ProjNatOriginLat",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSEEASTINGGEOKEY) {
                     dirList.add (new Property ("ProjFalseEasting",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSENORTHINGGEOKEY) {
                     dirList.add (new Property ("ProjFalseNorthing",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSEORIGINLONGGEOKEY) {
                     dirList.add (new Property ("ProjFalseOriginLong",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSEORIGINLATGEOKEY) {
                     dirList.add (new Property ("ProjFalseOriginLat",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSEORIGINEASTINGGEOKEY) {
                     dirList.add (new Property ("ProjFalseOriginEasting",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJFALSEORIGINNORTHINGGEOKEY ||
                          key == PROJFALSEORIGINNORTHINGGEOKEY_2) {
                     dirList.add (new Property ("ProjFalseOriginNorthing",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJCENTERLONGGEOKEY) {
                     dirList.add (new Property ("ProjCenterLong",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJCENTERLATGEOKEY) {
                     dirList.add (new Property ("ProjCenterLat",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJCENTEREASTINGGEOKEY) {
                     dirList.add (new Property ("ProjCenterEasting",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJSCALEATNATORIGINGEOKEY) {
                     dirList.add (new Property ("ProjScaleAtNatOrigin",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJSCALEATCENTERGEOKEY) {
                     dirList.add (new Property ("ProjScaleAtCenter",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJAZIMUTHANGLEGEOKEY) {
                     dirList.add (new Property ("ProjAzimuthAngle",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == PROJSTRAIGHTVERTPOLELONGEOKEY) {
                     dirList.add (new Property ("ProjStraightVertPoleLong",
                                                PropertyType.DOUBLE,
-                                               new Double (dval)));
+                                               Double.valueOf(dval)));
                 }
                 else if (key == VERTICALCSTYPEGEOKEY) {
                     dirList.add (addIntegerProperty ("VerticalCSType", ival,
@@ -2106,7 +2106,7 @@ public class TiffIFD
                                 rawOutput);
                 layerProps[1] = new Property ("OrdinalNumber",
                                 PropertyType.INTEGER,
-                                new Integer (_imageLayer[1]));
+                                Integer.valueOf(_imageLayer[1]));
 
                 entries.add (new Property ("ImageLayer",
                                            PropertyType.PROPERTY,
@@ -2217,12 +2217,12 @@ public class TiffIFD
         if (_calibrationIlluminant1 != NULL) {
             dngList.add (new Property ("CalibrationIlluminant1",
                     PropertyType.INTEGER,
-                    new Integer (_calibrationIlluminant1)));
+                    Integer.valueOf(_calibrationIlluminant1)));
         }
         if (_calibrationIlluminant2 != NULL) {
             dngList.add (new Property ("CalibrationIlluminant2",
                     PropertyType.INTEGER,
-                    new Integer (_calibrationIlluminant2)));
+                    Integer.valueOf(_calibrationIlluminant2)));
         }
         if (_colorMatrix1 != null) {
             dngList.add (new Property ("ColorMatrix1",
@@ -2296,7 +2296,7 @@ public class TiffIFD
         if (_bayerGreenSplit != NULL) {
             dngList.add (new Property ("BayerGreenSplit",
                     PropertyType.INTEGER,
-                    new Integer (_bayerGreenSplit)));
+                    Integer.valueOf(_bayerGreenSplit)));
         }
         if (_linearResponseLimit != null) {
             dngList.add (new Property ("LinearResponseLimit",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/BroadcastExtChunk.java
@@ -5,12 +5,17 @@
 
 package edu.harvard.hul.ois.jhove.module.wave;
 
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.AESAudioMetadata;
+import edu.harvard.hul.ois.jhove.InfoMessage;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.RepInfo;
 import edu.harvard.hul.ois.jhove.module.WaveModule;
 import edu.harvard.hul.ois.jhove.module.iff.Chunk;
 import edu.harvard.hul.ois.jhove.module.iff.ChunkHeader;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -213,10 +218,10 @@ public class BroadcastExtChunk extends Chunk {
         }
 
         if (extendedUmidExists) {
-            formattedUmid = DatatypeConverter.printHexBinary(umid);
+            formattedUmid = HexPrinter.printHexBinary(umid);
         }
         else if (basicUmidExists) {
-            formattedUmid = DatatypeConverter.printHexBinary(basicUmid);
+            formattedUmid = HexPrinter.printHexBinary(basicUmid);
         }
 
         return formattedUmid;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/CartChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/CartChunk.java
@@ -100,7 +100,7 @@ public class CartChunk extends Chunk {
                         timerTagUsage);
                 ttprop[1] = new Property ("Value",
                         PropertyType.LONG,
-                        new Long (timerTagValue));
+                        Long.valueOf(timerTagValue));
                 
                 timerTags.add (new Property ("PostTimer",
                         PropertyType.PROPERTY,
@@ -173,7 +173,7 @@ public class CartChunk extends Chunk {
             plist.add (new Property ("UserDef", PropertyType.STRING, userDef));
         }
         plist.add (new Property ("LevelReference", PropertyType.INTEGER,
-                new Integer (levelReference)));
+                Integer.valueOf(levelReference)));
         if (timerTags.size() > 0) {
             plist.add (new Property ("PostTimers", PropertyType.PROPERTY,
                 PropertyArity.LIST,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/DataChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/DataChunk.java
@@ -52,7 +52,7 @@ public class DataChunk extends Chunk {
         WaveModule module = (WaveModule) _module;
         Property lenProp = new Property ("DataLength",
                 PropertyType.LONG,
-                new Long (bytesLeft));
+                Long.valueOf(bytesLeft));
         // The behavior will be different if we are reading this under
         // a 'wavl' chunk.
         

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/FormatChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/FormatChunk.java
@@ -5,12 +5,16 @@
 
 package edu.harvard.hul.ois.jhove.module.wave;
 
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.AESAudioMetadata;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.RepInfo;
 import edu.harvard.hul.ois.jhove.module.WaveModule;
 import edu.harvard.hul.ois.jhove.module.iff.Chunk;
 import edu.harvard.hul.ois.jhove.module.iff.ChunkHeader;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -258,23 +262,23 @@ public class FormatChunk extends Chunk {
         StringBuilder guid = new StringBuilder(36);
 
         byte[] doubleWord = reverseBytes(Arrays.copyOf(guidBytes, 4));
-        guid.append(DatatypeConverter.printHexBinary(doubleWord));
+        guid.append(HexPrinter.printHexBinary(doubleWord));
         guid.append("-");
 
         byte[] word = reverseBytes(Arrays.copyOfRange(guidBytes, 4, 6));
-        guid.append(DatatypeConverter.printHexBinary(word));
+        guid.append(HexPrinter.printHexBinary(word));
         guid.append("-");
 
         word = reverseBytes(Arrays.copyOfRange(guidBytes, 6, 8));
-        guid.append(DatatypeConverter.printHexBinary(word));
+        guid.append(HexPrinter.printHexBinary(word));
         guid.append("-");
 
         byte[] bytes = Arrays.copyOfRange(guidBytes, 8, 10);
-        guid.append(DatatypeConverter.printHexBinary(bytes));
+        guid.append(HexPrinter.printHexBinary(bytes));
         guid.append("-");
 
         bytes = Arrays.copyOfRange(guidBytes, 10, 16);
-        guid.append(DatatypeConverter.printHexBinary(bytes));
+        guid.append(HexPrinter.printHexBinary(bytes));
 
         return guid.toString();
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/HexPrinter.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/HexPrinter.java
@@ -1,0 +1,23 @@
+package edu.harvard.hul.ois.jhove.module.wave;
+
+import java.util.Objects;
+
+/**
+ * This class implements functionality that is removed in java9+ jres
+ * -> javax.xml.bind.DatatypeConverter
+ */
+class HexPrinter {
+
+    private HexPrinter() {}
+
+    public static String printHexBinary(byte[] value) {
+        if(Objects.isNull(value)) {
+            throw new IllegalArgumentException("value was null!");
+        }
+        String ret = "";
+        for(byte v:value) {
+            ret += String.format("%02X", v);
+        }
+        return ret;
+    }
+}

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/InstrumentChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/InstrumentChunk.java
@@ -5,12 +5,17 @@
 
 package edu.harvard.hul.ois.jhove.module.wave;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.RepInfo;
 import edu.harvard.hul.ois.jhove.module.WaveModule;
 import edu.harvard.hul.ois.jhove.module.iff.Chunk;
 import edu.harvard.hul.ois.jhove.module.iff.ChunkHeader;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 /**
  * Implementation of the WAVE Instrument Chunk, which
@@ -57,19 +62,19 @@ public class InstrumentChunk extends Chunk {
         
         Property[] propArr = new Property[7];
         propArr[0] = new Property ("UnshiftedNote", PropertyType.INTEGER,
-                    new Integer (unshiftedNote));
+                    Integer.valueOf(unshiftedNote));
         propArr[1] = new Property ("FineTune", PropertyType.INTEGER,
-                    new Integer (fineTune));
+                    Integer.valueOf(fineTune));
         propArr[2] = new Property ("Gain", PropertyType.INTEGER,
-                    new Integer (gain));
+                    Integer.valueOf(gain));
         propArr[3] = new Property ("LowNote", PropertyType.INTEGER,
-                    new Integer (lowNote));
+                    Integer.valueOf(lowNote));
         propArr[4] = new Property ("HighNote", PropertyType.INTEGER,
-                    new Integer (highNote));
+                    Integer.valueOf(highNote));
         propArr[5] = new Property ("LowVelocity", PropertyType.INTEGER,
-                    new Integer (lowVelocity));
+                    Integer.valueOf(lowVelocity));
         propArr[6] = new Property ("HighVelocity", PropertyType.INTEGER,
-                    new Integer (highVelocity));
+                    Integer.valueOf(highVelocity));
         module.addWaveProperty (new Property ("Instrument",
                     PropertyType.PROPERTY,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/LabeledTextChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/LabeledTextChunk.java
@@ -62,19 +62,19 @@ public class LabeledTextChunk extends Chunk {
         // Make the information into a Property.
         List plist = new ArrayList (10);
         plist.add (new Property ("CuePointID", PropertyType.LONG,
-                new Long (cuePointID)));
+                Long.valueOf(cuePointID)));
         plist.add (new Property ("SampleLength", PropertyType.LONG,
-                new Long (sampleLength)));
+                Long.valueOf(sampleLength)));
         plist.add (new Property ("PurposeID", PropertyType.LONG,
-                new Long (purposeID)));
+                Long.valueOf(purposeID)));
         plist.add (new Property ("Country", PropertyType.INTEGER,
-                new Integer (country)));
+                Integer.valueOf(country)));
         plist.add (new Property ("Language", PropertyType.INTEGER,
-                new Integer (language)));
+                Integer.valueOf(language)));
         plist.add (new Property ("Dialect", PropertyType.INTEGER,
-                new Integer (dialect)));
+                Integer.valueOf(dialect)));
         plist.add (new Property ("CodePage", PropertyType.INTEGER,
-                new Integer (codePage)));
+                Integer.valueOf(codePage)));
         plist.add (new Property ("Text", PropertyType.STRING,
                 text));
         module.addLabeledText(new Property ("LabeledTextItem",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/MpegChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/MpegChunk.java
@@ -58,10 +58,10 @@ public class MpegChunk extends Chunk {
                 WaveStrings.SOUND_INFORMATION_0));
         propList.add (new Property ("FrameSize",
                 PropertyType.INTEGER,
-                new Integer (frameSize)));
+                Integer.valueOf(frameSize)));
         propList.add (new Property ("AncillaryDataLength",
                 PropertyType.INTEGER,
-                new Integer (ancillaryDataLength)));
+                Integer.valueOf(ancillaryDataLength)));
         propList.add (module.buildBitmaskProperty(ancillaryDataDef,
                 "AncillaryDataDef",
                 WaveStrings.ANCILLARY_DEF_1,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/PeakEnvelopeChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/PeakEnvelopeChunk.java
@@ -146,28 +146,28 @@ public class PeakEnvelopeChunk extends Chunk {
         List plist = new ArrayList (20);
         plist.add (new Property ("Version",
                 PropertyType.LONG,
-                new Long (version)));
+                Long.valueOf(version)));
         plist.add (new Property ("Format",
                 PropertyType.LONG,
-                new Long (format)));
+                Long.valueOf(format)));
         plist.add (new Property ("PointsPerValue",
                 PropertyType.LONG,
-                new Long (pointsPerValue)));
+                Long.valueOf(pointsPerValue)));
         plist.add (new Property ("BlockSize",
                 PropertyType.LONG,
-                new Long (blockSize)));
+                Long.valueOf(blockSize)));
         plist.add (new Property ("PeakChannels",
                 PropertyType.LONG,
-                new Long (peakChannels)));
+                Long.valueOf(peakChannels)));
         plist.add (new Property ("NumPeakFrames",
                 PropertyType.LONG,
-                new Long (numPeakFrames)));
+                Long.valueOf(numPeakFrames)));
         plist.add (new Property ("PosPeakOfPeaks",
                 PropertyType.LONG,
-                new Long (posPeakOfPeaks)));
+                Long.valueOf(posPeakOfPeaks)));
         plist.add (new Property ("OffsetToPeaks",
                 PropertyType.LONG,
-                new Long (offsetToPeaks)));
+                Long.valueOf(offsetToPeaks)));
         if (timestamp.length () > 0) {
             plist.add (new Property ("Timestamp",
                 PropertyType.STRING,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SampleChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SampleChunk.java
@@ -5,12 +5,17 @@
 
 package edu.harvard.hul.ois.jhove.module.wave;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import edu.harvard.hul.ois.jhove.*;
+import edu.harvard.hul.ois.jhove.ModuleBase;
+import edu.harvard.hul.ois.jhove.Property;
+import edu.harvard.hul.ois.jhove.PropertyArity;
+import edu.harvard.hul.ois.jhove.PropertyType;
+import edu.harvard.hul.ois.jhove.RepInfo;
 import edu.harvard.hul.ois.jhove.module.WaveModule;
 import edu.harvard.hul.ois.jhove.module.iff.Chunk;
 import edu.harvard.hul.ois.jhove.module.iff.ChunkHeader;
+
+import java.io.DataInputStream;
+import java.io.IOException;
 
 /**
  * Implementation of the WAVE Sample (or Sampler) Chunk, which
@@ -72,13 +77,13 @@ public class SampleChunk extends Chunk {
                      // Or should it be unsigned??
         Property[] smpteArr = new Property[4];
         smpteArr[0] = new Property ("Hour", PropertyType.INTEGER,
-                new Integer (sampleOffsetHour));
+                Integer.valueOf(sampleOffsetHour));
         smpteArr[1] = new Property ("Minute", PropertyType.INTEGER,
-                new Integer (sampleOffsetMinute));
+                Integer.valueOf(sampleOffsetMinute));
         smpteArr[2] = new Property ("Second", PropertyType.INTEGER,
-                new Integer (sampleOffsetSecond));
+                Integer.valueOf(sampleOffsetSecond));
         smpteArr[3] = new Property ("Frames", PropertyType.INTEGER,
-                new Integer (sampleOffsetFrames));
+                Integer.valueOf(sampleOffsetFrames));
 
         int nLoops = (int) module.readUnsignedInt (_dstream);
         long extraBytes = module.readUnsignedInt (_dstream);  // no. of extra bytes after loops
@@ -96,17 +101,17 @@ public class SampleChunk extends Chunk {
             // Build the loop property.
             Property[] lp = new Property[6];
             lp[0] = new Property ("CuePointID", PropertyType.LONG,
-                    new Long (cuePoint));
+                    Long.valueOf(cuePoint));
             lp[1] = new Property ("Type", PropertyType.INTEGER,
-                    new Integer (type));
+                    Integer.valueOf(type));
             lp[2] = new Property ("Start", PropertyType.INTEGER,
-                    new Integer (start));
+                    Integer.valueOf(start));
             lp[3] = new Property ("End", PropertyType.INTEGER,
-                    new Integer (end));
+                    Integer.valueOf(end));
             lp[4] = new Property ("Fraction", PropertyType.LONG,
-                    new Long (fraction));
+                    Long.valueOf(fraction));
             lp[5] = new Property ("PlayCount", PropertyType.LONG,
-                    new Long (playCount));
+                    Long.valueOf(playCount));
             loopProps[i] = new Property ("Loop",
                     PropertyType.PROPERTY,
                     PropertyArity.ARRAY,
@@ -115,17 +120,17 @@ public class SampleChunk extends Chunk {
         
         Property[] propArr = new Property[9];
         propArr[0] = new Property ("Manufacturer", PropertyType.LONG,
-                    new Long (manufacturer));
+                    Long.valueOf(manufacturer));
         propArr[1] = new Property ("Product", PropertyType.LONG,
-                    new Long (product));
+                    Long.valueOf(product));
         propArr[2] = new Property ("SamplePeriod", PropertyType.LONG,
-                    new Long (samplePeriod));
+                    Long.valueOf(samplePeriod));
         propArr[3] = new Property ("UnityNote", PropertyType.LONG,
-                    new Long (unityNote));
+                    Long.valueOf(unityNote));
         propArr[4] = new Property ("PitchFraction", PropertyType.LONG,
-                    new Long (pitchFraction));
+                    Long.valueOf(pitchFraction));
         propArr[5] = new Property ("SMPTEFormat", PropertyType.LONG,
-                    new Long (smpteFormat));
+                    Long.valueOf(smpteFormat));
         propArr[6] = new Property ("SMPTEOffset", PropertyType.PROPERTY,
                     PropertyArity.ARRAY,
                     smpteArr);
@@ -133,7 +138,7 @@ public class SampleChunk extends Chunk {
                     PropertyArity.ARRAY,
                     loopProps);
         propArr[8] = new Property ("ExtraDataBytes", PropertyType.LONG,
-                    new Long (extraBytes));
+                    Long.valueOf(extraBytes));
         module.addSample (new Property ("Sample",
                     PropertyType.PROPERTY,
                     PropertyArity.ARRAY,

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SimpleTextChunk.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/wave/SimpleTextChunk.java
@@ -49,7 +49,7 @@ public abstract class SimpleTextChunk extends Chunk {
         Property[] propArr = new Property[2];
         propArr[0] = new Property ("CuePointID",
                 PropertyType.LONG,
-                new Long (cueID));
+                Long.valueOf(cueID));
         propArr[1] = new Property ("Text",
                 PropertyType.STRING,
                 txt);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
@@ -196,12 +196,12 @@ public final class XhtmlProcessing {
         if (height >= 0) {
             plist.add (new Property ("Height",
                     PropertyType.INTEGER,
-                    new Integer (height)));
+                    Integer.valueOf(height)));
         }
         if (width >= 0) {
             plist.add (new Property ("Width",
                     PropertyType.INTEGER,
-                    new Integer (width)));
+                    Integer.valueOf(width)));
         }
         if (!plist.isEmpty ()) {
             mdata.addImage(new Property ("Image",

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlDeclStream.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlDeclStream.java
@@ -258,7 +258,7 @@ public class XmlDeclStream extends FilterInputStream {
                 }
             }
         }
-        _charRefs.add (new Integer (val));
+        _charRefs.add (Integer.valueOf(val));
     }
     
     

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/PdfModuleTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/PdfModuleTest.java
@@ -10,6 +10,6 @@ import edu.harvard.hul.ois.jhove.module.pdf.PageTreeTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({ DocCatTests.class, HeaderTests.class, PageTreeTests.class })
-class PdfModuleTest {
+public class PdfModuleTest {
 	// Empty test suite that runs the PDF Module tests.
 }

--- a/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/wave/HexPrinterTest.java
+++ b/jhove-modules/src/test/java/edu/harvard/hul/ois/jhove/module/wave/HexPrinterTest.java
@@ -1,0 +1,31 @@
+package edu.harvard.hul.ois.jhove.module.wave;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HexPrinterTest {
+
+    @Test
+    public void testHexPrinter() {
+        assertEquals("DEADBEEF1099", HexPrinter.printHexBinary(makeByteArray(new int[] { 0xDe, 0xAd, 0xBe, 0xEf, 0x10, 0x99 })));
+    }
+
+    @Test
+    public void testHexPrinterLeadingZeros() {
+        assertEquals("00001001", HexPrinter.printHexBinary(makeByteArray(new int[] { 0x00, 0x00, 0x10, 0x01 })));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testHexPrinterWhenValIsNull() {
+        HexPrinter.printHexBinary(null);
+    }
+
+    private byte[] makeByteArray(int[] values) {
+        final byte[] bytes = new byte[values.length];
+        for(int i=0;i<values.length;i++) {
+            bytes[i] = (byte)values[i];
+        }
+        return bytes;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,8 @@
     <mvn.source.version>3.0.1</mvn.source.version>
     <mvn.surefire.version>2.19.1</mvn.surefire.version>
     <mvn.release.version>2.5.3</mvn.release.version>
-    <jacoco.version>0.7.9</jacoco.version>
+    <mvn.junit.version>4.12</mvn.junit.version>
+    <jacoco.version>0.8.2</jacoco.version>
     <java.source.version>1.8</java.source.version>
     <java.target.version>1.8</java.target.version>
     <jhove.timestamp>${maven.build.timestamp}</jhove.timestamp>
@@ -279,7 +280,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>${mvn.junit.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This compiles on java11...

...apart from when maven is packaging jhove-installer.  It is not able to get a dependency due to the client TLS implementation in java11 being strict (will apparently be corrected in January 2019 release of java11)

So the travis build for java11 is currently disabled :(