### PR TITLE
FIX - Missing error IDs

### DIFF
--- a/jhove-bbt/scripts/create-1.23-target.sh
+++ b/jhove-bbt/scripts/create-1.23-target.sh
@@ -74,6 +74,16 @@ if [[ -d "${candidateRoot}/errors/modules/WAVE-hul" ]]; then
 	cp -Rf "${candidateRoot}/errors/modules/WAVE-hul" "${targetRoot}/errors/modules/"
 fi
 
+# Copy PDF files across for extra error ids
+if [[ -d "${candidateRoot}/regression/modules/PDF-hul" ]]; then
+	echo "Copying valid PDF regressions."
+	cp -Rf "${candidateRoot}/regression/modules/PDF-hul" "${targetRoot}/regression/modules/"
+fi
+if [[ -d "${candidateRoot}/errors/modules/PDF-hul" ]]; then
+	echo "Copying PDF errors."
+	cp -Rf "${candidateRoot}/errors/modules/PDF-hul" "${targetRoot}/errors/modules/"
+fi
+
 # Copy TIIF across for new Message IDs https://github.com/openpreserve/jhove/pull/510
 if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/chase-tif-f.tif.jhove.xml" ]]; then
 	echo "Copying affected TIFF examples."
@@ -98,6 +108,30 @@ fi
 if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/fax2d.g3.jhove.xml" ]]; then
 	echo "Copying affected TIFF examples."
 	cp -Rf "${candidateRoot}/examples/modules/TIFF-hul/fax2d.g3.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" ]]; then
+	echo "Copying affected TIFF examples."
+	cp -Rf "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" ]]; then
+	echo "Copying affected TIFF examples."
+	cp -Rf "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/XML-hul/valid-external.dtd.jhove.xml" ]]; then
+	echo "Copying affected XML examples."
+	cp -Rf "${candidateRoot}/examples/modules/XML-hul/valid-external.dtd.jhove.xml" "${targetRoot}/examples/modules/XML-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/XML-hul/external-parsed-entity.ent.jhove.xml" ]]; then
+	echo "Copying affected XML examples."
+	cp -Rf "${candidateRoot}/examples/modules/XML-hul/external-parsed-entity.ent.jhove.xml" "${targetRoot}/examples/modules/XML-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/XML-hul/external-unparsed-entity.ent.jhove.xml" ]]; then
+	echo "Copying affected XML examples."
+	cp -Rf "${candidateRoot}/examples/modules/XML-hul/external-unparsed-entity.ent.jhove.xml" "${targetRoot}/examples/modules/XML-hul/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" ]]; then
+	echo "Copying affected PDF examples."
+	cp -Rf "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
 fi
 
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.4.1">JPEG2000-hul<\/module>$/   <module release="1.4.2">JPEG2000-hul<\/module>/' {} \;

--- a/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
+++ b/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/AiffModule.java
@@ -678,7 +678,7 @@ public class AiffModule
         }
         else {
             info.setMessage (new InfoMessage
-                (MessageConstants.INF_CHUNK_TYPE_IGNORED + id, _nByte));
+                (MessageConstants.AIFF_HUL_9, id, _nByte));
         }
         if (chunk != null) {
             if (!chunk.readChunk (info)) {

--- a/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/MessageConstants.java
+++ b/jhove-modules/aiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/aiff/MessageConstants.java
@@ -42,7 +42,7 @@ public enum MessageConstants {
 	/**
 	 * Info messages
 	 */
-	public static final String INF_CHUNK_TYPE_IGNORED = "Ignored chunk type with ID: ";
+	
 	
 	/**
 	 * Error messages
@@ -55,4 +55,5 @@ public enum MessageConstants {
 	public static final JhoveMessage AIFF_HUL_6 = messageFactory.getMessage("AIFF-HUL-6"); //$NON-NLS-1$
 	public static final JhoveMessage AIFF_HUL_7 = messageFactory.getMessage("AIFF-HUL-7"); //$NON-NLS-1$
 	public static final JhoveMessage AIFF_HUL_8 = messageFactory.getMessage("AIFF-HUL-8"); //$NON-NLS-1$
+	public static final JhoveMessage AIFF_HUL_9 = messageFactory.getMessage("AIFF-HUL-9"); //$NON-NLS-1$
 }

--- a/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/aiff/ErrorMessages.properties
+++ b/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/aiff/ErrorMessages.properties
@@ -6,3 +6,4 @@ AIFF-HUL-5 = Multiple %s Chunks not permitted
 AIFF-HUL-6 = Audio Recording Chunk is incorrect size
 AIFF-HUL-7 = Common Chunk in AIFF-C does not have compression type
 AIFF-HUL-8 = Unexpected EOF
+AIFF-HUL-9 = Ignored chunk type with ID: 

--- a/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
+++ b/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Jpeg2000Module.java
@@ -790,8 +790,8 @@ public class Jpeg2000Module extends ModuleBase {
         // 8 bytes have been read
         if (!"ftyp".equals(hdr.getType())) {
             info.setMessage(new
-                    ErrorMessage(MessageConstants.JPEG2000_HUL_22
-                        + hdr.getType(), _nByte));
+                    ErrorMessage(MessageConstants.JPEG2000_HUL_22,
+                        hdr.getType(), _nByte));
             info.setWellFormed(false);
             return false;
 

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1392,7 +1392,10 @@ public class PdfModule extends ModuleBase {
 		} catch (PdfException e) {
 
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// If it's merely invalid rather than ill-formed, keep going
 			return (e instanceof PdfInvalidException);
@@ -1471,7 +1474,10 @@ public class PdfModule extends ModuleBase {
 			} catch (PdfException e) {
 
 				e.disparage(info);
-				info.setMessage(
+				if (e.getJhoveMessage() != null)
+					info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+				else
+					info.setMessage(
 						new ErrorMessage(e.getMessage(), _parser.getOffset()));
 				// If it's merely invalid rather than ill-formed, keep going
 				return (e instanceof PdfInvalidException);
@@ -1537,7 +1543,10 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			return false;
 		} catch (Exception e) {
@@ -1717,7 +1726,10 @@ public class PdfModule extends ModuleBase {
 
 		catch (PdfException e) {
 			e.disparage(info);  // clears Valid or WellFormed as appropriate
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Keep going if it's only invalid
 			return (e instanceof PdfInvalidException);
@@ -1853,7 +1865,10 @@ public class PdfModule extends ModuleBase {
 
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			return (e instanceof PdfInvalidException);
 		}
@@ -1893,8 +1908,11 @@ public class PdfModule extends ModuleBase {
 					PROP_NAME_TRAPPED);
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
-					new ErrorMessage(e.getMessage(), _parser.getOffset()));
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
+						new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Keep parsing if it's only invalid
 			return (e instanceof PdfInvalidException);
 		} catch (Exception e) {
@@ -1933,7 +1951,10 @@ public class PdfModule extends ModuleBase {
 			_docTreeRoot.buildSubtree(true, MAX_PAGE_TREE_DEPTH);
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Continue parsing if it's only invalid
 			return (e instanceof PdfInvalidException);
@@ -1965,7 +1986,10 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Continue parsing if it's only invalid
 			return (e instanceof PdfInvalidException);
@@ -2027,7 +2051,10 @@ public class PdfModule extends ModuleBase {
 
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Continue parsing if it's only invalid
 			return (e instanceof PdfInvalidException);
@@ -2070,7 +2097,11 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(new ErrorMessage(e.getMessage()));
+			if (e.getJhoveMessage() != null) {
+				info.setMessage(new ErrorMessage(e.getJhoveMessage()));
+			} else {
+				info.setMessage(new ErrorMessage(e.getMessage()));
+			}
 		} catch (Exception e) {
 			info.setWellFormed(false);
 			String mess = MessageFormat.format(
@@ -2115,7 +2146,10 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			// Continue parsing if it's only invalid
 			return (e instanceof PdfInvalidException);
@@ -2413,7 +2447,10 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 		} catch (Exception e) {
 			info.setWellFormed(false);
@@ -2493,7 +2530,10 @@ public class PdfModule extends ModuleBase {
 			}
 		} catch (PdfException e) {
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			return;
 		} catch (Exception e) {
@@ -2877,7 +2917,10 @@ public class PdfModule extends ModuleBase {
 		} catch (PdfException e) {
 
 			e.disparage(info);
-			info.setMessage(
+			if (e.getJhoveMessage() != null)
+				info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+			else
+				info.setMessage(
 					new ErrorMessage(e.getMessage(), _parser.getOffset()));
 			return;
 		}
@@ -4082,7 +4125,10 @@ public class PdfModule extends ModuleBase {
 					_skippedOutlinesReported = true;
 				}
 			} catch (PdfException e) {
-				info.setMessage(
+				if (e.getJhoveMessage() != null)
+					info.setMessage(new ErrorMessage(e.getJhoveMessage(), _parser.getOffset()));
+				else
+					info.setMessage(
 						new ErrorMessage(e.getMessage(), _parser.getOffset()));
 				e.disparage(info);
 				// If it's just invalid, we can keep going

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfException.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfException.java
@@ -17,6 +17,10 @@ import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
  */
 public abstract class PdfException extends Exception {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 972230109944524397L;
 	/*
 	 * Note 25-Feb-2004: Previously PdfException indicated
 	 * a not-well-formed condition, and PdfInvalidException
@@ -34,13 +38,6 @@ public abstract class PdfException extends Exception {
 	/**
 	 * Create a PdfException.
 	 */
-	public PdfException(final String m) {
-		this(JhoveMessages.getMessageInstance(m));
-	}
-
-	/**
-	 * Create a PdfException.
-	 */
 	public PdfException(final JhoveMessage message) {
 		this(message, -1);
 	}
@@ -48,22 +45,8 @@ public abstract class PdfException extends Exception {
 	/**
 	 * Create a PdfException with specified offset.
 	 */
-	public PdfException(final String m, final long offset) {
-		this(JhoveMessages.getMessageInstance(m), offset);
-	}
-
-	/**
-	 * Create a PdfException with specified offset.
-	 */
 	public PdfException(final JhoveMessage message, final long offset) {
 		this(message, offset, null);
-	}
-
-	/**
-	 * Create a PdfException with specified offset and token.
-	 */
-	public PdfException(final String m, final long offset, final Token token) {
-		this(JhoveMessages.getMessageInstance(m), offset, token);
 	}
 
 	/**

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfInvalidException.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfInvalidException.java
@@ -14,13 +14,10 @@ import edu.harvard.hul.ois.jhove.messages.JhoveMessage;
  * that the document is invalid but not necessarily ill-formed.
  */
 public final class PdfInvalidException extends PdfException {
-
 	/**
-	 * Creates a PdfInvalidException.
+	 * 
 	 */
-	public PdfInvalidException(final String m) {
-		super(m);
-	}
+	private static final long serialVersionUID = -3224356746816316033L;
 
 	/**
 	 * Creates a PdfInvalidException.
@@ -32,24 +29,10 @@ public final class PdfInvalidException extends PdfException {
 	/**
 	 * Creates a PdfInvalidException with specified offset.
 	 */
-	public PdfInvalidException(final String m, final long offset) {
-		super(m, offset);
-	}
-
-	/**
-	 * Creates a PdfInvalidException with specified offset.
-	 */
 	public PdfInvalidException(final JhoveMessage message, final long offset) {
 		super(message, offset);
 	}
 
-	/**
-	 * Creates a PdfInvalidException with specified offset and token.
-	 */
-	public PdfInvalidException(final String m, final long offset,
-			final Token token) {
-		super(m, offset, token);
-	}
 
 	/**
 	 * Creates a PdfInvalidException with specified offset and token.

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfMalformedException.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfMalformedException.java
@@ -21,26 +21,11 @@ public class PdfMalformedException extends PdfException {
     /**
      *  Creates a PdfMalformedException.
      */
-    public PdfMalformedException (final String m)
-    {
-        super(m);
-    }
-
-    /**
-     *  Creates a PdfMalformedException.
-     */
     public PdfMalformedException (final JhoveMessage message)
     {
         super(message);
     }
 
-    /**
-     *  Creates a PdfMalformedException with specified offset.
-     */
-    public PdfMalformedException (final String m, final long offset) 
-    {
-        super(m, offset);
-    }
 
     /**
      *  Creates a PdfMalformedException with specified offset.
@@ -50,13 +35,6 @@ public class PdfMalformedException extends PdfException {
         super(message, offset);
     }
 
-    /**
-     *  Creates a PdfMalformedException with specified offset and token.
-     */
-    public PdfMalformedException (final String m, final long offset, final Token token) 
-    {
-        super(m, offset, token);
-    }
 
     /**
      *  Creates a PdfMalformedException with specified offset and token.

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -737,7 +737,10 @@ public class TiffModule extends ModuleBase {
             // For parsing EXIF, we don't want to make the enclosing
             // document invalid, so we don't declare the EXIF non-well-formed
             // even though it is.
-            info.setMessage(new InfoMessage(e.getMessage(), e.getOffset()));
+        	if (e.getJhoveMessage() != null)
+        		info.setMessage(new InfoMessage(e.getJhoveMessage(), e.getOffset()));
+        	else
+        		info.setMessage(new InfoMessage(e.getMessage(), e.getOffset()));
             return ifds;
         } catch (IOException e) {
             JhoveMessage msg;
@@ -838,7 +841,11 @@ public class TiffModule extends ModuleBase {
                     checkValidity((TiffIFD) ifd, info);
                 }
             } catch (TiffException e) {
-                info.setMessage(new ErrorMessage(e.getMessage(), e.getOffset()));
+                if (e.getJhoveMessage() != null) { // try to keep the id
+                    info.setMessage(new ErrorMessage(e.getJhoveMessage(), e.getOffset()));
+                } else {
+                	info.setMessage(new ErrorMessage(e.getMessage(), e.getOffset()));
+                }
                 info.setValid(false);
             }
         }

--- a/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
+++ b/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/Utf8Module.java
@@ -478,7 +478,7 @@ public class Utf8Module extends ModuleBase {
             // Check for UTF-8 byte order mark in 1st 3 bytes
             if (this.initialBytes[0] == 0xEF && this.initialBytes[1] == 0xBB
                     && this.initialBytes[2] == 0xBF) {
-                InfoMessage im = new InfoMessage(MessageConstants.INF_BOM_MARK_PRESENT, 0); // UTF8-HUL-1
+                InfoMessage im = new InfoMessage(MessageConstants.UTF8_HUL_1, 0); // UTF8-HUL-1
                 info.setMessage(im);
                 // If we've found a non-character header, clear
                 // all usage blocks

--- a/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/utf8/MessageConstants.java
+++ b/jhove-modules/utf8-hul/src/main/java/edu/harvard/hul/ois/jhove/module/utf8/MessageConstants.java
@@ -38,8 +38,8 @@ public enum MessageConstants {
 
 	public static final JhoveMessageFactory messageFactory = JhoveMessages
 			.getInstance("edu.harvard.hul.ois.jhove.module.utf8.ErrorMessages");
-	public static final String INF_BOM_MARK_PRESENT = "UTF-8 Byte Order Mark signature is present"; // UTF8-HUL-1
 
+	public static final JhoveMessage UTF8_HUL_1 = messageFactory.getMessage("UTF8-HUL-1");
 	public static final JhoveMessage UTF8_HUL_2 = messageFactory.getMessage("UTF8-HUL-2");
 	public static final JhoveMessage UTF8_HUL_3 = messageFactory.getMessage("UTF8-HUL-3");
 	public static final JhoveMessage UTF8_HUL_4 = messageFactory.getMessage("UTF8-HUL-4");

--- a/jhove-modules/utf8-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/utf8/ErrorMessages.properties
+++ b/jhove-modules/utf8-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/utf8/ErrorMessages.properties
@@ -1,3 +1,4 @@
+UTF8-HUL-1 = UTF-8 Byte Order Mark signature is present
 UTF8-HUL-2 = Not valid first byte of UTF-8 encoding
 UTF8-HUL-3 = Not valid second byte of UTF-8 encoding
 UTF8-HUL-4 = Not valid third byte of UTF-8 encoding

--- a/jhove-modules/utf8-hul/src/test/java/edu/harvard/hul/ois/jhove/module/utf8/Utf8ByteOrderTests.java
+++ b/jhove-modules/utf8-hul/src/test/java/edu/harvard/hul/ois/jhove/module/utf8/Utf8ByteOrderTests.java
@@ -37,13 +37,13 @@ public class Utf8ByteOrderTests {
 	@Test
 	public final void testBom() throws URISyntaxException {
 		TestUtils.testValidateResource(this.module, utf8BomTest, RepInfo.TRUE,
-				RepInfo.TRUE, MessageConstants.INF_BOM_MARK_PRESENT, true);
+				RepInfo.TRUE, MessageConstants.UTF8_HUL_1.getMessage(), true);
 	}
 
 	@Test
 	public final void testNoBom() throws URISyntaxException {
 		TestUtils.testValidateResource(this.module, utf8NoBomTest, RepInfo.TRUE,
-				RepInfo.TRUE, MessageConstants.INF_BOM_MARK_PRESENT, false);
+				RepInfo.TRUE, MessageConstants.UTF8_HUL_1.getMessage(), false);
 	}
 
 }

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -388,8 +388,8 @@ public class XmlModule extends ModuleBase {
 			if (handler.getSigFlag() && !_parseFromSig) {
 				info.setSigMatch(_name);
 			}
-			info.setMessage(new ErrorMessage(
-					e.getClass().getName() + ": " + e.getMessage().toString()));
+			String mess = e.getClass().getName() + ": " + e.getMessage().toString();
+			info.setMessage(new ErrorMessage(CoreMessageConstants.ERR_FILE_READ, mess));
 			info.setWellFormed(false);
 			return 0;
 		} catch (SAXParseException e) {
@@ -399,8 +399,9 @@ public class XmlModule extends ModuleBase {
 			}
 			int line = e.getLineNumber();
 			int col = e.getColumnNumber();
-			info.setMessage(new ErrorMessage(e.getMessage().toString(),
-					"Line = " + line + ", Column = " + col));
+			String mess = e.getMessage().toString() +
+					"Line = " + line + ", Column = " + col;
+			info.setMessage(new ErrorMessage(MessageConstants.XML_HUL_1, mess));
 			info.setWellFormed(false);
 			return 0;
 		} catch (SAXException e) {


### PR DESCRIPTION
- plugged Message ID gaps in:
  - AIFF Module;
  - JPEG2000 Module;
  - PDF Module;
  - TIFF Module;
  - UTF-8 Module where added JhoveMessage for `MessageConstants.INF_BOM_MARK_PRESENT`; and
  - XML Module;
- copied `PDF-hul` error and regression results wholesale; and
- spot copied exmples for `TIFF-hul`, 'XML-hul', and `PDF-hul` for affected results.