### PR TITLE
FIX #361 - Mis-spelled property name in TIFF ID

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
@@ -1392,7 +1392,7 @@ public class TiffIFD
                                     new Long (_subfileType)));
         }
         if (_documentName != null) {
-            entries.add (new Property ("DocmentName", PropertyType.STRING,
+            entries.add (new Property ("DocumentName", PropertyType.STRING,
                                        _documentName));
         }
         if (_pageName != null) {


### PR DESCRIPTION
- corrected typo in TIFF module property name 'DocmentName'.
Closes #361