### PR TITLE
FIX - XML Module failure when no checksumming

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ConfigHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ConfigHandler.java
@@ -23,7 +23,6 @@ public class ConfigHandler
 
     private String _class;
     protected StringBuffer _content;
-    private Map<String, String> _extension;
 
     /** The schema name */
     private final static String configSchemaName =
@@ -100,7 +99,6 @@ public class ConfigHandler
 
         _bufferSize = -1;
         _encoding   = null;
-        _extension  = new Hashtable<> ();
         _tempDir    = null;
         _mixVsn     = null;
         _sigBytes   = 1024;
@@ -201,14 +199,6 @@ public class ConfigHandler
     public int getBufferSize ()
     {
 	return _bufferSize;
-    }
-
-    /**
-     * Return an associative map of configuration extensions.
-     */
-    public Map<String, String> getExtensions ()
-    {
-        return _extension;
     }
 
     /**
@@ -364,9 +354,6 @@ public class ConfigHandler
 		/* Just ignore a malformed number */
 	    }
 	    _isBufferSize = false;
-	}
-	else if (!"jhoveConfig".equals (rawName)) {
-	    _extension.put (rawName, _content.toString ().trim ());
 	}
     }
     

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -89,8 +89,6 @@ public class JhoveBase {
     protected String _configFile;
     /** Selected encoding. */
     protected String _encoding;
-    /** Associate map of configuration extensions. */
-    protected Map<String, String> _extensions;
     /** Ordered list of output handlers. */
     protected List<OutputHandler> _handlerList;
     /** Map of output handlers (for fast access by name). */
@@ -247,7 +245,6 @@ public class JhoveBase {
 
         // Update the application state to reflect the configuration file,
         // if necessary.
-        _extensions = configHandler.getExtensions();
         _jhoveHome = configHandler.getJhoveHome();
 
         _encoding = configHandler.getEncoding();
@@ -857,20 +854,6 @@ public class JhoveBase {
      */
     public String getEncoding() {
         return _encoding;
-    }
-
-    /**
-     * Returns the JHOVE configuration extensions.
-     */
-    public Map<String, String> getExtension() {
-        return _extensions;
-    }
-
-    /**
-     * Returns the JHOVE configuration extension by name.
-     */
-    public String getExtension(String name) {
-        return _extensions.get(name);
     }
 
     /**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -92,7 +92,7 @@ public abstract class ModuleBase implements Module {
 	protected Checksummer _ckSummer;
 
 	/* Input stream wrapper which handles checksums */
-	protected ChecksumInputStream _cstream;
+	private ChecksumInputStream _cstream;
 
 	/* Data input stream wrapped around _cstream */
 	protected DataInputStream _dstream;

--- a/jhove-installer/src/main/scripts/jhove
+++ b/jhove-installer/src/main/scripts/jhove
@@ -51,7 +51,7 @@ done
 # Store absolute location
 CWD="$( pwd )"
 JHOVE_HOME="$( cd "$(dirname "${SCRIPT}" )" && pwd )"
-cd "${CWD}"
+cd "${CWD}" || exit
 
 # Create Java class path
 CP="${JHOVE_HOME}/bin/*"

--- a/jhove-installer/src/main/scripts/jhove-gui
+++ b/jhove-installer/src/main/scripts/jhove-gui
@@ -51,7 +51,7 @@ done
 # Store absolute location
 CWD="$( pwd )"
 JHOVE_HOME="$( cd "$(dirname "${SCRIPT}" )" && pwd )"
-cd "${CWD}"
+cd "${CWD}" || exit
 
 # Create Java class path
 CP="${JHOVE_HOME}/bin/*"

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -278,7 +278,7 @@ public class XmlModule extends ModuleBase {
 		// The XmlDeclStream filters the characters, looking for an
 		// XML declaration, since there's no way to get that info
 		// out of SAX.
-		XmlDeclStream xds = new XmlDeclStream(_cstream);
+		XmlDeclStream xds = new XmlDeclStream(_dstream);
 		try {
 			// Create an InputSource to feed the parser.
 			// If a SAX class was specified, use it, otherwise use


### PR DESCRIPTION
- removed unused configuration extensions;
- made `ChecksumInputStream _cstream` private to `ModuleBase` to avoid abuse by other modules;
- `XmlModule` now forced to use `_dstream` so works without checksumming engaged; and
- added defensive `exit` to change directories in bash scripts.