### PR TITLE
REL - JHOVE v1.22

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,12 +1,115 @@
 RELEASE NOTES
 =============
-JHOVE - JSTOR/Harvard Object Validation Environment  
-Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.  
+JHOVE - JSTOR/Harvard Object Validation Environment
+Copyright 2003-2009 by JSTOR and the President and Fellows of Harvard College.
 JHOVE is made available under the GNU Lesser General Public License (LGPL;
 see the file LICENSE for details).
 
-Versions 1.7 to 1.11 of JHOVE released independently.  
+Versions 1.7 to 1.11 of JHOVE released independently.
 Versions 1.12 onwards released by the Open Preservation Foundation.
+
+JHOVE 1.22
+-------------
+2018-04-18
+
+### General
+
+- Error IDs for JHOVE messages [[#397][]]
+- Fixed Rational data types for MIX metadata [[#394][], [#429][]]
+- Individual, Maven based versioning for internal modules [[#390][]]
+- Java support upgraded to Java 1.8 [[#342][], [#343][], [#391][]]
+- Factored out error messages for core applications [[#348][]]
+- Code maintenance [[#351][], [#392][]]
+- Improvements to test scripts and automated build [[#350][], [#352][], [#379][], [#383][]]
+
+### AIFF Module
+
+- Error IDs and message constants as external resources [[#398]]
+
+### ASCII Module
+
+- Refactoring and code readability improvements [[#353][]]
+- Error IDs and message constants as external resources [[#399]]
+
+### GIF Module
+
+- Error IDs and message constants as external resources [[#400]]
+
+### HTML Module
+
+- Error IDs and message constants as external resources [[#401]]
+
+### JPEG Module
+
+- Error IDs and message constants as external resources [[#402]]
+
+### JPEG 2000 Module
+
+- Error IDs and message constants as external resources [[#403]]
+
+### PDF Module
+
+- Refactored all PDF Module error messages [[#347][]]
+- Fixed class cast exception on cross-ref streams [[#349][]]
+- Error IDs and message constants as external resources [[#404]]
+
+### TIFF Module
+
+- Fixed typo in TIFF properties [[#361][]]
+- Error IDs and message constants as external resources [[#405]]
+
+### UTF-8 Module
+
+- Refactoring and code readability improvements [[#389][]]
+- Error IDs and message constants as external resources [[#406]]
+
+### WAVE Module
+
+- Flag not well-formed when chunk exceeds RIFF length [[#360][]]
+
+### XML Module
+
+- Fix for premature end of file error [[#378][]]
+- Fix internal DTD and entity problems [[#378][]]
+
+
+[#342]: https://github.com/openpreserve/jhove/pull/342
+[#343]: https://github.com/openpreserve/jhove/pull/343
+[#347]: https://github.com/openpreserve/jhove/pull/347
+[#348]: https://github.com/openpreserve/jhove/pull/348
+[#349]: https://github.com/openpreserve/jhove/pull/349
+[#350]: https://github.com/openpreserve/jhove/pull/350
+[#351]: https://github.com/openpreserve/jhove/pull/351
+[#352]: https://github.com/openpreserve/jhove/pull/352
+[#353]: https://github.com/openpreserve/jhove/pull/353
+[#360]: https://github.com/openpreserve/jhove/pull/360
+[#363]: https://github.com/openpreserve/jhove/pull/363
+[#378]: https://github.com/openpreserve/jhove/pull/378
+[#379]: https://github.com/openpreserve/jhove/pull/379
+[#382]: https://github.com/openpreserve/jhove/pull/382
+[#383]: https://github.com/openpreserve/jhove/pull/383
+[#384]: https://github.com/openpreserve/jhove/pull/384
+[#389]: https://github.com/openpreserve/jhove/pull/389
+[#390]: https://github.com/openpreserve/jhove/pull/390
+[#391]: https://github.com/openpreserve/jhove/pull/391
+[#392]: https://github.com/openpreserve/jhove/pull/392
+[#394]: https://github.com/openpreserve/jhove/pull/394
+[#397]: https://github.com/openpreserve/jhove/pull/397
+[#398]: https://github.com/openpreserve/jhove/pull/398
+[#399]: https://github.com/openpreserve/jhove/pull/399
+[#400]: https://github.com/openpreserve/jhove/pull/400
+[#401]: https://github.com/openpreserve/jhove/pull/401
+[#402]: https://github.com/openpreserve/jhove/pull/402
+[#403]: https://github.com/openpreserve/jhove/pull/403
+[#404]: https://github.com/openpreserve/jhove/pull/404
+[#405]: https://github.com/openpreserve/jhove/pull/405
+[#406]: https://github.com/openpreserve/jhove/pull/406
+[#407]: https://github.com/openpreserve/jhove/pull/407
+[#408]: https://github.com/openpreserve/jhove/pull/408
+[#409]: https://github.com/openpreserve/jhove/pull/409
+[#411]: https://github.com/openpreserve/jhove/pull/411
+[#429]: https://github.com/openpreserve/jhove/pull/429
+
 
 JHOVE 1.20
 -------------
@@ -54,7 +157,7 @@ JHOVE 1.20
 - Subformat GUID's are now reported in their standard format, e.g.
   `00000001-0000-0010-8000-00AA00389B71`, instead of as an
   array of byte values [[#308][]]
-- Added checks to verify the existence of Data chunks and their appearance 
+- Added checks to verify the existence of Data chunks and their appearance
   after Format chunks [[#308][]]
 - Expanded WAVE example corpora to cover more formats and errors [[#308][]]
 - Improved truncation detection and reporting [[#308][]]

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-bbt/scripts/process-modules.sh
+++ b/jhove-bbt/scripts/process-modules.sh
@@ -88,7 +88,7 @@ showHelp() {
 
 # Cycle through the test module directories and invoke the correct JHOVE module
 getCorpusModules() {
-  DIRS=`ls -l "$paramModuleLoc" | egrep '^d' | awk '{print $9}'`
+  DIRS=$(ls -l "$paramModuleLoc" | grep -E '^d' | awk '{print $9}')
   for DIR in $DIRS ; do
 		moduleName=${DIR}
 		if [[ ! -e "$paramOutputRootDir/audit-$moduleName.jhove.xml" ]]
@@ -102,7 +102,7 @@ getCorpusModules() {
 processModuleDir() {
 	moduleDir=$1
 	while IFS= read -r -d '' FILE; do
-		fileName=$( basename $FILE )
+		fileName=$( basename "$FILE" )
 		if [[ ! $fileName == .gitignore ]]; then
 			echo "Testing ${FILE}"
 			bash "$SCRIPT_DIR/exec-with-to.sh" -t 300 "$paramJhoveLoc/jhove" -m "${moduleName}" -h xml -o "$paramOutputRootDir/$moduleName/$fileName.jhove.xml" -k "$FILE"

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -166,57 +166,57 @@
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>aiff-hul</artifactId>
-      <version>1.5.0-RC</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>ascii-hul</artifactId>
-      <version>1.4.0-RC</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>gif-hul</artifactId>
-      <version>1.4.0-RC</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>html-hul</artifactId>
-      <version>1.4.0-RC</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>jpeg2000-hul</artifactId>
-      <version>1.4.0-RC</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>jpeg-hul</artifactId>
-      <version>1.5.0-RC</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>pdf-hul</artifactId>
-      <version>1.12.0-RC</version>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>tiff-hul</artifactId>
-      <version>1.8.0-RC2</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>utf8-hul</artifactId>
-      <version>1.7.0-RC</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>wave-hul</artifactId>
-      <version>1.6.0-RC</version>
+      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>xml-hul</artifactId>
-      <version>1.5.0-RC2</version>
+      <version>1.5.1</version>
     </dependency>
   </dependencies>
 

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -64,7 +64,7 @@
       <file targetdir="$INSTALL_PATH/bin" src="bin/ascii-hul-1.4.1.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/ascii-hul-1.4.1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/gif-hul-1.4.1.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/gif-hul-1.4.0.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/gif-hul-1.4.1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/html-hul-1.4.1.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/html-hul-1.4.1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg2000-hul-1.4.1.jar"/>

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -59,28 +59,28 @@
       <description>JHOVE application JARs including the internal modules and configuration files.</description>
       <file targetdir="$INSTALL_PATH/bin" src="bin/jhove-apps-${project.version}.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/jhove-apps-${project.version}.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/aiff-hul-1.5.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/aiff-hul-1.5.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/ascii-hul-1.4.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/ascii-hul-1.4.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/gif-hul-1.4.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/gif-hul-1.4.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/html-hul-1.4.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/html-hul-1.4.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg2000-hul-1.4.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/jpeg2000-hul-1.4.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg-hul-1.5.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/jpeg-hul-1.5.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/pdf-hul-1.12.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/pdf-hul-1.12.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/tiff-hul-1.8.0-RC2.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/tiff-hul-1.8.0-RC2.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/utf8-hul-1.7.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/utf8-hul-1.7.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/wave-hul-1.6.0-RC.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/wave-hul-1.6.0-RC.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/xml-hul-1.5.0-RC2.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/xml-hul-1.5.0-RC2.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/aiff-hul-1.5.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/aiff-hul-1.5.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/ascii-hul-1.4.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/ascii-hul-1.4.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/gif-hul-1.4.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/gif-hul-1.4.0.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/html-hul-1.4.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/html-hul-1.4.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg2000-hul-1.4.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/jpeg2000-hul-1.4.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg-hul-1.5.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/jpeg-hul-1.5.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/pdf-hul-1.12.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/pdf-hul-1.12.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/tiff-hul-1.9.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/tiff-hul-1.9.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/utf8-hul-1.7.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/utf8-hul-1.7.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/wave-hul-1.6.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/wave-hul-1.6.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/xml-hul-1.5.1.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/xml-hul-1.5.1.jar"/>
       <file targetdir="$INSTALL_PATH/conf"  override="true" src="config/jhove.conf"/>
       <parsable targetfile="$INSTALL_PATH/conf/jhove.conf" type="xml"/>
       <updatecheck>

--- a/jhove-modules/aiff-hul/pom.xml
+++ b/jhove-modules/aiff-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>aiff-hul</artifactId>
-  <version>1.5.0-RC</version>
+  <version>1.5.1</version>
   <name>JHOVE AIFF Module HUL</name>
   <description>AIFF module developed by Harvard University Library</description>
 </project>

--- a/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
+++ b/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
@@ -25,7 +25,7 @@ import edu.harvard.hul.ois.jhove.module.iff.*;
 /**
  * Module for identification and validation of AIFF files.
  * Supports AIFF and AIFF-C.
- * 
+ *
  * @author Gary McGath
  */
 public class AiffModule
@@ -40,7 +40,7 @@ public class AiffModule
 
     /* Top-level property list */
     protected List _propList;
-    
+
     /* AES audio metadata to go into AIFF metadata */
     protected AESAudioMetadata _aesMetadata;
 
@@ -49,16 +49,16 @@ public class AiffModule
 
     /* List of MIDI Chunk properties */
     protected List _midiList;
-    
+
     /* List of Saxel properties */
     protected List _saxelList;
-    
+
     /* Bytes remaining to be read. */
     protected long bytesRemaining;
-    
+
     /* Flag to check for multiple sound chunks */
     protected boolean soundChunkSeen;
-    
+
     /* Flag to check for exactly one format version chunk */
     protected boolean formatVersionChunkSeen;
 
@@ -73,47 +73,47 @@ public class AiffModule
 
     /* Flag to check for exactly one name chunk */
     protected boolean nameChunkSeen;
-    
+
     /* Flag to check for exactly one author chunk */
     protected boolean authorChunkSeen;
-    
+
     /* Flag to check for exactly one copyright chunk */
     protected boolean copyrightChunkSeen;
-    
+
     /* Flag to check for exactly one marker chunk */
     protected boolean markerChunkSeen;
 
     /* Flag to check for exactly one audio recording chunk */
     protected boolean audioRecChunkSeen;
-    
+
     /* Flag to note that first sample offset has been recorded */
     protected boolean firstSampleOffsetMarked;
-    
+
     /* File type */
     protected int fileType;
-    
+
     /* Endianness for current file (not necessarily same as _bigEndian) */
     protected boolean thisFileBigEndian;
 
     /******************************************************************
      * PRIVATE CLASS FIELDS.
      ******************************************************************/
-    
+
     /* Chunk data orientation is big-endian. */
     private static final boolean BIGENDIAN = true;
 
     /* Values for fileType */
-    public final static int 
+    public final static int
         AIFFTYPE = 1,
         AIFCTYPE = 2;
-        
+
     /* Fixed value for first 4 bytes */
     private static final int[] sigByte =
        { 0X46, 0X4F, 0X52, 0X4D };
 
     private static final String NAME = "AIFF-hul";
-    private static final String RELEASE = "1.5.0-RC";
-    private static final int [] DATE = { 2019, 03, 05 };
+    private static final String RELEASE = "1.5.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String [] FORMAT = {
 	"AIFF", "Audio Interchange File Format"
     };
@@ -158,7 +158,7 @@ public class AiffModule
        Document doc = new Document ("Audio Interchange File Format: " +
 				    "\"AIFF\", A Standard for Sampled Sound " +
 				    "Files, Version 1.3", DocumentType.REPORT);
-       Builder builder = new Agent.Builder ("Apple Computer, Inc.", 
+       Builder builder = new Agent.Builder ("Apple Computer, Inc.",
                     AgentType.COMMERCIAL).address ("1 Infinite Loop, Cupertino, CA 95014").telephone("(408) 996-1010").web("http://www.apple.com/");
        Agent appleAgent = builder.build();
        doc.setAuthor (appleAgent);
@@ -174,7 +174,7 @@ public class AiffModule
        doc.setDate ("1991-08-26");
        doc.setNote ("*** DRAFT ***");   // Asterisks as in the printed document
        _specification.add (doc);
-                                           
+
        Signature sig = new ExternalSignature ("AIFF", SignatureType.FILETYPE,
                                     SignatureUseType.OPTIONAL);
        _signature.add (sig);
@@ -188,8 +188,8 @@ public class AiffModule
                                     SignatureUseType.OPTIONAL,
                                     "For AIFF-C profile");
        _signature.add (sig);
-       
-       sig = new InternalSignature ("FORM", SignatureType.MAGIC, 
+
+       sig = new InternalSignature ("FORM", SignatureType.MAGIC,
                                    SignatureUseType.MANDATORY, 0);
        _signature.add (sig);
 
@@ -209,7 +209,7 @@ public class AiffModule
    /**
     *   Parses the content of a purported AIFF digital object and stores the
     *   results in RepInfo.
-    * 
+    *
     *
     *   @param stream    An InputStream, positioned at its beginning,
     *                    which is generated from the object to be parsed
@@ -217,7 +217,7 @@ public class AiffModule
     *                    to reflect the results of the parsing
     *   @param parseIndex  Must be 0 in first call to <code>parse</code>.  If
     *                    <code>parse</code> returns a nonzero value, it must be
-    *                    called again with <code>parseIndex</code> 
+    *                    called again with <code>parseIndex</code>
     *                    equal to that return value.
     */
    @Override
@@ -250,18 +250,18 @@ public class AiffModule
            }
            /* If we got this far, take note that the signature is OK. */
            info.setSigMatch(_name);
-           
+
            // Get the length of the Form chunk.  This includes all
            // the subsequent chunks in the file, but excludes the
            // header ("FORM" and the length itself).
 //         bytesRemaining = readUnsignedInt (_dstream, _bigEndian, this);
            bytesRemaining = readUnsignedInt (_dstream,  BIGENDIAN, this);
-           
+
            // Read the file type.
            if (!readFileType (info)) {
                return 0;
            }
-    
+
            while (bytesRemaining > 0) {
                if (!readChunk (info)) {
                    break;
@@ -270,11 +270,11 @@ public class AiffModule
        }
        catch (EOFException e) {
            info.setWellFormed (RepInfo.FALSE);
-           info.setMessage (new ErrorMessage 
+           info.setMessage (new ErrorMessage
                 (MessageConstants.AIFF_HUL_8, _nByte));
            return 0;
        }
-       
+
        if (!commonChunkSeen) {
            info.setWellFormed (RepInfo.FALSE);
            info.setMessage (new ErrorMessage
@@ -288,7 +288,7 @@ public class AiffModule
        if (info.getWellFormed () != RepInfo.TRUE) {
            return 0;
        }
-       
+
        /* This file looks OK. */
        if (_ckSummer != null){
            skipDstreamToEnd(info);
@@ -348,21 +348,21 @@ public class AiffModule
     {
         _propList.add (prop);
     }
-    
+
     /** Adds an Annotation Property to the annotation list.
      *  This will get put into an Annotations Property. */
     public void addAnnotation (Property prop)
     {
         _annotationList.add (prop);
     }
-    
+
     /** Adds a Saxel Property to the saxel list.
      *  This will get put into a Saxels Property. */
     public void addSaxel (Property prop)
     {
         _saxelList.add (prop);
     }
-    
+
     /** Adds a MIDI Property to the MIDI list.
      *  This will get put into a MIDIData Property. */
     public void addMidi (Property prop)
@@ -374,7 +374,7 @@ public class AiffModule
      *   Initializes the state of the module for parsing.
      */
     @Override
-    protected void initParse() 
+    protected void initParse()
     {
         super.initParse ();
 
@@ -397,20 +397,20 @@ public class AiffModule
         _aesMetadata.clearBitrateReduction();
         _aesMetadata.setUse ("OTHER", "JHOVE_validation");
         _aesMetadata.setDirection ("NONE");
-        
+
         _propList.add (new Property ("AESAudioMetadata",
                 PropertyType.AESAUDIOMETADATA,
                 _aesMetadata));
-     
+
         // Create a List for accumulating properties from Annotation Chunks
         _annotationList = new LinkedList ();
 
         // Create a List for accumulating properties from MIDI Chunks
         _midiList = new LinkedList ();
-       
+
         // Create a List for accumulating properties from SAXL chunks
         _saxelList = new LinkedList ();
-       
+
         // Most chunk types are allowed to occur only once,
         // and a few must occur exactly once.
         // Clear flags for whether they have been seen.
@@ -448,8 +448,8 @@ public class AiffModule
     {
         return readSignedShort (stream, true, this);
     }
-    
-    /** This reads an 80-bit SANE number, aka IEEE 754 
+
+    /** This reads an 80-bit SANE number, aka IEEE 754
      *  extended double.
      */
     public double read80BitDouble (DataInputStream stream)
@@ -465,7 +465,7 @@ public class AiffModule
      *   Reads 4 bytes and concatenates them into a String.
      *   This pattern is used for ID's of various kinds.
      */
-    public String read4Chars(DataInputStream stream) throws IOException 
+    public String read4Chars(DataInputStream stream) throws IOException
     {
         StringBuffer sbuf = new StringBuffer(4);
         for (int i = 0; i < 4; i++) {
@@ -474,15 +474,15 @@ public class AiffModule
         }
         return sbuf.toString();
     }
-    
+
     /** Reads a Pascal string.
      *  A Pascal string is one whose count is given in the first
      *  byte.  The count is exclusive of the count byte itself.
-     *  A Pascal string can have a maximum of 255 characters. 
+     *  A Pascal string can have a maximum of 255 characters.
      *  If the count of a Pascal string is even (meaning the total
      *  number of bytes is odd), there will be a pad byte to skip,
      *  so that the next item can start on an even boundary.
-     * 
+     *
      *  We assume the string will be in ASCII or Macintosh encoding.
      */
     public String readPascalString (DataInputStream stream) throws IOException
@@ -500,15 +500,15 @@ public class AiffModule
      *  January 1, 1904) into a Java date.  The timestamp is
      *  treated as a time in the default localization.
      *  Depending on that localization,
-     *  there may be some variation in the exact hour of the date 
+     *  there may be some variation in the exact hour of the date
      *  returned, e.g., due to daylight savings time.
-     * 
+     *
      */
     public Date timestampToDate (long timestamp)
     {
         Calendar cal = Calendar.getInstance ();
         cal.set (1904, 0, 1, 0, 0, 0);
-        
+
         // If we add the seconds directly, we'll truncate the long
         // value when converting to int.  So convert to hours plus
         // residual seconds.
@@ -524,7 +524,7 @@ public class AiffModule
     {
         return fileType;
     }
-    
+
     /** Marks the first sample offset as the current byte position,
      * if it hasn't already been marked.
      * The SSND chunk offset value must be added to the current
@@ -538,7 +538,7 @@ public class AiffModule
         }
     }
 
-    /** Reads the file type.   
+    /** Reads the file type.
      *  Broken out from parse().
      *  If it is not a valid file type, returns false.
      */
@@ -557,7 +557,7 @@ public class AiffModule
             return true;
         }
         else {
-            info.setMessage (new ErrorMessage 
+            info.setMessage (new ErrorMessage
                     (MessageConstants.AIFF_HUL_4, _nByte));
             info.setWellFormed (RepInfo.FALSE);
             return false;
@@ -565,7 +565,7 @@ public class AiffModule
     }
 
     /** Reads an AIFF Chunk.
-     * 
+     *
      */
      protected boolean readChunk (RepInfo info) throws IOException
      {
@@ -576,7 +576,7 @@ public class AiffModule
         }
         int chunkSize = (int) chunkh.getSize ();
         bytesRemaining -= chunkSize + 8;
-        
+
         String id = chunkh.getID ();
         if ("FVER".equals (id)) {
             if (formatVersionChunkSeen) {
@@ -671,7 +671,7 @@ public class AiffModule
         }
         else if ("SAXL".equals (id)) {
             chunk = new SaxelChunk (this, chunkh, _dstream);
-            // Multiple saxel chunks are ok 
+            // Multiple saxel chunks are ok
         }
         else if ("ANNO".equals (id)) {
             chunk = new AnnotationChunk (this, chunkh, _dstream);
@@ -695,7 +695,7 @@ public class AiffModule
             skipBytes (_dstream, 1, this);
             --bytesRemaining;
         }
-        return true;   
+        return true;
      }
 
     /** Returns the module's AES metadata. */

--- a/jhove-modules/ascii-hul/pom.xml
+++ b/jhove-modules/ascii-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>ascii-hul</artifactId>
-  <version>1.4.0-RC</version>
+  <version>1.4.1</version>
   <name>JHOVE ASCII Module HUL</name>
   <description>ASCII module developed by Harvard University Library</description>
 

--- a/jhove-modules/ascii-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
+++ b/jhove-modules/ascii-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AsciiModule.java
@@ -40,8 +40,8 @@ public class AsciiModule extends ModuleBase {
      * PRIVATE CLASS FIELDS.
      ******************************************************************/
     private static final String NAME = "ASCII-hul";
-    private static final String RELEASE = "1.4.0-RC";
-    private static final int [] DATE = { 2019, 03, 05 };
+    private static final String RELEASE = "1.4.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String[] FORMAT = { "ASCII", "US-ASCII", "ANSI X3.4",
             "ISO 646" };
     private static final String COVERAGE = null;

--- a/jhove-modules/gif-hul/pom.xml
+++ b/jhove-modules/gif-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>gif-hul</artifactId>
-  <version>1.4.0-RC</version>
+  <version>1.4.1</version>
   <name>JHOVE GIF Module HUL</name>
   <description>GIF module developed by Harvard University Library</description>
 </project>

--- a/jhove-modules/gif-hul/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
+++ b/jhove-modules/gif-hul/src/main/java/edu/harvard/hul/ois/jhove/module/GifModule.java
@@ -83,8 +83,8 @@ public class GifModule extends ModuleBase
      ******************************************************************/
 
     private static final String NAME = "GIF-hul";
-    private static final String RELEASE = "1.4.0-RC";
-    private static final int [] DATE = { 2019, 05, 03 };
+    private static final String RELEASE = "1.4.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String [] FORMAT = {"GIF",
                                              "Graphics Interchange Format"};
     private static final String COVERAGE = "GIF87a, GIF89a";

--- a/jhove-modules/html-hul/pom.xml
+++ b/jhove-modules/html-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>html-hul</artifactId>
-  <version>1.4.0-RC</version>
+  <version>1.4.1</version>
   <name>JHOVE HTML Module HUL</name>
   <description>HTML module developed by Harvard University Library</description>
 
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>xml-hul</artifactId>
-        <version>1.5.0-RC2</version>
+        <version>1.5.1</version>
       </dependency>
   </dependencies>
 

--- a/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
+++ b/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/HtmlModule.java
@@ -104,8 +104,8 @@ public class HtmlModule extends ModuleBase {
 	private static final String XHTML_1_0 = "XHTML 1.0";
 
 	private static final String NAME = "HTML-hul";
-	private static final String RELEASE = "1.4.0-RC";
-	private static final int[] DATE = { 2019, 05, 03 };
+	private static final String RELEASE = "1.4.1";
+  private static final int [] DATE = { 2019, 04, 17 };
 	private static final String[] FORMAT = { "HTML" };
 	private static final String COVERAGE = "HTML 3.2, HTML 4.0 Strict,"
 			+ "HTML 4.0 Transitional, HTML 4.0 Frameset, "

--- a/jhove-modules/jpeg-hul/pom.xml
+++ b/jhove-modules/jpeg-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>jpeg-hul</artifactId>
-  <version>1.5.0-RC</version>
+  <version>1.5.1</version>
   <name>JHOVE JPEG Module HUL</name>
   <description>JPEG module developed by Harvard University Library</description>
 
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>tiff-hul</artifactId>
-        <version>1.8.0-RC2</version>
+        <version>1.9.1</version>
       </dependency>
   </dependencies>
 

--- a/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -6,12 +6,12 @@
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option) any
  * later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -76,9 +76,9 @@ import edu.harvard.hul.ois.jhove.module.jpeg.Tiling;
 
 /**
  * Module for identification and validation of JPEG files.
- * 
+ *
  * General notes:
- * 
+ *
  * There is no such thing as a "JPEG file format." There are several commonly
  * used file formats which encapsulate JPEG data and conform to the JPEG stream
  * format. There are also many formats which can encapsulate JPEG data within
@@ -87,7 +87,7 @@ import edu.harvard.hul.ois.jhove.module.jpeg.Tiling;
  * which isn't one of the known file formats will be regarded as well-formed,
  * but not valid. To be valid, a file must conform to one of the following:
  * JFIF, SPIFF, and JPEG/Exif. Other formats may be added in the future.
- * 
+ *
  * This module uses the JPEG-L method of detecting a marker following a data
  * stream, checking for a 0 high bit rather than an entire 0 byte. So long at no
  * JPEG markers are defined with a value from 0 through 7F, this is valid for
@@ -108,8 +108,8 @@ public class JpegModule extends ModuleBase {
 	 ******************************************************************/
 	private static final String NISO_IMAGE_MD = "NisoImageMetadata";
 	private static final String NAME = "JPEG-hul";
-	private static final String RELEASE = "1.5.0-RC2";
-	private static final int[] DATE = { 2019, 03, 29 };
+	private static final String RELEASE = "1.5.1";
+  private static final int [] DATE = { 2019, 04, 17 };
 	private static final String[] FORMAT = { "JPEG", "ISO/IEC 10918-1:1994",
 			"Joint Photographic Experts Group", "JFIF",
 			"JPEG File Interchange Format", "SPIFF", "ISO/IEC 10918-3:1997",
@@ -468,7 +468,7 @@ public class JpegModule extends ModuleBase {
 	/**
 	 * Parse the content of a purported JPEG stream digital object and store the
 	 * results in RepInfo.
-	 * 
+	 *
 	 * This function uses the JPEG-L method of detecting a marker following a
 	 * data stream, checking for a 0 high bit rather than an entire 0 byte. So
 	 * long at no JPEG markers are defined with a value from 0 through 7F, this

--- a/jhove-modules/jpeg2000-hul/pom.xml
+++ b/jhove-modules/jpeg2000-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>jpeg2000-hul</artifactId>
-  <version>1.4.0-RC</version>
+  <version>1.4.1</version>
   <name>JHOVE JPEG 2000 Module HUL</name>
   <description>JPEG 2000 module developed by Harvard University Library</description>
 </project>

--- a/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
+++ b/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
@@ -6,12 +6,12 @@
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option) any
  * later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -56,7 +56,7 @@ import edu.harvard.hul.ois.jhove.module.jpeg2000.TopLevelBoxHolder;
 
 /**
  * Module for identification and validation of JPEG 2000 files.
- * 
+ *
  * Code is included for JPX, but is almost entirely untested due to the lack of
  * available sample files that use more than a tiny fraction of the features.
  * The current version of the module is based on the typo-laden and inconsisent
@@ -64,7 +64,7 @@ import edu.harvard.hul.ois.jhove.module.jpeg2000.TopLevelBoxHolder;
  * standard (5 May 2004) has just reached our hands, and this code will be
  * reviewed against it and revised accordingly in the near future. (All opinions
  * expressed in this paragraph are those of the programmer.)
- * 
+ *
  * JPEG 2000 format is not JPEG format, and isn't compatible with it. As with
  * JPEG, JPEG 2000 is not in itself a file format. It can be encapsulated in JP2
  * or JPX format, which are recognized here.
@@ -85,7 +85,7 @@ public class Jpeg2000Module extends ModuleBase {
      * boxes to be hidden within its compressed or encrypted data. All this
      * makes the concept of "parent box" trickier than it is in unextended JP2,
      * since parenthood and containment are not necessarily the same thing.
-     * 
+     *
      * The way I've chosen deal with this rather chimerical design is to have a
      * RandomAccessFile for a base, but have each Box based on a
      * DataInputStream. Not every Box has its own separate stream -- that would
@@ -94,7 +94,7 @@ public class Jpeg2000Module extends ModuleBase {
      * TopLevelBoxHolder. The extension to multiple files isn't supported here,
      * since the job of Jhove is to validate individual files, but it wouldn't
      * be difficult to add.
-     * 
+     *
      * Every BoxHolder (hence every box) implements the Iterator interface, so
      * that a box can get its subboxes in a way which is blind to the details of
      * their encoding.
@@ -105,8 +105,8 @@ public class Jpeg2000Module extends ModuleBase {
      ******************************************************************/
 
     private static final String NAME = "JPEG2000-hul";
-    private static final String RELEASE = "1.4.0-RC";
-    private static final int[] DATE = { 2019, 03, 04 };
+    private static final String RELEASE = "1.4.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String[] FORMAT = { "JPEG 2000", "JP2", "JPX" };
     private static final String COVERAGE = "JP2 (ISO/IEC 15444-1:2000/"
             + "ITU-T Rec. T.800 (200)), JPX (ISO/IEC 15444-2:2004)";
@@ -315,17 +315,17 @@ public class Jpeg2000Module extends ModuleBase {
     /**
      * Parse the content of a stream digital object and store the results in
      * RepInfo.
-     * 
+     *
      * This module is based on a RandomAccessFile because of the requirements of
      * the (so far) rarely used fragmented codestream feature. Since just about
      * everything else can be done with an InputStream, we use a RAFInputStream
      * except on the occasions when random access is needed. We pass the module
      * as the <code>counted</code> argment to all read calls, so that we can
      * compute relative positions in the stream based on _nByte.
-     * 
+     *
      * @param raf
      *            A RandomAccessFile to be parsed.
-     * 
+     *
      * @param info
      *            A fresh (on the first call) RepInfo object which will be
      *            modified to reflect the results of the parsing If multiple

--- a/jhove-modules/pdf-hul/pom.xml
+++ b/jhove-modules/pdf-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>pdf-hul</artifactId>
-  <version>1.12.0-RC</version>
+  <version>1.12.1</version>
   <name>JHOVE PDF Module HUL</name>
   <description>PDF module developed by Harvard University Library</description>
 </project>

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -374,8 +374,8 @@ public class PdfModule extends ModuleBase {
 	 ******************************************************************/
 
 	private static final String NAME = "PDF-hul";
-	private static final String RELEASE = "1.12-RC";
-	private static final int[] DATE = { 2019, 03, 05 };
+	private static final String RELEASE = "1.12.1";
+  private static final int [] DATE = { 2019, 04, 17 };
 	private static final String[] FORMAT = { "PDF",
 			"Portable Document Format" };
 	private static final String COVERAGE = "PDF 1.0-1.6; PDF/X-1 (ISO 15930-1:2001), X-1a (ISO 15930-4:2003), "
@@ -3881,7 +3881,7 @@ public class PdfModule extends ModuleBase {
 	 * catalog dictionary. As a side effect, we set the actionsExist
 	 * flag if any Actions are found. Because we check destinations,
 	 * this can't be called till the page tree is built.
-	 * 
+	 *
 	 * Outlines can be recursive, according to Adobe people, so we have
 	 * to track visited nodes.
 	 */

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
 
   <groupId>org.openpreservation.jhove.modules</groupId>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.openpreservation.jhove</groupId>
       <artifactId>jhove-core</artifactId>
-      <version>1.22.0-RC2</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jhove-modules/tiff-hul/pom.xml
+++ b/jhove-modules/tiff-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>tiff-hul</artifactId>
-  <version>1.8.0-RC2</version>
+  <version>1.9.1</version>
   <name>JHOVE TIFF Module HUL</name>
   <description>TIFF module developed by Harvard University Library</description>
 </project>

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -6,12 +6,12 @@
  * the terms of the GNU Lesser General Public License as published by the Free
  * Software Foundation; either version 2 of the License, or (at your option) any
  * later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -121,8 +121,8 @@ public class TiffModule extends ModuleBase {
     protected Logger _logger;
 
     private static final String NAME = "TIFF-hul";
-    private static final String RELEASE = "1.8.0-RC2";
-    private static final int[] DATE = { 2019, 03, 29 };
+    private static final String RELEASE = "1.9.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String[] FORMAT = { "TIFF", "Tagged Image File Format" };
     private static final String COVERAGE = "TIFF 4.0, 5.0, and 6.0; "
             + "TIFF/IT (ISO/DIS 12639:2003), including file types CT, LW, HC, MP, "
@@ -474,7 +474,7 @@ public class TiffModule extends ModuleBase {
     /**
      * Parse the TIFF for well-formedness and validity, accumulating
      * representation information.
-     * 
+     *
      * @param raf
      *            Open TIFF file
      * @param info
@@ -664,7 +664,7 @@ public class TiffModule extends ModuleBase {
 
     /**
      * Special-purpose, limited parser for embedded Exif files.
-     * 
+     *
      * @param raf
      *            Open TIFF file
      * @param info
@@ -847,7 +847,7 @@ public class TiffModule extends ModuleBase {
 
     /**
      * Check the validity of the IFD.
-     * 
+     *
      * @param ifd
      *            IFD
      */
@@ -1141,7 +1141,7 @@ public class TiffModule extends ModuleBase {
 
     /**
      * Parse all IFDs in the file, accumulating representation information.
-     * 
+     *
      * @param offset
      *            Starting byte offset
      * @param info
@@ -1154,7 +1154,7 @@ public class TiffModule extends ModuleBase {
 
     /**
      * Parse all IFDs in the file, accumulating representation information.
-     * 
+     *
      * @param offset
      *            Starting byte offset
      * @param info

--- a/jhove-modules/utf8-hul/pom.xml
+++ b/jhove-modules/utf8-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>utf8-hul</artifactId>
-  <version>1.7.0-RC</version>
+  <version>1.7.1</version>
   <name>JHOVE UTF8 Module HUL</name>
   <description>UTF8 module developed by Harvard University Library</description>
 
@@ -14,12 +14,12 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>ascii-hul</artifactId>
-        <version>1.4.0-RC</version>
+        <version>1.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>pdf-hul</artifactId>
-        <version>1.12.0-RC</version>
+        <version>1.12.1</version>
         <scope>test</scope>
       </dependency>
   </dependencies>

--- a/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
+++ b/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
@@ -63,8 +63,8 @@ public class Utf8Module extends ModuleBase {
      * PRIVATE CLASS FIELDS.
      ******************************************************************/
     private static final String NAME = "UTF8-hul";
-    private static final String RELEASE = "1.7.0-RC";
-    private static final int[] DATE = { 2019, 03, 05 };
+    private static final String RELEASE = "1.7.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String[] FORMAT = { "UTF-8" };
     private static final String COVERAGE = "Unicode 7.0.0";
     private static final String[] MIMETYPE = { "text/plain; charset=UTF-8" };

--- a/jhove-modules/wave-hul/pom.xml
+++ b/jhove-modules/wave-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>wave-hul</artifactId>
-  <version>1.6.0-RC</version>
+  <version>1.6.1</version>
   <name>JHOVE WAVE Module HUL</name>
   <description>WAVE module developed by Harvard University Library</description>
 
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>aiff-hul</artifactId>
-        <version>1.5.0-RC</version>
+        <version>1.5.1</version>
       </dependency>
   </dependencies>
 

--- a/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -71,8 +71,8 @@ public class WaveModule extends ModuleBase {
 
     /* Module metadata */
     private static final String NAME = "WAVE-hul";
-    private static final String RELEASE = "1.7.0-RC";
-    private static final int[] DATE = { 2019, 03, 05 };
+    private static final String RELEASE = "1.7.1";
+    private static final int [] DATE = { 2019, 04, 17 };
     private static final String[] FORMATS = { "WAVE", "Audio for Windows",
             "EBU Technical Specification 3285", "Broadcast Wave Format", "BWF",
             "EBU Technical Specification 3306", "RF64" };

--- a/jhove-modules/xml-hul/pom.xml
+++ b/jhove-modules/xml-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.22.0-RC2</version>
+    <version>1.22.0</version>
   </parent>
   <artifactId>xml-hul</artifactId>
-  <version>1.5.0-RC2</version>
+  <version>1.5.1</version>
   <name>JHOVE XML Module HUL</name>
   <description>XML module developed by Harvard University Library</description>
 
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>utf8-hul</artifactId>
-        <version>1.7.0-RC</version>
+        <version>1.7.1</version>
       </dependency>
   </dependencies>
 

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -2,7 +2,7 @@
  * Jhove - JSTOR/Harvard Object Validation Environment
  * Copyright 2004-2007 by JSTOR and the President and Fellows of Harvard College
  *
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or (at
@@ -39,7 +39,7 @@ import org.xml.sax.helpers.*;
 
 /**
  * Module for identification and validation of XML files.
- * 
+ *
  * @author Gary McGath
  */
 public class XmlModule extends ModuleBase {
@@ -48,8 +48,8 @@ public class XmlModule extends ModuleBase {
 	 ******************************************************************/
 
 	private static final String NAME = "XML-hul";
-	private static final String RELEASE = "1.5.0-RC2";
-	private static final int[] DATE = { 2019, 03, 29 };
+	private static final String RELEASE = "1.5.1";
+  private static final int [] DATE = { 2019, 04, 17 };
 	private static final String[] FORMAT = { "XML", "XHTML" };
 	private static final String COVERAGE = "XML 1.0";
 	/*
@@ -1005,7 +1005,7 @@ public class XmlModule extends ModuleBase {
 
 	/**
 	 * Verification that the string contains something usefull.
-	 * 
+	 *
 	 * @param value
 	 *            string to test
 	 * @return boolean

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.22.0-RC2</version>
+  <version>1.22.0</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>


### PR DESCRIPTION
- bumped core code versions to 1.22;
- bumped all module versions and dependencies;
- updated `RELEASENOTES.md` for 1.22; and
- fixed lint errors in test scripts.
