### PR TITLE
Migrate additional Java 5 compatibility checks to Java 8

### DIFF
--- a/jhove-apps/src/main/java/Jhove.java
+++ b/jhove-apps/src/main/java/Jhove.java
@@ -18,23 +18,19 @@
  * USA
  **********************************************************************/
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import edu.harvard.hul.ois.jhove.App;
 import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.Module;
 import edu.harvard.hul.ois.jhove.OutputHandler;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class Jhove
 {
-    /******************************************************************
-     * PRIVATE CLASS FIELDS.
-     ******************************************************************/
-
     /** Application name. */
     private static final String NAME = "Jhove";
     /** Logger for this class. */
@@ -45,73 +41,64 @@ public class Jhove
     /** Incompatible Java VM. */
     private static final int INCOMPATIBLE_VM = -2;
 
-    private Jhove() {
+    private Jhove()
+    {
         throw new AssertionError("Should never enter private constructor");
     }
-    /******************************************************************
-     * MAIN ENTRY POINT.
-     ******************************************************************/
 
-    public static void main (String [] args)
+    /**
+     * MAIN ENTRY POINT.
+     */
+    public static void main(String [] args)
     {
-        /* Make sure we have a satisfactory version of Java. */
-        String version = System.getProperty ("java.vm.version");
+        // Make sure we have a satisfactory version of Java.
+        String version = System.getProperty("java.vm.version");
         if (version.compareTo("1.8.0") < 0) {
             LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
             System.exit(INCOMPATIBLE_VM);
         }
 
         try {
-    
-    	    /**********************************************************
-    	     * Initialize the application state object.
-    	     **********************************************************/
-    
-    	    App app = App.newAppWithName(NAME);
-    
-    	    /**********************************************************
-    	     * Retrieve the configuration file.
-    	     **********************************************************/
-    
-    	    String configFile = JhoveBase.getConfigFileFromProperties ();
-    	    String saxClass   = JhoveBase.getSaxClassFromProperties ();
-    
-    	    /* Pre-parse the command line for -c and -x config options. 
-    	     * With Windows, we have to deal with quote marks on our own. With Unix,
-    	     * the shell takes care of quotes for us. */
-    	    boolean quoted = false;
-    	    for (int i=0; i<args.length; i++) {
-    		if (quoted) {
-    		    int len = args[i].length ();
-                if (args[i].charAt (len-1) == '"') {
-                    quoted = false;
-                }
-    		}
-    		else {
-    		    if ("-c".equals(args[i])) {
-                    if (i < args.length-1) {
-                        configFile = args[++i];
+
+            // Initialize the application state object.
+            App app = App.newAppWithName(NAME);
+
+            // Retrieve configuration.
+            String configFile = JhoveBase.getConfigFileFromProperties();
+            String saxClass = JhoveBase.getSaxClassFromProperties();
+
+            /* Pre-parse the command line for -c and -x config options.
+             * With Windows, we have to deal with quote marks on our own.
+             * With Unix, the shell takes care of quotes for us. */
+            boolean quoted = false;
+            for (int i = 0; i < args.length; i++) {
+                if (quoted) {
+                    int len = args[i].length();
+                    if (args[i].charAt(len - 1) == '"') {
+                        quoted = false;
                     }
                 }
-    		    else if ("-x".equals(args[i])) {
-                    if (i <args.length-1) {
-                        saxClass = args[++i];
+                else {
+                    if ("-c".equals(args[i])) {
+                        if (i < args.length - 1) {
+                            configFile = args[++i];
+                        }
+                    }
+                    else if ("-x".equals(args[i])) {
+                        if (i < args.length - 1) {
+                            saxClass = args[++i];
+                        }
+                    }
+                    else if (args[i].charAt(0) == '"') {
+                        quoted = true;
                     }
                 }
-    		    else if (args[i].charAt (0) == '"') {
-                    quoted = true;
-                }
-    		}
-        }
-    
-    	    /**********************************************************
-    	     * Initialize the JHOVE engine.
-    	     **********************************************************/
-    
-    	    String encoding     = null;
-    	    String tempDir      = null;
-    	    int    bufferSize   = -1;
-    
+            }
+
+            // Initialize the JHOVE engine.
+            String encoding     = null;
+            String tempDir      = null;
+            int    bufferSize   = -1;
             String moduleName   = null;
             String handlerName  = null;
             String aboutHandler = null;
@@ -120,193 +107,187 @@ public class Jhove
             boolean checksum    = false;
             boolean showRaw     = false;
             boolean signature   = false;
-            List<String> list   = new ArrayList<> ();
-    
-    	 
-                /**********************************************************
-                 * Parse command line arguments:
-                 *  -m module    Module name
-                 *  -h handler   Output handler
-    	     *  -e encoding  Output encoding
-                 *  -H handler   About handler
-                 *  -o output    Output file pathname
-                 *  -t tempdir   Directory for temp files
-                 *  -b bufsize   Buffer size for buffered I/O
-                 *  -k           Calculate checksums
-                 *  -r           Display raw numeric flags 
-                 *  -s           Check internal signatures only
-                 *  dirFileOrUri Directories, file pathnames, or URIs
-    	     *
-    	     * The following arguments were defined in previous
-    	     * versions, but are now obsolete
-                 *  -p param     OBSOLETE
-                 *  -P param     OBSOLETE
-    	     **********************************************************/
-    
-    	    quoted = false;
-    	    StringBuffer filename = null;
-    
-            for (int i=0; i<args.length; i++) {
+            List<String> list   = new ArrayList<>();
+
+            /*
+             * Parse command line arguments:
+             *  -m module    Module name
+             *  -h handler   Output handler
+             *  -e encoding  Output encoding
+             *  -H handler   About handler
+             *  -o output    Output file pathname
+             *  -t tempdir   Directory for temp files
+             *  -b bufsize   Buffer size for buffered I/O
+             *  -k           Calculate checksums
+             *  -r           Display raw numeric flags
+             *  -s           Check internal signatures only
+             *  dirFileOrUri Directories, file pathnames, or URIs
+             *
+             * The following arguments were defined in previous
+             * versions, but are now obsolete
+             *  -p param     OBSOLETE
+             *  -P param     OBSOLETE
+             */
+
+            quoted = false;
+            StringBuilder filename = null;
+
+            for (int i = 0; i < args.length; i++) {
                 if (quoted) {
-                    int len = args[i].length ();
-                    if (args[i].charAt (len-1) == '"') {
-                        filename.append (" " + args[i].substring (0, len-1));
-                        list.add (filename.toString ());
+                    filename.append(" ");
+                    int len = args[i].length();
+                    if (args[i].charAt(len - 1) == '"') {
+                        filename.append(args[i].substring(0, len - 1));
+                        list.add(filename.toString());
                         quoted = false;
                     }
                     else {
-                        filename.append (" " + args[i]);
+                        filename.append(args[i]);
                     }
                 }
                 else {
-        		    if ("-c".equals(args[i])) {
+                    if ("-c".equals(args[i])) {
                         i++;
-        		    }
-        		    else if ("-m".equals(args[i])) {
-                        if (i < args.length-1) {
+                    }
+                    else if ("-m".equals(args[i])) {
+                        if (i < args.length - 1) {
                             moduleName = args[++i];
                         }
-        		    }
-        		    else if ("-p".equals(args[i])) {
+                    }
+                    else if ("-p".equals(args[i])) {
                         // Obsolete -- but eat the next arg for compatibility
-                        if (i <args.length-1) {
+                        if (i < args.length - 1) {
                             @SuppressWarnings("unused")
                             String moduleParam = args[++i];
                         }
                     }
-        		    else if ("-h".equals(args[i])) {
-                        if (i < args.length-1) {
+                    else if ("-h".equals(args[i])) {
+                        if (i < args.length - 1) {
                             handlerName = args[++i];
                         }
                     }
-        		    else if ("-P".equals(args[i])) {
+                    else if ("-P".equals(args[i])) {
                         // Obsolete -- but eat the next arg for compatibility
-                        if (i <args.length-1) {
+                        if (i < args.length - 1) {
                             @SuppressWarnings("unused")
                             String handlerParam = args[++i];
                         }
-        		    }
-        		    else if ("-e".equals(args[i])) {
-                        if (i < args.length-1) {
+                    }
+                    else if ("-e".equals(args[i])) {
+                        if (i < args.length - 1) {
                             encoding = args[++i];
                         }
-        		    }
-        		    else if ("-H".equals(args[i])) {
-                        if (i < args.length-1) {
+                    }
+                    else if ("-H".equals(args[i])) {
+                        if (i < args.length - 1) {
                             aboutHandler = args[++i];
                         }
                     }
-        		    else if ("-l".equals(args[i])) {
-                        if (i < args.length-1) {
+                    else if ("-l".equals(args[i])) {
+                        if (i < args.length - 1) {
                             logLevel = args[++i];
                         }
-        		    }
-        		    else if ("-o".equals(args[i])) {
-                        if (i < args.length-1) {
+                    }
+                    else if ("-o".equals(args[i])) {
+                        if (i < args.length - 1) {
                             outputFile = args[++i];
                         }
                     }
-        		    else if ("-x".equals(args[i])) {
+                    else if ("-x".equals(args[i])) {
                         i++;
-        		    }
-        		    else if ("-t".equals(args[i])) {
-                        if (i <args.length-1) {
+                    }
+                    else if ("-t".equals(args[i])) {
+                        if (i < args.length - 1) {
                             tempDir = args[++i];
                         }
                     }
-        		    else if ("-b".equals(args[i])) {
-                        if (i <args.length-1) {
+                    else if ("-b".equals(args[i])) {
+                        if (i < args.length - 1) {
                             try {
-                                bufferSize = Integer.parseInt (args[++i]);
+                                bufferSize = Integer.parseInt(args[++i]);
                             }
-                            catch (NumberFormatException e) {
+                            catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Invalid buffer size, using default.");
                             }
                         }
-        		    }
-        		    else if ("-k".equals(args[i])) {
+                    }
+                    else if ("-k".equals(args[i])) {
                         checksum = true;
-        		    }
-        		    else if ("-r".equals(args[i])) {
+                    }
+                    else if ("-r".equals(args[i])) {
                         showRaw = true;
-        		    }
-        		    else if ("-s".equals(args[i])) {
+                    }
+                    else if ("-s".equals(args[i])) {
                         signature = true;
                     }
-        		    else if (args[i].charAt (0) != '-') {
-                        if (args[i].charAt (0) == '"') {
-                            filename = new StringBuffer ();
-                            filename.append (args[i].substring (1));
+                    else if (args[i].charAt(0) != '-') {
+                        if (args[i].charAt(0) == '"') {
+                            filename = new StringBuilder();
+                            filename.append(args[i].substring(1));
                             quoted = true;
                         }
                         else {
-                            list.add (args[i]);
+                            list.add(args[i]);
                         }
-        		    }
-        		}
+                    }
+                }
             }
             if (quoted) {
-                list.add (filename.toString ());
-    	    }
+                list.add(filename.toString());
+            }
     
-            JhoveBase je = new JhoveBase ();
+            JhoveBase je = new JhoveBase();
             // Only set the log level if a param value was assigned
             if (logLevel != null) {
-                je.setLogLevel (logLevel);
+                je.setLogLevel(logLevel);
             }
             je.init (configFile, saxClass);
             if (encoding == null) {
-                encoding = je.getEncoding ();
+                encoding = je.getEncoding();
             }
             if (tempDir == null) {
-                tempDir = je.getTempDirectory ();
+                tempDir = je.getTempDirectory();
             }
             if (bufferSize < 0) {
-                bufferSize = je.getBufferSize ();
+                bufferSize = je.getBufferSize();
             }
-            Module module = je.getModule  (moduleName);
+            Module module = je.getModule(moduleName);
             if (module == null && moduleName != null) {
                 LOGGER.log(Level.SEVERE, "Module '" + moduleName + "' not found");
                 System.exit(ERROR);
             }
-            OutputHandler about   = je.getHandler (aboutHandler);
+            OutputHandler about = je.getHandler(aboutHandler);
             if (about == null && aboutHandler != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + aboutHandler + "' not found");
                 System.exit(ERROR);
             }
-    	    OutputHandler handler = je.getHandler (handlerName);
+            OutputHandler handler = je.getHandler(handlerName);
             if (handler == null && handlerName != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + handlerName + "' not found");
                 System.exit(ERROR);
             }
-    	    String [] dirFileOrUri = null;
-    	    int len = list.size ();
+            String[] dirFileOrUri = null;
+            int len = list.size();
             if (len > 0) {
-        		dirFileOrUri = new String [len];
-        		for (int i=0; i<len; i++) {
-        		    dirFileOrUri[i] = list.get (i);
-        		}
+                dirFileOrUri = new String[len];
+                for (int i = 0; i < len; i++) {
+                    dirFileOrUri[i] = list.get(i);
+                }
             }
-    
-    	    /**********************************************************
-    	     * Invoke the JHOVE engine.
-    	     **********************************************************/
-                
-            je.setEncoding (encoding);
-            je.setTempDirectory (tempDir);
-            je.setBufferSize (bufferSize);
-            je.setChecksumFlag (checksum);
-            je.setShowRawFlag (showRaw);
-            je.setSignatureFlag (signature);
-    	    je.dispatch (app, module, about, handler, outputFile, 
-    			 dirFileOrUri);
-    	}
+
+            // Invoke the JHOVE engine.
+            je.setEncoding(encoding);
+            je.setTempDirectory(tempDir);
+            je.setBufferSize(bufferSize);
+            je.setChecksumFlag(checksum);
+            je.setShowRawFlag(showRaw);
+            je.setSignatureFlag(signature);
+            je.dispatch(app, module, about, handler, outputFile, dirFileOrUri);
+        }
         catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage());
             e.printStackTrace(System.err);
             System.exit(ERROR);
         }
     }
-    
-
 }

--- a/jhove-apps/src/main/java/Jhove.java
+++ b/jhove-apps/src/main/java/Jhove.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.Module;
 import edu.harvard.hul.ois.jhove.OutputHandler;
@@ -39,6 +40,11 @@ public class Jhove
     /** Logger for this class. */
     private static final Logger LOGGER = Logger.getLogger(Jhove.class.getCanonicalName());
 
+    /** General error. */
+    private static final int ERROR = -1;
+    /** Incompatible Java VM. */
+    private static final int INCOMPATIBLE_VM = -2;
+
     private Jhove() {
         throw new AssertionError("Should never enter private constructor");
     }
@@ -50,9 +56,9 @@ public class Jhove
     {
         /* Make sure we have a satisfactory version of Java. */
         String version = System.getProperty ("java.vm.version");
-        if (version.compareTo ("1.5.0") < 0) {
-            LOGGER.log(Level.SEVERE, "Java 1.5 or higher is required");
-            System.exit (-1);
+        if (version.compareTo("1.8.0") < 0) {
+            LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
+            System.exit(INCOMPATIBLE_VM);
         }
 
         try {
@@ -261,17 +267,17 @@ public class Jhove
             Module module = je.getModule  (moduleName);
             if (module == null && moduleName != null) {
                 LOGGER.log(Level.SEVERE, "Module '" + moduleName + "' not found");
-                System.exit (-1);
+                System.exit(ERROR);
             }
             OutputHandler about   = je.getHandler (aboutHandler);
             if (about == null && aboutHandler != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + aboutHandler + "' not found");
-                System.exit (-1);
+                System.exit(ERROR);
             }
     	    OutputHandler handler = je.getHandler (handlerName);
             if (handler == null && handlerName != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + handlerName + "' not found");
-                System.exit (-1);
+                System.exit(ERROR);
             }
     	    String [] dirFileOrUri = null;
     	    int len = list.size ();
@@ -298,7 +304,7 @@ public class Jhove
         catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage());
             e.printStackTrace(System.err);
-            System.exit (-1);
+            System.exit(ERROR);
         }
     }
     

--- a/jhove-apps/src/main/java/Jhove.java
+++ b/jhove-apps/src/main/java/Jhove.java
@@ -19,6 +19,7 @@
  **********************************************************************/
 
 import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.ExitCode;
 import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.Module;
@@ -36,11 +37,6 @@ public class Jhove
     /** Logger for this class. */
     private static final Logger LOGGER = Logger.getLogger(Jhove.class.getCanonicalName());
 
-    /** General error. */
-    private static final int ERROR = -1;
-    /** Incompatible Java VM. */
-    private static final int INCOMPATIBLE_VM = -2;
-
     private Jhove()
     {
         throw new AssertionError("Should never enter private constructor");
@@ -55,7 +51,7 @@ public class Jhove
         String version = System.getProperty("java.vm.version");
         if (version.compareTo("1.8.0") < 0) {
             LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
-            System.exit(INCOMPATIBLE_VM);
+            System.exit(ExitCode.INCOMPATIBLE_VM.getReturnCode());
         }
 
         try {
@@ -254,17 +250,17 @@ public class Jhove
             Module module = je.getModule(moduleName);
             if (module == null && moduleName != null) {
                 LOGGER.log(Level.SEVERE, "Module '" + moduleName + "' not found");
-                System.exit(ERROR);
+                System.exit(ExitCode.ERROR.getReturnCode());
             }
             OutputHandler about = je.getHandler(aboutHandler);
             if (about == null && aboutHandler != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + aboutHandler + "' not found");
-                System.exit(ERROR);
+                System.exit(ExitCode.ERROR.getReturnCode());
             }
             OutputHandler handler = je.getHandler(handlerName);
             if (handler == null && handlerName != null) {
                 LOGGER.log(Level.SEVERE, "Handler '" + handlerName + "' not found");
-                System.exit(ERROR);
+                System.exit(ExitCode.ERROR.getReturnCode());
             }
             String[] dirFileOrUri = null;
             int len = list.size();
@@ -287,7 +283,7 @@ public class Jhove
         catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage());
             e.printStackTrace(System.err);
-            System.exit(ERROR);
+            System.exit(ExitCode.ERROR.getReturnCode());
         }
     }
 }

--- a/jhove-apps/src/main/java/JhoveView.java
+++ b/jhove-apps/src/main/java/JhoveView.java
@@ -19,6 +19,7 @@
  **********************************************************************/
 
 import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.ExitCode;
 import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.JhoveException;
@@ -43,11 +44,6 @@ public class JhoveView
     /** Application icon. */
     private static final String ICON_PATH = "org/openpreservation/jhove/icon.png"; //$NON-NLS-1$
 
-    /** General error. */
-    private static final int ERROR = -1;
-    /** Incompatible Java VM. */
-    private static final int INCOMPATIBLE_VM = -2;
-
     /** Stub constructor. */
     private JhoveView()
     {
@@ -65,7 +61,7 @@ public class JhoveView
         if (version.compareTo("1.8.0") < 0) { //$NON-NLS-1$
             LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
             errorAlert(CoreMessageConstants.EXC_JAVA_VER_INCMPT);
-            System.exit(INCOMPATIBLE_VM);
+            System.exit(ExitCode.INCOMPATIBLE_VM.getReturnCode());
         }
 
         // If we're running on a Macintosh, put the menubar at the top
@@ -126,7 +122,7 @@ public class JhoveView
         catch (Exception e) {
             e.printStackTrace(System.err);
             LOGGER.log(Level.SEVERE, e.getMessage());
-            System.exit(ERROR);
+            System.exit(ExitCode.ERROR.getReturnCode());
         }
     }
 

--- a/jhove-apps/src/main/java/JhoveView.java
+++ b/jhove-apps/src/main/java/JhoveView.java
@@ -18,19 +18,18 @@
  * USA
  **********************************************************************/
 
-import java.awt.Toolkit;
-import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-
 import edu.harvard.hul.ois.jhove.App;
 import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.JhoveException;
 import edu.harvard.hul.ois.jhove.viewer.JhoveWindow;
+
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import java.awt.Toolkit;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * JhoveView - JSTOR/Harvard Object Validation Environment.
@@ -38,50 +37,31 @@ import edu.harvard.hul.ois.jhove.viewer.JhoveWindow;
 public class JhoveView
 {
     private static final Logger LOGGER = Logger.getLogger(JhoveView.class.getCanonicalName());
-    /******************************************************************
-     * PRIVATE CLASS FIELDS.
-     *
-     * Application constants.
-     ******************************************************************/
 
     /** Application name. */
     private static final String NAME = "JhoveView"; //$NON-NLS-1$
-    private static final String iconPath = "org/openpreservation/jhove/icon.png"; //$NON-NLS-1$
-
-    /******************************************************************
-     * Action constants.
-     ******************************************************************/
-
-    /******************************************************************
-     * Exit code constants.
-     ******************************************************************/
+    /** Application icon. */
+    private static final String ICON_PATH = "org/openpreservation/jhove/icon.png"; //$NON-NLS-1$
 
     /** General error. */
     private static final int ERROR = -1;
-
     /** Incompatible Java VM. */
     private static final int INCOMPATIBLE_VM = -2;
 
-    /******************************************************************
-     * PUBLIC CLASS METHODS.
-     ******************************************************************/
-
-    /**
-     *  Stub constructor.
-     */
-
-    private JhoveView ()
+    /** Stub constructor. */
+    private JhoveView()
     {
     }
 
     /**
      * Application main entry point.
-     * @parm args Command line arguments
+     *
+     * @param args Command-line arguments
      */
-    public static void main (String [] args)
+    public static void main(String[] args)
     {
-        /* Make sure we have a satisfactory version of Java. */
-        String version = System.getProperty ("java.vm.version"); //$NON-NLS-1$
+        // Make sure we have a satisfactory version of Java.
+        String version = System.getProperty("java.vm.version"); //$NON-NLS-1$
         if (version.compareTo("1.8.0") < 0) { //$NON-NLS-1$
             LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
             errorAlert(CoreMessageConstants.EXC_JAVA_VER_INCMPT);
@@ -90,89 +70,74 @@ public class JhoveView
 
         // If we're running on a Macintosh, put the menubar at the top
         // of the screen where it belongs.
-        System.setProperty ("apple.laf.useScreenMenuBar", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+        System.setProperty("apple.laf.useScreenMenuBar", "true"); //$NON-NLS-1$ //$NON-NLS-2$
 
         App app = App.newAppWithName(NAME);
         try {
 
-            /**********************************************************
-             * Retrieve the configuration file.
-             **********************************************************/
-    
-            String configFile = JhoveBase.getConfigFileFromProperties ();
-            String saxClass   = JhoveBase.getSaxClassFromProperties ();
+            // Retrieve configuration.
+            String configFile = JhoveBase.getConfigFileFromProperties();
+            String saxClass = JhoveBase.getSaxClassFromProperties();
 
-            /**********************************************************
-             * Initialization:
-             *  configFile  Configuration file pathname
-             *  saxClass    SAX parser class
-             **********************************************************/
+            // Pre-parse the command line for -c and -x config options.
+            boolean quoted = false;
+            for (int i = 0; i < args.length; i++) {
+                if (quoted) {
+                    int len = args[i].length();
+                    if (args[i].charAt(len - 1) == '"') {
+                        quoted = false;
+                    }
+                }
+                else {
+                    if ("-c".equals(args[i])) {
+                        if (i < args.length - 1) {
+                            configFile = args[++i];
+                        }
+                    }
+                    else if ("-x".equals(args[i])) {
+                        if (i < args.length - 1) {
+                            saxClass = args[++i];
+                        }
+                    }
+                    else if (args[i].charAt(0) == '"') {
+                        quoted = true;
+                    }
+                }
+            }
 
-	    /* Pre-parse the command line for -c and -x config options. */
-	    boolean quoted = false;
-	    for (int i=0; i<args.length; i++) {
-		if (quoted) {
-		    int len = args[i].length ();
-		    if (args[i].charAt (len-1) == '"') {
-			quoted = false;
-		    }
-		}
-		else {
-		    if ("-c".equals(args[i])) {
-			if (i < args.length-1) {
-			    configFile = args[++i];
-			}
-		    }
-		    else if ("-x".equals(args[i])) {
-			if (i <args.length-1) {
-			    saxClass = args[++i];
-			}
-		    }
-		    else if (args[i].charAt (0) == '"') {
-			quoted = true;
-		    }
-		}
-	    }
-
-            
-            /**********************************************************
-             * Initialize the JHOVE engine.
-             **********************************************************/
-    
-            JhoveBase je = new JhoveBase ();
+            // Initialize the JHOVE engine.
+            JhoveBase je = new JhoveBase();
             try {
-                je.init (configFile, saxClass);
+                je.init(configFile, saxClass);
             }
             catch (JhoveException e) {
-                errorAlert (e.getMessage ());
+                errorAlert(e.getMessage());
                 // Keep going, so user can correct in editor
             }
 
             // Create the main window to select a file.
-            
-            JhoveWindow jwin = new JhoveWindow (app, je);
-			URL url = ClassLoader.getSystemResource(iconPath); //$NON-NLS-1$
-			Toolkit kit = Toolkit.getDefaultToolkit();
-			jwin.setIconImage(kit.createImage(url));
+            JhoveWindow jwin = new JhoveWindow(app, je);
+            URL url = ClassLoader.getSystemResource(ICON_PATH); //$NON-NLS-1$
+            Toolkit kit = Toolkit.getDefaultToolkit();
+            jwin.setIconImage(kit.createImage(url));
             jwin.setVisible (true);
 
         }
         catch (Exception e) {
-            e.printStackTrace (System.err);
+            e.printStackTrace(System.err);
             LOGGER.log(Level.SEVERE, e.getMessage());
-            System.exit (ERROR);
+            System.exit(ERROR);
         }
     }
-    
-    /* Displays an error alert. */
-    private static void errorAlert (String msg)
+
+    /** Displays an error alert. */
+    private static void errorAlert(String msg)
     {
-        JFrame hiddenFrame = new JFrame ();
-        // Truncate long messages so the alert isn't wider
-        // than the screen
-        String message = (msg.length() > 80) ? msg.substring (0, 79) + "..." : msg;
+        JFrame hiddenFrame = new JFrame();
+        // Truncate long messages so the alert isn't wider than the screen
+        String message = (msg.length() > 80) ? msg.substring(0, 79) + "..." : msg;
         LOGGER.log(Level.WARNING, msg);
-        JOptionPane.showMessageDialog (hiddenFrame, 
-                message, "Jhove Error", JOptionPane.ERROR_MESSAGE);
+        JOptionPane.showMessageDialog(hiddenFrame, message, "Jhove Error",
+                JOptionPane.ERROR_MESSAGE);
     }
 }

--- a/jhove-apps/src/main/java/JhoveView.java
+++ b/jhove-apps/src/main/java/JhoveView.java
@@ -27,6 +27,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
 import edu.harvard.hul.ois.jhove.App;
+import edu.harvard.hul.ois.jhove.CoreMessageConstants;
 import edu.harvard.hul.ois.jhove.JhoveBase;
 import edu.harvard.hul.ois.jhove.JhoveException;
 import edu.harvard.hul.ois.jhove.viewer.JhoveWindow;
@@ -81,10 +82,9 @@ public class JhoveView
     {
         /* Make sure we have a satisfactory version of Java. */
         String version = System.getProperty ("java.vm.version"); //$NON-NLS-1$
-        if (version.compareTo ("1.5.0") < 0) { //$NON-NLS-1$
-            final String message = "Java 1.5 or higher is required"; 
-            LOGGER.log(Level.SEVERE, message);
-            errorAlert (message);
+        if (version.compareTo("1.8.0") < 0) { //$NON-NLS-1$
+            LOGGER.log(Level.SEVERE, CoreMessageConstants.EXC_JAVA_VER_INCMPT);
+            errorAlert(CoreMessageConstants.EXC_JAVA_VER_INCMPT);
             System.exit(INCOMPATIBLE_VM);
         }
 

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/ExitCode.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/ExitCode.java
@@ -1,0 +1,24 @@
+package edu.harvard.hul.ois.jhove;
+
+/**
+ * The set of possible exit codes returned by JHOVE applications.
+ */
+public enum ExitCode {
+
+    /** General error. */
+    ERROR(-1),
+
+    /** Incompatible Java VM. */
+    INCOMPATIBLE_VM(-2);
+
+
+    private final int returnCode;
+
+    ExitCode(int returnCode) {
+        this.returnCode = returnCode;
+    }
+
+    public int getReturnCode() {
+        return returnCode;
+    }
+}


### PR DESCRIPTION
Previous updates missed the checks done in JHOVE application code (further addressing issue #372). This corrects that and comes with a little house-cleaning for good measure.