### PR TITLE
Change method scope to support extending module classes

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/HandlerBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/HandlerBase.java
@@ -591,7 +591,7 @@ public abstract class HandlerBase
      *   to entities as necessary and removing control characters disallowed
      *   by XML.  The null string will be converted to an empty string.
      */
-    private static String encodeContent (String content)
+    protected static String encodeContent (String content)
     {
         if (content == null) {
             content = "";
@@ -632,7 +632,7 @@ public abstract class HandlerBase
      *   converting quote characters to entities and removing control
      *   characters disallowed by XML.
      */
-    private static String encodeValue (String value)
+    protected static String encodeValue (String value)
     {
         StringBuffer buffer = new StringBuffer (value);
 

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -92,7 +92,7 @@ public abstract class ModuleBase implements Module {
 	protected Checksummer _ckSummer;
 
 	/* Input stream wrapper which handles checksums */
-	private ChecksumInputStream _cstream;
+	protected ChecksumInputStream _cstream;
 
 	/* Data input stream wrapped around _cstream */
 	protected DataInputStream _dstream;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -897,10 +897,15 @@ public class XmlHandler
     }
 
 
-    /** Checks if a property would produce an empty XML element, and
-     *  returns true if it would.
+    /**
+     * Checks if a property would produce an empty XML element, and returns true if
+     * it would.
+     * 
+     * @param property
+     * @param arity
+     * @return
      */
-    private boolean isPropertyEmpty (Property property, PropertyArity arity) {
+    public boolean isPropertyEmpty (Property property, PropertyArity arity) {
         try {
             if (arity.equals (PropertyArity.SET)) {
                 Set propSet = (Set) property.getValue ();
@@ -4406,10 +4411,14 @@ public class XmlHandler
 	}
     }
 
-    /* Clean up a URI string by escaping forbidden characters.
+    /**
+     * Clean up a URI string by escaping forbidden characters. 
      * We assume (perhaps dangerously) that a % is the start of
-     * an already escaped hexadecimal sequence. */
-    private String cleanURIString (String uri) {
+     * an already escaped hexadecimal sequence.
+     * @param uri
+     * @return
+     */
+    public String cleanURIString (String uri) {
         StringBuffer sb = new StringBuffer (uri.length() * 2);
         boolean change = false;
         for (int i = 0; i < uri.length (); i++) {

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
@@ -21,7 +21,7 @@ public final class XhtmlProcessing {
 
     /** Process an element and extract metadata */
     /** Process the element to extract any available metadata. */
-    protected static void processElement (String localName,
+    public static void processElement (String localName,
                 String qualifiedName,
                 Attributes atts,
                 HtmlMetadata mdata)


### PR DESCRIPTION
Portico is working to upgrade to 1.23 - we currently use a modified older version of JHOVE. There are several method/property scope changes would that allow us to continue to use some local module extensions without having to maintain a customized version of JHOVE. If they are benign (or even useful) for other users, it would be great if we could merge these.  

Question for reviewer(s): one of the changes is in the `xml-hul` module. Should I increment the version? and if so to a SNAPSHOT version?

Thanks!