### PR TITLE
Fixed: nested if statements could be combined

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ModuleInfoWindow.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/ModuleInfoWindow.java
@@ -160,11 +160,10 @@ public class ModuleInfoWindow extends InfoWindow{
         }
         texta.append (margin + signature.getType ().toString () + ": " +
                          sigValue + eol);
-        if (signature.getType ().equals (SignatureType.MAGIC)) {
-            if (((InternalSignature) signature).hasFixedOffset ()) {
-                texta.append (margin + "Offset: " +
+        if (signature.getType ().equals (SignatureType.MAGIC) && 
+                ((InternalSignature) signature).hasFixedOffset ()) {
+            texta.append (margin + "Offset: " +
 		     ((InternalSignature) signature).getOffset () + eol);
-            }
         }
         String note = signature.getNote ();
         if (note != null) {

--- a/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlDocDesc.java
+++ b/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/html/HtmlDocDesc.java
@@ -154,12 +154,11 @@ public abstract class HtmlDocDesc {
 		 * If it's anything but an HTML tag, and the stack is empty,
 		 * push an "HTML" element.
 		 */
-		if (elementStack.isEmpty()) {
-			if (!"html".equals(name)) {
-				JHOpenTag fakeTag = new JHOpenTag("html");
-				fakeTag.setElement(htmlElement);
-				elementStack.push(fakeTag);
-			}
+		if (elementStack.isEmpty() && !"html".equals(name)) {
+                    JHOpenTag fakeTag = new JHOpenTag("html");
+                    fakeTag.setElement(htmlElement);
+                    elementStack.push(fakeTag);
+			
 		}
 		HtmlTagDesc tagDesc = (HtmlTagDesc) supportedElements.get(name);
 		if (tagDesc == null) {

--- a/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/html/JHOpenTag.java
+++ b/jhove-modules/html-hul/src/main/java/edu/harvard/hul/ois/jhove/module/html/JHOpenTag.java
@@ -430,10 +430,8 @@ public class JHOpenTag extends JHElement {
             JHAttribute attr = (JHAttribute) iter.next ();
             String attname = attr.getName ();
             String attval = attr.getValue ();
-            if ("type".equals (attname)) {
-                if (attval.length() > 0 ) {
-                    mdata.addScript (attval);
-                }
+            if ("type".equals (attname) && attval.length() > 0 ) {
+                mdata.addScript (attval);
             }
         }
     }

--- a/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -1493,32 +1493,29 @@ public class JpegModule extends ModuleBase {
 		if (dbyt != 0XF7 && dbyt != 0XF8) {
 			_seenJPEGL = false;
 		}
-
-		if (dbyt == 0XF7) {
-			// This is probably a JPEG-L file.
-			if (!_seenSPIFF && !_seenJFIF && !_seenExif && !_seenJPEGL) {
-				if (!_reportedSigMatch) {
-					info.setSigMatch(_name);
-					_reportedSigMatch = true;
-				}
-				int length = readUnsignedShort(_dstream);
-				int precision = readUnsignedByte(_dstream, this);
-				int nLines = readUnsignedShort(_dstream);
-				int samPerLine = readUnsignedShort(_dstream);
-				int numComps = readUnsignedByte(_dstream, this);
-				skipBytes(_dstream, length - 8, this);
-				_seenJPEGL = true;
-				_niso.setImageLength(nLines);
-				_niso.setImageWidth(samPerLine);
-				int[] bps = new int[numComps];
-				for (int i = 0; i < numComps; i++) {
-					bps[i] = precision;
-				}
-				_niso.setBitsPerSample(bps);
-				_niso.setSamplesPerPixel(numComps);
-				_seenSOF = true;
-				return;
-			}
+		if (dbyt == 0XF7 && !_seenSPIFF && !_seenJFIF && !_seenExif && !_seenJPEGL) {
+                    // This is probably a JPEG-L file.
+                    if (!_reportedSigMatch) {
+                        info.setSigMatch(_name);
+                        _reportedSigMatch = true;
+                    }
+                    int length = readUnsignedShort(_dstream);
+                    int precision = readUnsignedByte(_dstream, this);
+                    int nLines = readUnsignedShort(_dstream);
+                    int samPerLine = readUnsignedShort(_dstream);
+                    int numComps = readUnsignedByte(_dstream, this);
+                    skipBytes(_dstream, length - 8, this);
+                    _seenJPEGL = true;
+                    _niso.setImageLength(nLines);
+                    _niso.setImageWidth(samPerLine);
+                    int[] bps = new int[numComps];
+                    for (int i = 0; i < numComps; i++) {
+                            bps[i] = precision;
+                    }
+                    _niso.setBitsPerSample(bps);
+                    _niso.setSamplesPerPixel(numComps);
+                    _seenSOF = true;
+                    return;
 		}
 
 		int length = readUnsignedShort(_dstream);

--- a/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/JpegExif.java
+++ b/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/JpegExif.java
@@ -137,22 +137,20 @@ public final class JpegExif {
             NisoImageMetadata niso = null;
             while (iter.hasNext()) {
                 Object ifd = iter.next ();
-                if (ifd instanceof TiffIFD) {
+                if (ifd instanceof TiffIFD && first) {
                     // The TIFF IFD has useful information, which gets put
                     // into its NISO metadata.  Make it available to the caller.
-                    if (first) {
-                    	TiffIFD tifd = (TiffIFD)ifd;
-                        niso = tifd.getNisoImageMetadata ();
-                        // The first one is presumed to be the interesting one.
-                        info.setProperty (new Property ("NisoImageMetadata",
-                                               PropertyType.NISOIMAGEMETADATA,
-                                               niso));
-                        haveNisoMetadata = true;
-                        TiffProfileExif exifProfile = new TiffProfileExif ();
-                        _exifProfileOK = exifProfile.satisfiesProfile (tifd);
-                        if (_exifProfileOK) {
-                        	_profileText = exifProfile.getText();
-                        }
+                    TiffIFD tifd = (TiffIFD)ifd;
+                    niso = tifd.getNisoImageMetadata ();
+                    // The first one is presumed to be the interesting one.
+                    info.setProperty (new Property ("NisoImageMetadata",
+                                           PropertyType.NISOIMAGEMETADATA,
+                                           niso));
+                    haveNisoMetadata = true;
+                    TiffProfileExif exifProfile = new TiffProfileExif ();
+                    _exifProfileOK = exifProfile.satisfiesProfile (tifd);
+                    if (_exifProfileOK) {
+                            _profileText = exifProfile.getText();
                     }
                 }
                 if (ifd instanceof ExifIFD) {

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/AProfile.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/AProfile.java
@@ -203,10 +203,8 @@ public final class AProfile extends PdfProfile
             // If it has an interactive form, it must meet certain criteria
             PdfDictionary form = (PdfDictionary) 
                 _module.resolveIndirectObject (cat.get ("AcroForm"));
-            if (form != null) {
-                if (!formOK (form)) {
-                    return false;
-                }
+            if (form != null && !formOK (form)) {
+                return false;
             }
 
             // It may not contain an AA entry or an OCProperties entry
@@ -505,10 +503,8 @@ public final class AProfile extends PdfProfile
             // The NeedAppearances flag either shall not be present
             // or shall be false.
             PdfSimpleObject needapp = (PdfSimpleObject) form.get ("NeedAppearances");
-            if (needapp != null) {
-                if (!needapp.isFalse ()) {
-                    return false;
-                }
+            if (needapp != null && !needapp.isFalse ()) {
+                return false;
             }
         }
         catch (Exception e) {
@@ -548,10 +544,8 @@ public final class AProfile extends PdfProfile
                     PdfDictionary kid = (PdfDictionary) kidVec.elementAt (i);
                     // The safest way to check if this is a field seems
                     // to be to look for the required Parent entry.
-                    if (kid.get ("Parent") != null) {
-                        if (!fieldOK (kid)) {
-                            return false;
-                        }
+                    if (kid.get ("Parent") != null && !fieldOK (kid)) {
+                        return false;
                     }
                 }
             }
@@ -681,10 +675,8 @@ public final class AProfile extends PdfProfile
                             }
                             
                             // If it's a Widget, it can't have an AA entry
-                            if ("Widget".equals (subtypeVal)) {
-                                if (annDict.get ("AA") != null) {
-                                    return false;
-                                }
+                            if ("Widget".equals (subtypeVal) && annDict.get ("AA") != null) {
+                                return false;
                             }
                             // For non-text annotation types, the
                             // Contents key is RECOMMENDED, not required.
@@ -754,10 +746,8 @@ public final class AProfile extends PdfProfile
                 }
                 // If this is the first time we've hit an uncalibrated
                 // color space, check for an appropriate OutputIntent dict.
-                if (hasUncalCS && !oldHasUncalCS) {
-                    if (!checkUncalIntent ()) {
-                        return false;
-                    }
+                if (hasUncalCS && !oldHasUncalCS && !checkUncalIntent ()) {
+                    return false;
                 }
                 if (hasDevRGB && hasDevCMYK) {
                     return false;   // can't have both in same file
@@ -806,10 +796,9 @@ public final class AProfile extends PdfProfile
                             theOutProfile = outProfile;
                         }
                         PdfSimpleObject subtype = (PdfSimpleObject) intent.get ("S");
-                        if (subtype != null) {
-                            if ("GTS_PDFA1".equals (subtype.getStringValue())) {
-                                pdfaProfileSeen = true;
-                            }
+                        if (subtype != null && 
+                                "GTS_PDFA1".equals (subtype.getStringValue())) {
+                            pdfaProfileSeen = true;
                         }
                     }
                 }
@@ -865,10 +854,8 @@ public final class AProfile extends PdfProfile
         try {
             PdfDictionary action = (PdfDictionary) 
                      _module.resolveIndirectObject (item.get ("A"));
-            if (action != null) {
-                if (!actionOK (action)) {
-                    return false;
-                }
+            if (action != null && !actionOK (action)) {
+                return false;
             }
             PdfDictionary child = (PdfDictionary)
                      _module.resolveIndirectObject (item.get ("First"));
@@ -1037,15 +1024,11 @@ public final class AProfile extends PdfProfile
                     // PS XObjects aren't allowed.
                     return false;
                 }
-                if ("Image".equals (subtypeVal)) {
-                    if (!imageObjectOK (xo)) {
-                        return false;   
-                    }
+                if ("Image".equals (subtypeVal) && !imageObjectOK (xo)) {
+                    return false;
                 }
-                if ("Form".equals (subtypeVal)) {
-                    if (!formObjectOK (xo)) {
-                        return false;   
-                    }
+                if ("Form".equals (subtypeVal) && !formObjectOK (xo)) {
+                    return false;
                 }
             }
         }
@@ -1085,10 +1068,8 @@ public final class AProfile extends PdfProfile
             
             // Interpolate is allowed only if its value is false.
             PdfSimpleObject interp = (PdfSimpleObject) xo.get ("Interpolate");
-            if (interp != null) {
-                if (!interp.isFalse ()) {
-                    return false;
-                }
+            if (interp != null && !interp.isFalse ()) {
+                return false;
             }
             
             // Intent must be one of the four standard rendering intents,

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/LinearizedProfile.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/LinearizedProfile.java
@@ -179,16 +179,14 @@ public final class LinearizedProfile extends PdfProfile
             // "obj".
             for (;;) {
                 Token tok = _parser.getNext ();
-                if (tok instanceof Keyword) {
-                    if ("obj".equals(((Keyword) tok).getValue ())) {
-                        PdfObject val = _parser.readObject (false);
-                        // Object must be completely contained in
-                        // the first 1024 bytes.
-                        if (_parser.getOffset () <= 1024) {
-                            return val;
-                        }
-                        return null;
+                if (tok instanceof Keyword && "obj".equals(((Keyword) tok).getValue ())) {
+                    PdfObject val = _parser.readObject (false);
+                    // Object must be completely contained in
+                    // the first 1024 bytes.
+                    if (_parser.getOffset () <= 1024) {
+                        return val;
                     }
+                    return null;
                 }
                 if (_parser.getOffset () > 1024) {
                     return null;

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Parser.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Parser.java
@@ -407,33 +407,31 @@ public class Parser
             PdfObject obj = v.elementAt (i);
             if (obj instanceof PdfSimpleObject) {
                 Token tok = ((PdfSimpleObject) obj).getToken ();
-                if (tok instanceof Keyword) {
-                    if ("R".equals (((Keyword)tok).getValue ())) {
-                        // We're in the key of 'R'.  The two previous tokens
-                        // had better be Numerics.  Three objects in the Vector
-                        // are replaced by one.
-                        try {
-                            PdfSimpleObject nobj =
-                                    (PdfSimpleObject) v.elementAt (i - 2);
-                            Numeric ntok = (Numeric) nobj.getToken ();
-                            int objNum = ntok.getIntegerValue ();
-                            nobj = (PdfSimpleObject) v.elementAt (i - 1);
-                            ntok = (Numeric) nobj.getToken ();
-                            int genNum = ntok.getIntegerValue ();
-                            v.set (i - 2, new PdfIndirectObj
-                                    (objNum, genNum, _objectMap));
-                            //v.removeElementAt (i);
-                            //v.removeElementAt (i - 1);
-                            // Put in null as placeholder, to be removed below
-                            v.set(i, null);
-                            v.set(i - 1, null);
-                            lowestChanged = i - 1;
-                            i -= 2;
-                        }
-                        catch (Exception e) {
-                            throw new PdfMalformedException 
-                                (MessageConstants.PDF_HUL_44); // PDF-HUL-44
-                        }
+                if (tok instanceof Keyword && "R".equals (((Keyword)tok).getValue ())) {
+                    // We're in the key of 'R'.  The two previous tokens
+                    // had better be Numerics.  Three objects in the Vector
+                    // are replaced by one.
+                    try {
+                        PdfSimpleObject nobj =
+                                (PdfSimpleObject) v.elementAt (i - 2);
+                        Numeric ntok = (Numeric) nobj.getToken ();
+                        int objNum = ntok.getIntegerValue ();
+                        nobj = (PdfSimpleObject) v.elementAt (i - 1);
+                        ntok = (Numeric) nobj.getToken ();
+                        int genNum = ntok.getIntegerValue ();
+                        v.set (i - 2, new PdfIndirectObj
+                                (objNum, genNum, _objectMap));
+                        //v.removeElementAt (i);
+                        //v.removeElementAt (i - 1);
+                        // Put in null as placeholder, to be removed below
+                        v.set(i, null);
+                        v.set(i - 1, null);
+                        lowestChanged = i - 1;
+                        i -= 2;
+                    }
+                    catch (Exception e) {
+                        throw new PdfMalformedException 
+                            (MessageConstants.PDF_HUL_44); // PDF-HUL-44
                     }
                 }
             }

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/StructureElement.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/StructureElement.java
@@ -146,13 +146,12 @@ public class StructureElement
                                 if(kidsObject instanceof PdfSimpleObject) {
                                     PdfSimpleObject kids = (PdfSimpleObject)kidsObject;
                                     Token tok = kids.getToken();
-                                    if(tok instanceof Numeric) {
+                                    if (tok instanceof Numeric && ((Numeric)tok).getValue() == 0) {
                                         //if the kids value is zero then there are no child objects; exit method
-                                        if(((Numeric)tok).getValue()==0) {
-                                            _logger.info(MessageConstants.LOG_NO_CHILD_OBJS);
-                                            children = null;
-                                            return;
-                                        }
+                                        _logger.info(MessageConstants.LOG_NO_CHILD_OBJS);
+                                        children = null;
+                                        return;
+                                        
                                     }
                                 }                                StructureElement se = 
                                     new StructureElement (kdict, _tree);
@@ -298,11 +297,9 @@ public class StructureElement
     {
         try {
             PdfObject typ = elem.get ("Type");
-            if (typ != null) {
-                if (!"StructElem".equals
+            if (typ != null && !"StructElem".equals
                       (((PdfSimpleObject) typ).getStringValue ())) {
-                    return false;
-                }
+                return false;
             }
 
             PdfObject s = _module.resolveIndirectObject (elem.get ("S"));

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Tokenizer.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Tokenizer.java
@@ -170,21 +170,18 @@ public abstract class Tokenizer
 
         try {
             while (true) {
-                if (max > 0L) {
-                    if (_offset - startOffset > max) {
-                        // The token has exceeded the specified maximum size.
-
-                        if (token != null
-                                && token instanceof StringValuedToken
-                                && buffer != null) {
-                            ((StringValuedToken) token).setValue (
-                                    buffer.toString ());
-                        }
-                        else {
-                            token = null;
-                        }
-                        return token;
+                if (max > 0L && _offset - startOffset > max) {
+                    // The token has exceeded the specified maximum size.
+                    if (token != null
+                            && token instanceof StringValuedToken
+                            && buffer != null) {
+                        ((StringValuedToken) token).setValue (
+                                buffer.toString ());
                     }
+                    else {
+                        token = null;
+                    }
+                    return token;
                 }
 
                 if (!_lookAhead) {

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/XProfileBase.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/XProfileBase.java
@@ -265,15 +265,11 @@ public abstract class XProfileBase extends PdfProfile
                     // PS XObjects aren't allowed in any X format.
                     return false;
                 }
-                if ("Image".equals (subtypeVal)) {
-                    if (!imageObjectOK (xo)) {
-                        return false;   
-                    }
+                if ("Image".equals (subtypeVal) && !imageObjectOK (xo)) {
+                    return false;   
                 }
-                if ("Form".equals (subtypeVal)) {
-                    if (!formObjectOK (xo)) {
-                        return false;   
-                    }
+                if ("Form".equals (subtypeVal) && !formObjectOK (xo)) {
+                    return false;
                 }
             }
         }
@@ -303,20 +299,16 @@ public abstract class XProfileBase extends PdfProfile
                     return false;
                 }
             }
-            if (_xType == PDFX2) {
+            if (_xType == PDFX2 && xo.get ("OPI") != null) {
                  // PDF-X/2 elements can't have an OPI key in Form
                  // or Image xobjects.
-                 if (xo.get ("OPI") != null) {
-                    return false;
-                 }
+                 return false;
             }
 	    if (_xType == PDFX1A || _xType == PDFX2) {
 		// SMask is restricted in PDFX-1/a and X-2
 		PdfSimpleObject smask = (PdfSimpleObject) xo.get ("SMask");
-		if (smask != null) {
-		    if (!"None".equals (smask.getStringValue ())) {
-			return false;
-		    }
+		if (smask != null && !"None".equals (smask.getStringValue ())) {
+                    return false;
 		}
 	    }
         }

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -572,10 +572,8 @@ public class TiffModule extends ModuleBase {
                 ListIterator<TiffProfile> pter = _profile.listIterator();
                 while (pter.hasNext()) {
                     TiffProfile prof = pter.next();
-                    if (!prof.isAlreadyOK()) {
-                        if (prof.satisfiesProfile(ifd)) {
+                    if (!prof.isAlreadyOK() && prof.satisfiesProfile(ifd)) {
                             info.setProfile(prof.getText());
-                        }
                     }
                 }
 
@@ -984,30 +982,24 @@ public class TiffModule extends ModuleBase {
                     info);
         }
         int[] bitsPerSample = niso.getBitsPerSample();
-        if (photometricInterpretation == 4) {
-            if (samplesPerPixel < 1 || bitsPerSample[0] != 1) {
+        if (photometricInterpretation == 4 && (samplesPerPixel < 1 || bitsPerSample[0] != 1)) {
                 reportInvalid(MessageConstants.TIFF_HUL_41, info);
-            }
         }
 
         /* Samples per pixel. */
 
-        if (photometricInterpretation == 0 || photometricInterpretation == 1
+        if ((photometricInterpretation == 0 || photometricInterpretation == 1
                 || photometricInterpretation == 3
-                || photometricInterpretation == 4) {
-            if (samplesPerPixel < 1) {
+                || photometricInterpretation == 4) && samplesPerPixel < 1) {
                 String mess = MessageFormat.format(MessageConstants.TIFF_HUL_42.getMessage(), samplesPerPixel);
                 JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.TIFF_HUL_42.getId(), mess);
                 reportInvalid(message, info);
-            }
         }
-        if (photometricInterpretation == 2 || photometricInterpretation == 6
-                || photometricInterpretation == 8) {
-            if (samplesPerPixel < 3) {
+        if ((photometricInterpretation == 2 || photometricInterpretation == 6
+                || photometricInterpretation == 8) && samplesPerPixel < 3) {
                 String mess = MessageFormat.format(MessageConstants.TIFF_HUL_43.getMessage(), samplesPerPixel);
                 JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.TIFF_HUL_43.getId(), mess);
                 reportInvalid(message, info);
-            }
         }
 
         /* Palette color. */
@@ -1082,11 +1074,9 @@ public class TiffModule extends ModuleBase {
 
         /* Clipping path. */
 
-        if (ifd.getClipPath() != null) {
-            if (ifd.getXClipPathUnits() == IFD.NULL) {
-                reportInvalid(MessageConstants.TIFF_HUL_52,
+        if (ifd.getClipPath() != null && ifd.getXClipPathUnits() == IFD.NULL) {
+            reportInvalid(MessageConstants.TIFF_HUL_52,
                         info);
-            }
         }
 
         /* Date. */

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
@@ -960,11 +960,10 @@ public abstract class IFD
     {
         /* Readers are supposed to accept BYTE, SHORT or LONG for any
          * unsigned integer field. */
-        if (type == BYTE || type == SHORT || type == LONG || type == IFD) {
-            if (expected == BYTE || expected == SHORT || expected == LONG ||
-		expected == IFD) {
-                return;    // it's OK
-            }
+        if ((type == BYTE || type == SHORT || type == LONG || type == IFD) && 
+                (expected == BYTE || expected == SHORT || expected == LONG ||
+		expected == IFD)) {
+            return;    // it's OK
         }
         if (type != expected) {
             String mess = MessageFormat.format(MessageConstants.TIFF_HUL_7.getMessage(), Integer.valueOf(tag), Integer.valueOf(expected), Integer.valueOf(type));

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffFXBase.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffFXBase.java
@@ -65,10 +65,8 @@ public abstract class TiffFXBase extends TiffProfile {
         }
      
         // If compression method is 3, T4 options must be specified
-        if (niso.getCompressionScheme () == 3) {
-            if (ifd.getT4Options () == IFD.NULL) {
-                return false;
-            }
+        if (niso.getCompressionScheme () == 3 && ifd.getT4Options () == IFD.NULL) {
+            return false;
         }
         return true;        // placeholder
     }

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffIFD.java
@@ -3453,12 +3453,10 @@ public class TiffIFD extends IFD {
 		// }
 		// }
 		// }
-		if (_photometricInterpretation == 5) {
-			if (_dotRange == null) {
-				_dotRange = new int[2];
-				_dotRange[0] = 0;
-				_dotRange[1] = bps1;
-			}
+		if (_photometricInterpretation == 5 && _dotRange == null) {
+                    _dotRange = new int[2];
+                    _dotRange[0] = 0;
+                    _dotRange[1] = bps1;
 		}
 		if (_photometricInterpretation == 2
 				|| _photometricInterpretation == 6) {

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITCT.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITCT.java
@@ -61,10 +61,8 @@ public final class TiffProfileClassITCT extends TiffProfileClassIT
             return false;
         }
         String seq = tifd.getColorSequence ();
-        if (seq == null || "CMYK".equals (seq)) {
-            if (inkSet != 1) {
-                return false;
-            }
+        if ((seq == null || "CMYK".equals (seq)) && inkSet != 1) {
+            return false;
         }
 
         int spp = niso.getSamplesPerPixel ();

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITHC.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITHC.java
@@ -66,10 +66,8 @@ public final class TiffProfileClassITHC extends TiffProfileClassIT
             return false;
         }
         String seq = tifd.getColorSequence ();
-        if (seq == null || "CMYK".equals (seq)) {
-            if (inkSet != 1) {
-                return false;
-            }
+        if ((seq == null || "CMYK".equals (seq)) && inkSet != 1) {
+            return false;
         }
 
 		// Per footnote: If NumberOfInks tag is used, it must have the

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITLW.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITLW.java
@@ -71,10 +71,8 @@ public final class TiffProfileClassITLW extends TiffProfileClassIT
             return false;
         }
         String seq = tifd.getColorSequence ();
-        if (seq == null || "CMYK".equals (seq)) {
-            if (inkSet != 1) {
-                return false;
-            }
+        if ((seq == null || "CMYK".equals (seq)) && inkSet != 1) {
+            return false;
         }
 
         // Per footnote h, this applies to LW, LW/P1 and LW/P2

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMP.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMP.java
@@ -70,10 +70,8 @@ public final class TiffProfileClassITMP extends TiffProfileClassIT
         
         // ImageColorValue is defined if ImageColorIndicator=1
 	int ind = tifd.getImageColorIndicator ();
-        if (ind == 1) {
-            if (tifd.getImageColorValue () == IFD.NULL) {
+        if (ind == 1 && tifd.getImageColorValue () == IFD.NULL) {
                 return false;
-            }
         }
         return true;
     }

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMPP1.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMPP1.java
@@ -83,10 +83,8 @@ public final class TiffProfileClassITMPP1 extends TiffProfileClassIT
         }
         
         // ImageColorValue is defined if ImageColorIndicator=1
-        if (ind == 1) {
-            if (tifd.getImageColorValue () == IFD.NULL) {
-                return false;
-            }
+        if (ind == 1 && tifd.getImageColorValue () == IFD.NULL) {
+            return false;
         }
         
         // PixelIntesityRange={0,255}

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMPP2.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileClassITMPP2.java
@@ -80,10 +80,8 @@ public final class TiffProfileClassITMPP2 extends TiffProfileClassIT
         }
         
         // ImageColorValue is defined if ImageColorIndicator=1
-        if (ind == 1) {
-            if (tifd.getImageColorValue () == IFD.NULL) {
-                return false;
-            }
+        if (ind == 1 && tifd.getImageColorValue () == IFD.NULL) {
+            return false;
         }
         
         // PixelIntesityRange={0,255}

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileDNG.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileDNG.java
@@ -99,12 +99,10 @@ public class TiffProfileDNG extends TiffProfile {
         
         /* If the photometric interpretation is CFA, there must be
          * certain other tags. */
-        if (pInterpretation == CFA) {
-            if (tifd.getCFAPlaneColor() == null ||
+        if (pInterpretation == CFA && (tifd.getCFAPlaneColor() == null ||
                 tifd.getCFARepeatPatternDim() == null ||
-                tifd.getCFAPattern() == null) {
-                return false;
-            }
+                tifd.getCFAPattern() == null)) {
+            return false;
         }
 
         /* Orientation is required. */
@@ -114,10 +112,9 @@ public class TiffProfileDNG extends TiffProfile {
         
         /* Compression must be 1 or 7 */
         int compression = niso.getCompressionScheme ();
-        if (compression != NisoImageMetadata.NULL) {
-            if (!(compression == 1 || compression == 7)) {
-                return false;
-            }
+        if (compression != NisoImageMetadata.NULL && 
+                !(compression == 1 || compression == 7)) {
+            return false;
         }
         
         return true;

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileEP.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileEP.java
@@ -116,33 +116,26 @@ public class TiffProfileEP extends TiffProfile
 	 * are compatible. 
 	 */
 	int samplesPerPixel = niso.getSamplesPerPixel ();
-	if (pInterpretation == 1 || pInterpretation == 32803) {
-	    if (samplesPerPixel != 1) {
-		return false;
-	    }
+	if ((pInterpretation == 1 || pInterpretation == 32803) && 
+                samplesPerPixel != 1) {
 	}
-	if (pInterpretation == 2 || pInterpretation == 6) {
-	    if (samplesPerPixel != 3) {
-		return false;
-	    }
+	if ((pInterpretation == 2 || pInterpretation == 6) && 
+                samplesPerPixel != 3) {
 	}
-	if (pInterpretation == 6) {
-	    if (niso.getYCbCrCoefficients() == null ||
+	if (pInterpretation == 6 && (niso.getYCbCrCoefficients() == null ||
 		niso.getYCbCrSubSampling () == null ||
 		niso.getYCbCrPositioning () == NisoImageMetadata.NULL ||
-		niso.getReferenceBlackWhite () == null) {
-		    return false;
-	    }
+		niso.getReferenceBlackWhite () == null)) {
+            return false;
 	}
 	// meteringMode and exposureProgram checks deleted, per Bugzilla #33
 	
 	int compression = niso.getCompressionScheme ();
-	if (compression != NisoImageMetadata.NULL) {
         // Corrected 6-Jan-04 per Bugzilla #33
-	    if (!(compression == 1 || compression == 7 ||
+	if (compression != NisoImageMetadata.NULL && 
+                !(compression == 1 || compression == 7 || 
 		  compression > 32767)) {
-		return false;
-	    }
+            return false;
 	}
 	return true;
     }

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExif.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileExif.java
@@ -78,11 +78,10 @@ public final class TiffProfileExif extends TiffProfile
 	            if (!(pInterpretation == 2 || pInterpretation == 6)) {
 	                return false;
 	            }
-	            if (pInterpretation == 6) {
-	                if (niso.getYCbCrSubSampling () == null ||
-	                niso.getYCbCrPositioning () == NisoImageMetadata.NULL) {
-	                    return false;
-	                }
+	            if (pInterpretation == 6 && (
+                            niso.getYCbCrSubSampling () == null ||
+                            niso.getYCbCrPositioning () == NisoImageMetadata.NULL)) {
+                        return false;
 	            }
 	    	}
 	        else {

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXC.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXC.java
@@ -126,16 +126,9 @@ public class TiffProfileFXC extends TiffFXBase {
                 }
                 break;
         }
-        
         // By my best reading, the colormap is needed only
         // if the Indexed value is 1.
-        if (tifd.getIndexed() == 1) {
-            if (niso.getColormapRedValue () == null) {
-                return false;
-            }
-        }
-
-        return true;         // passed all tests
+        return !(tifd.getIndexed() == 1 && niso.getColormapRedValue () == null);  // passed all tests       
     }
 
 }

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXF.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXF.java
@@ -61,10 +61,8 @@ public class TiffProfileFXF extends TiffFXBase {
         // We've already established that if the compression
         // scheme is 3, T4Options exists.  But we must establish
         // that if it's 4, T6Options exists and has a value of 0.
-        if (niso.getCompressionScheme () == 4) {
-            if (tifd.getT6Options () != 0) {
-                return false;
-            }
+        if (niso.getCompressionScheme() == 4 && tifd.getT6Options() != 0) {
+            return false;
         }
 
         // XResolution, YResolution, and ImageWidth have codependencies.
@@ -77,25 +75,22 @@ public class TiffProfileFXF extends TiffFXBase {
             yRes = perCMtoPerInch ((int) yRes);
         }
         long wid = niso.getImageWidth();
-        if ((xRes == 200 && yRes == 100) ||
+        if (((xRes == 200 && yRes == 100) ||
                 (xRes == 204 && yRes == 98) ||
                 (xRes == 200 && yRes == 200) ||
                 (xRes == 204 && yRes == 196) ||
-                (xRes == 204 && yRes == 391)) {
-            if (wid == 1728 || wid == 2048 || wid == 2432) {
+                (xRes == 204 && yRes == 391)) && 
+                (wid == 1728 || wid == 2048 || wid == 2432)) {
                 xywOK = true;
-            }
         }
-        if (xRes == 300 && yRes == 300) {
-            if (wid == 2592 || wid == 3072 || wid == 3648) {
+        if (xRes == 300 && yRes == 300 && 
+                (wid == 2592 || wid == 3072 || wid == 3648)) {
                 xywOK = true;
-            }
         }
-        if ((xRes == 408 && yRes == 391) ||
-                (xRes == 400 && yRes == 400)) {
-            if (wid == 3456 || wid == 4096 || wid == 4864) {
+        if (((xRes == 408 && yRes == 391) ||
+                (xRes == 400 && yRes == 400)) 
+                && (wid == 3456 || wid == 4096 || wid == 4864)) {
                 xywOK = true;
-            }
         }
         // passed all tests
         return xywOK;         

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXJ.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXJ.java
@@ -63,10 +63,8 @@ public class TiffProfileFXJ extends TiffFXBase {
         // We've already established that if the compression
         // scheme is 3, T4Options exists.  But we must establish
         // that if it's 4, T6Options exists and has a value of 0.
-        if (cmp == 4) {
-            if (tifd.getT6Options () != 0) {
-                return false;
-            }
+        if (cmp == 4 && tifd.getT6Options () != 0) {
+            return false;
         }
 
         // XResolution, YResolution, and ImageWidth have codependencies.
@@ -79,25 +77,22 @@ public class TiffProfileFXJ extends TiffFXBase {
             yRes = perCMtoPerInch ((int) yRes);
         }
         long wid = niso.getImageWidth();
-        if ((xRes == 200 && yRes == 100) ||
+        if (((xRes == 200 && yRes == 100) ||
                 (xRes == 204 && yRes == 98) ||
                 (xRes == 200 && yRes == 200) ||
                 (xRes == 204 && yRes == 196) ||
-                (xRes == 204 && yRes == 391)) {
-            if (wid == 1728 || wid == 2048 || wid == 2432) {
-                xywOK = true;
-            }
+                (xRes == 204 && yRes == 391)) && 
+                (wid == 1728 || wid == 2048 || wid == 2432)) {
+            xywOK = true;
         }
-        if (xRes == 300 && yRes == 300) {
-            if (wid == 2592 || wid == 3072 || wid == 3648) {
-                xywOK = true;
-            }
+        if (xRes == 300 && yRes == 300 && 
+                (wid == 2592 || wid == 3072 || wid == 3648)) {
+            xywOK = true;
         }
-        if ((xRes == 408 && yRes == 391) ||
-                (xRes == 400 && yRes == 400)) {
-            if (wid == 3456 || wid == 4096 || wid == 4864) {
-                xywOK = true;
-            }
+        if (((xRes == 408 && yRes == 391) ||
+                (xRes == 400 && yRes == 400)) && 
+                (wid == 3456 || wid == 4096 || wid == 4864)) {
+            xywOK = true;
         }
         // passed all tests
         return xywOK;         

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXL.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXL.java
@@ -103,10 +103,8 @@ public class TiffProfileFXL extends TiffFXBase {
             return false;
         }
         
-        if (tifd.getIndexed() == 1) {
-            if (niso.getColormapRedValue () == null) {
-                return false;
-            }
+        if (tifd.getIndexed() == 1 && niso.getColormapRedValue () == null) {
+            return false;
         }
 
         return true;         // passed all tests

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXM.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfileFXM.java
@@ -104,10 +104,8 @@ public class TiffProfileFXM extends TiffFXBase {
         }
         // By my best reading, the colormap is needed only
         // if the Indexed value is 1.
-        if (tifd.getIndexed() == 1) {
-            if (niso.getColormapRedValue () == null) {
-                return false;
-            }
+        if (tifd.getIndexed() == 1 && niso.getColormapRedValue () == null) {
+            return false;
         }
 
         return true;         // passed all tests

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfilePagemaker6.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfilePagemaker6.java
@@ -56,13 +56,11 @@ public final class TiffProfilePagemaker6 extends TiffProfile
 	    }
 	}
 
-	if (to) {
-	    if (niso.getTileWidth () == NisoImageMetadata.NULL ||
+	if (to && (niso.getTileWidth () == NisoImageMetadata.NULL ||
 		niso.getTileLength () == NisoImageMetadata.NULL ||
 		niso.getTileOffsets () == null ||
-		niso.getTileByteCounts () == null) {
+		niso.getTileByteCounts () == null)) {
 		return false;
-	    }
 	}
 
 	/* Check required values. */
@@ -89,10 +87,8 @@ public final class TiffProfilePagemaker6 extends TiffProfile
 		return false;
 	    }
 	}
-	else if (inkSet == 1) {  /* Only check for RGB, not hi-fi/multi-ink. */
-	    if (spp != 4) {
+	else if (inkSet == 1 && spp != 4) {  /* Only check for RGB, not hi-fi/multi-ink. */
 		return false;
-	    }
 	}
 
 	int [] bps = niso.getBitsPerSample ();
@@ -117,12 +113,10 @@ public final class TiffProfilePagemaker6 extends TiffProfile
 	    return false;
 	}
 
-	if (inkSet == 2) {
-	    if (tifd.getInkNames () == null ||
-		tifd.getNumberOfInks () == IFD.NULL) {
-		return false;
-	    }
-	}
+	if (inkSet == 2 && (tifd.getInkNames () == null ||
+		tifd.getNumberOfInks () == IFD.NULL)) {
+            return false;
+        }
 
 	return true;
     }

--- a/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
+++ b/jhove-modules/wave-hul/src/main/java/edu/harvard/hul/ois/jhove/module/WaveModule.java
@@ -490,14 +490,12 @@ public class WaveModule extends ModuleBase {
 		if (flagWaveFormatExtensible) {
 			info.setProfile("WAVEFORMATEXTENSIBLE");
 		}
-		if (broadcastExtChunkSeen) {
-			if ((waveCodec == FormatChunk.WAVE_FORMAT_MPEG && factChunkSeen)
-					|| waveCodec == FormatChunk.WAVE_FORMAT_PCM) {
-				info.setProfile("BWF");
-			}
+		if (broadcastExtChunkSeen && (
+                        (waveCodec == FormatChunk.WAVE_FORMAT_MPEG && factChunkSeen)
+                        || waveCodec == FormatChunk.WAVE_FORMAT_PCM)) {
+                    info.setProfile("BWF");
 		}
-
-		return 0;
+                return 0;
 	}
 
 	/**

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XhtmlProcessing.java
@@ -292,16 +292,12 @@ public final class XhtmlProcessing {
         for (int i = 0; i < atts.getLength (); i++) {
             String attname = atts.getLocalName (i);
             String attval = atts.getValue (i);
-            if ("title".equals (attname)) {
-                if (attval.length() > 0 ) {
-                    lst.add (new Property ("title",
-                            PropertyType.STRING,
-                            attval));
+            if ("title".equals (attname) && attval.length() > 0) {
+                lst.add (new Property ("title", PropertyType.STRING, attval));
                 }
                 // Note: The PCData should be stuck at the
                 // front of the list when we get it, as
                 // the "abbr" property.
-            }
         }
         mdata.setPropUnderConstruction (p);
     }

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
@@ -342,10 +342,8 @@ public class XmlModuleHandler extends DefaultHandler {
 		}
 
 		// Do special-case checking for the XHTML DTD's
-		if (!_xhtmlFlag) {
-			if (DTDMapper.isXHTMLDTD(publicId)) {
-				_xhtmlFlag = true;
-			}
+		if (!_xhtmlFlag && DTDMapper.isXHTMLDTD(publicId)) {
+                    _xhtmlFlag = true;
 		}
 		InputSource ent = DTDMapper.publicIDToFile(publicId);
 		if (ent == null) {
@@ -382,14 +380,12 @@ public class XmlModuleHandler extends DefaultHandler {
 		entArr.publicID = publicId;
 		entArr.systemID = systemId;
 		_entities.add(entArr);
-		if (systemId.endsWith(".dtd")) {
-			/*
-			 * Assume that the first system ID in the file with a .dtd
-			 * extension is the actual DTD
-			 */
-			if (_dtdURI == null) {
-				_dtdURI = systemId;
-			}
+                /*
+                 * Assume that the first system ID in the file with a .dtd
+                 * extension is the actual DTD
+                 */
+		if (systemId.endsWith(".dtd") && _dtdURI == null) {
+                    _dtdURI = systemId;
 		}
 		return ent;
 	}


### PR DESCRIPTION
Tries  to solve #417 

Didn't fix following issues in following files:
- `jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RFC1766Lang.java` (line 68) because of a mistake that should be fixed first (cfr. comments in issue #417) 
- `jhove-core/src/main/java/edu/harvard/hul/ois/jhove/XMPHandler.java` (line 129) because it's part of a method that's doing nothing
```java
    /**
     *  Catches the end of an element.
     */
    @Override
    public void endElement (String namespaceURI, String localName,
                String rawName)
    {
        if (xmpBasicSchema.equals (namespaceURI)) {
            // Check for the end of an XMP structure
            if ("Bag".equals (rawName)||
                    "Seq".equals (rawName) ||
                    "Alt".equals (rawName)) {
            }
        }
    }
```

Also, I think that lines 81 and 86 of file `jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/TiffProfilePagemaker6.java` consist of if-statements that could be combined, but because codacy isn't complaining about these lines, I was afraid to change it and break something.
