### PR TITLE
FIX - Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,8 @@ coverage:
 before_install:
   - sudo apt-get install -y realpath
   - sudo apt-get install jq
-  - curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest > codacy_rep_dets.txt
-  - cat codacy_rep_dets.txt
-  - export CODACY_REP_URL=$(cat codacy_rep_dets.txt | jq -r .assets[0].browser_download_url)
-  - echo $CODACY_REP_URL
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $CODACY_REP_URL
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl -u carlwilson:$GITHUB_API_TOKEN https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
+    | jq -r .assets[0].browser_download_url)
 
 script:
   - mvn clean install -DjacocoAgg

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ coverage:
 before_install:
   - sudo apt-get install -y realpath
   - sudo apt-get install jq
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl -u carlwilson:$GITHUB_API_TOKEN https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
-    | jq -r .assets[0].browser_download_url)
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar http://resources.openpreservation.org/codacy-coverage-reporter-assembly-latest.jar
 
 script:
   - mvn clean install -DjacocoAgg

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ coverage:
 before_install:
   - sudo apt-get install -y realpath
   - sudo apt-get install jq
-  - export CODACY_REP_URL=$(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
-    | jq -r .assets[0].browser_download_url)
+  - curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest > codacy_rep_dets.txt
+  - cat codacy_rep_dets.txt
+  - export CODACY_REP_URL=$(cat codacy_rep_dets.txt | jq -r .assets[0].browser_download_url)
   - echo $CODACY_REP_URL
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $CODACY_REP_URL
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,10 @@ coverage:
 before_install:
   - sudo apt-get install -y realpath
   - sudo apt-get install jq
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
+  - export CODACY_REP_URL=$(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest
     | jq -r .assets[0].browser_download_url)
+  - echo $CODACY_REP_URL
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $CODACY_REP_URL
 
 script:
   - mvn clean install -DjacocoAgg


### PR DESCRIPTION
This was caused by the gitHub API rate limiter sometimes firing when trying to dwnload the codacy reporter. Solved by downloading the reporter once a day on the OPF build box and downloading from there instead, bypassing the GH API altogether.

Fixes #380