### PR TITLE
Update gif Error.Message properties for Control Extensions

### DIFF
--- a/jhove-modules/gif-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/gif/ErrorMessages.properties
+++ b/jhove-modules/gif-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/gif/ErrorMessages.properties
@@ -1,10 +1,10 @@
-GIF-HUL-1 = Wrong application extension block size
+GIF-HUL-1 = Wrong Application Extension block size
 GIF-HUL-2 = Unknown data block type
 GIF-HUL-3 = Unknown extension block type
 GIF-HUL-4 = Invalid GIF header
-GIF-HUL-5 = Multiple graphics control blocks for one image
-GIF-HUL-6 = Wrong graphics control block size
-GIF-HUL-7 = Wrong plain text extension block size
-GIF-HUL-8 = Plain text extension requires global color table
+GIF-HUL-5 = Multiple Graphics Control Extension blocks for one image
+GIF-HUL-6 = Wrong Graphic Control Extension block size
+GIF-HUL-7 = Wrong Plain Text Extension block size
+GIF-HUL-8 = Plain Text Extension requires global color table
 GIF-HUL-9 = End of file reached without encountering Trailer block
 GIF-HUL-10 = Unexpected end of file


### PR DESCRIPTION
extension block wording has been homogenized to capital lettering as per standard (e.g. graphic control extension -> Graphic Control Extension); 
changed "Multiple graphics control blocks" to "Multiple Graphics Control Extension blocks" in GIF-HUL-5 as per standard