### PR TITLE
FIX - PDF Indirect Object Message

### DIFF
--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -8,7 +8,7 @@ PDF-HUL-123 = Outlines contain recursive references.
 PDF-HUL-128 = Outlines contain recursive references.
 PDF-HUL-129 = Outlines contain recursive references.
 PDF-HUL-136 = Too many fonts to report; some fonts omitted.
-PDF-HUL-136-SUB = Total fonts =
+PDF-HUL-136-SUB = Total fonts = 
 
 # Error messages
 PDF-HUL-1 = Invalid destination object

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -8,7 +8,7 @@ PDF-HUL-123 = Outlines contain recursive references.
 PDF-HUL-128 = Outlines contain recursive references.
 PDF-HUL-129 = Outlines contain recursive references.
 PDF-HUL-136 = Too many fonts to report; some fonts omitted.
-PDF-HUL-136-SUB = Total fonts = 
+PDF-HUL-136-SUB = Total fonts =
 
 # Error messages
 PDF-HUL-1 = Invalid destination object
@@ -151,5 +151,5 @@ PDF-HUL-145 = Pages dictionary Type key does not have a simple String value.
 PDF-HUL-146 = Pages dictionary Type key must have value /Pages.
 PDF-HUL-147 = Page tree node not found.
 PDF-HUL-148 = PDF minor version number is greater than 7.
-PDF-HUL-149 = Invalid indirect destination - referenced object '{0}' cannot be found
+PDF-HUL-149 = Invalid indirect destination - referenced object ''{0}'' cannot be found
 PDF-HUL-150 = Cross-reference stream must be a stream


### PR DESCRIPTION
- fixed bug in reporting of indirect object message.

Bug caused by Java's interpretation of message patterns, particularly
rules governing single quotes and format items.
See https://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html

closes #414 