### PR TITLE
Adding support for SHA-256 message digest algorithm

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ChecksumType.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ChecksumType.java
@@ -10,7 +10,7 @@ package edu.harvard.hul.ois.jhove;
  * stream or file.
  * Applications will not create or modify ChecksumTypes, but will
  * use one of the predefined ChecksumType instances
- * CRC32, MD5, or SHA1.
+ * CRC32, MD5, SHA1, or SHA256.
  *
  * @see Checksum
  */
@@ -20,7 +20,9 @@ public enum ChecksumType {
 	/** 128-bit Message Digest 5. */
 	MD5("MD5"),
 	/** 160-bit Secure Hash Algorithm. */
-	SHA1("SHA-1");
+	SHA1("SHA-1"),
+	/** 256-bit Secure Hash Algorithm 2. */
+	SHA256("SHA-256");
 	/** A String name for the type, used for reporting. */
 	public final String name;
 

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Checksummer.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Checksummer.java
@@ -25,6 +25,8 @@ public class Checksummer implements java.util.zip.Checksum
     private MessageDigest _md5;
     /** SHA-1 message digest. */
     private MessageDigest _sha1;
+    /** SHA-256 message digest. */
+    private MessageDigest _sha256;
 
     /**
      *  Creates a Checksummer, with instances of each of 
@@ -51,6 +53,7 @@ public class Checksummer implements java.util.zip.Checksum
         try {
             _md5  = MessageDigest.getInstance ("MD5");
             _sha1 = MessageDigest.getInstance ("SHA-1");
+            _sha256 = MessageDigest.getInstance ("SHA-256");
         }
         catch (NoSuchAlgorithmException e) {
         }
@@ -79,6 +82,9 @@ public class Checksummer implements java.util.zip.Checksum
 	}
 	if (_sha1 != null) {
        	    _sha1.update (b);
+	}
+	if (_sha256 != null) {
+            _sha256.update (b);
 	}
     }
 
@@ -112,6 +118,9 @@ public class Checksummer implements java.util.zip.Checksum
 	if (_sha1 != null) {
 	    _sha1.update (b);
 	}
+	if (_sha256 != null) {
+	    _sha256.update (b);
+	}
     }
     
     /**
@@ -128,6 +137,9 @@ public class Checksummer implements java.util.zip.Checksum
 	if (_sha1 != null) {
 	    _sha1.update (b, off, len);
 	}
+	if (_sha256 != null) {
+	    _sha256.update (b, off, len);
+	}
     }
 
     /**
@@ -135,7 +147,7 @@ public class Checksummer implements java.util.zip.Checksum
      */
     public String getCRC32 ()
     {
-	return padLeadingZeroes 
+	return padLeadingZeroes
             (Long.toHexString (_crc32.getValue ()), 8);
     }
 
@@ -175,6 +187,28 @@ public class Checksummer implements java.util.zip.Checksum
 	    for (int i=0; i<digest.length; i++) {
 		int un = (digest[i] >= 0) ? digest[i] : 256+digest[i];
 		buffer.append (padLeadingZeroes 
+                                (Integer.toHexString (un), 2));
+	    }
+	    value = buffer.toString ();
+	}
+
+	return value;
+    }
+
+    /**
+     *  Returns the value of the SHA-256 digest as a hex string.
+     *  Returns null if the digest is not available.
+     */
+    public String getSHA256 ()
+    {
+	String value = null;
+
+	if (_sha256 != null) {
+	    StringBuffer buffer = new StringBuffer ();
+	    byte [] digest = _sha256.digest ();
+	    for (int i=0; i<digest.length; i++) {
+		int un = (digest[i] >= 0) ? digest[i] : 256+digest[i];
+		buffer.append (padLeadingZeroes
                                 (Integer.toHexString (un), 2));
 	    }
 	    value = buffer.toString ();

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -718,6 +718,10 @@ public class JhoveBase {
             if (value != null) {
                 info.setChecksum(new Checksum(value, ChecksumType.SHA1));
             }
+            value = ckSummer.getSHA256();
+            if (value != null) {
+                info.setChecksum(new Checksum(value, ChecksumType.SHA256));
+            }
         }
         return tempFile;
     }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -76,6 +76,8 @@ public abstract class ModuleBase
     protected MessageDigest _md5;
     /**  SHA-1 digest calculated on content object */
     protected MessageDigest _sha1;
+    /**  SHA-256 digest calculate on content object */
+    protected MessageDigest _sha256;
         /**  Flag indicating valid checksum information set */
     protected boolean _checksumFinished;
     /**  Indicator of how much data to report */
@@ -576,6 +578,16 @@ public abstract class ModuleBase
         _checksumFinished = true;
     }
 
+    /**
+     *  Sets the SHA-256 calculated digest for the content object, and sets
+     *  the checksumFinished flag.
+     */
+    public final void setSHA256 (MessageDigest sha256)
+    {
+        _sha256 = sha256;
+        _checksumFinished = true;
+    }
+
     /******************************************************************
      * Parsing methods.
      ******************************************************************/
@@ -783,6 +795,7 @@ public abstract class ModuleBase
         try {
             _md5  = MessageDigest.getInstance ("MD5");
             _sha1 = MessageDigest.getInstance ("SHA-1");
+            _sha256 = MessageDigest.getInstance ("SHA-256");
         }
         catch (NoSuchAlgorithmException e) {
         }    
@@ -828,6 +841,9 @@ public abstract class ModuleBase
             }
             if ((value = ckSummer.getSHA1 ()) != null) {
                 info.setChecksum (new Checksum (value, ChecksumType.SHA1));
+            }
+            if ((value = ckSummer.getSHA256 ()) != null) {
+                info.setChecksum (new Checksum (value, ChecksumType.SHA256));
             }
         }
     }

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
@@ -329,6 +329,9 @@ public class AiffModule
             if ((value = _ckSummer.getSHA1 ()) != null) {
             info.setChecksum (new Checksum (value, ChecksumType.SHA1));
             }
+            if ((value = _ckSummer.getSHA256 ()) != null) {
+            info.setChecksum (new Checksum (value, ChecksumType.SHA256));
+            }
        }
 
        if (fileType == AIFFTYPE) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
@@ -326,6 +326,9 @@ public class GifModule extends ModuleBase
             if ((value = _ckSummer.getSHA1 ()) != null) {
             info.setChecksum (new Checksum (value, ChecksumType.SHA1));
             }
+            if ((value = _ckSummer.getSHA256 ()) != null) {
+            info.setChecksum (new Checksum (value, ChecksumType.SHA256));
+            }
         }
         Property[] metaArray;
         if (_xmpProp != null) {

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
@@ -530,6 +530,9 @@ public class HtmlModule extends ModuleBase {
             if ((value = ckSummer.getSHA1()) != null) {
                 info.setChecksum(new Checksum(value, ChecksumType.SHA1));
             }
+            if ((value = ckSummer.getSHA256()) != null) {
+                info.setChecksum(new Checksum(value, ChecksumType.SHA256));
+            }
         }
 
         return 0;

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -766,6 +766,9 @@ public class JpegModule extends ModuleBase {
             if ((value = _ckSummer.getSHA1()) != null) {
                 info.setChecksum(new Checksum(value, ChecksumType.SHA1));
             }
+            if ((value = _ckSummer.getSHA256()) != null) {
+                info.setChecksum(new Checksum(value, ChecksumType.SHA256));
+            }
         }
 
         // Put the primary image in the image list.

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
@@ -340,6 +340,9 @@ public class Utf8Module extends ModuleBase {
             if ((value = ckSummer.getSHA1()) != null) {
                 info.setChecksum(new Checksum(value, ChecksumType.SHA1));
             }
+            if ((value = ckSummer.getSHA256()) != null) {
+                info.setChecksum(new Checksum(value, ChecksumType.SHA256));
+            }
         }
 
         /*

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -484,6 +484,9 @@ public class WaveModule extends ModuleBase {
             if ((value = _ckSummer.getSHA1()) != null) {
                 info.setChecksum(new Checksum(value, ChecksumType.SHA1));
             }
+            if ((value = _ckSummer.getSHA256()) != null) {
+                info.setChecksum(new Checksum(value, ChecksumType.SHA256));
+            }
         }
 
         info.setProperty(_metadata);

--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -974,6 +974,9 @@ public class XmlModule
             if ((value = _ckSummer.getSHA1 ()) != null) {
                 info.setChecksum (new Checksum (value, ChecksumType.SHA1));
             }
+            if ((value = _ckSummer.getSHA256 ()) != null) {
+                info.setChecksum (new Checksum (value, ChecksumType.SHA256));
+            }
         }
         if (info.getVersion () == null) {
             info.setVersion ("1.0");


### PR DESCRIPTION
The [MessageDigest JavaDocs](https://docs.oracle.com/javase/9/docs/api/java/security/MessageDigest.html) say all implementations must support MD5, SHA-1, and SHA-256.  Since MD5 and SHA-1 are already supported, I added support for SHA-256.