### PR TITLE
Adds EPUB validation extension module based on W3C's EPUBCheck

### DIFF
--- a/jhove-bbt/scripts/bbt-jhove.sh
+++ b/jhove-bbt/scripts/bbt-jhove.sh
@@ -25,7 +25,7 @@ export SCRIPT_DIR
 # Global for Backslashed string value
 
 # Include utils script
-# shellcheck source=src/inc/bb-utils.sh
+# shellcheck source=inc/bb-utils.sh
 . "$SCRIPT_DIR/inc/bb-utils.sh"
 
 # Globals to hold the checked param vals
@@ -125,7 +125,7 @@ showHelp() {
 checkParams "$@";
 candidate="${paramOutputLoc:?}/${paramKey}"
 tempInstallLoc="/var/tmp/to-test";
-sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.7.9\/org\.jacoco.agent-0\.7\.9-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -classpath "$CP" Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
+sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.7.9\/org\.jacoco.agent-0\.7\.9-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -Xss2048k  -classpath "$CP" Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
 bash "$SCRIPT_DIR/baseline-jhove.sh" -j "${tempInstallLoc}" -c "${paramCorpusLoc}" -o "${candidate}"
 
 if [[ -f "${SCRIPT_DIR}/create-${paramKey}-target.sh" ]]

--- a/jhove-installer/src/main/scripts/jhove
+++ b/jhove-installer/src/main/scripts/jhove
@@ -63,4 +63,4 @@ fi
 CONFIG="${JHOVE_HOME}/conf/jhove.conf"
 
 # Set class path and invoke Java
-java -classpath "${CP}" Jhove -c "${CONFIG}" "${@}"
+java -Xss1024k -classpath "${CP}" Jhove -c "${CONFIG}" "${@}"

--- a/jhove-installer/src/main/scripts/jhove-gui
+++ b/jhove-installer/src/main/scripts/jhove-gui
@@ -63,4 +63,4 @@ fi
 CONFIG="${JHOVE_HOME}/conf/jhove.conf"
 
 # Set class path and invoke Java
-java -classpath "${CP}" JhoveView -c "${CONFIG}" "${@}"
+java -Xss1024k -classpath "${CP}" JhoveView -c "${CONFIG}" "${@}"

--- a/jhove-installer/src/main/scripts/jhove-gui.bat
+++ b/jhove-installer/src/main/scripts/jhove-gui.bat
@@ -47,4 +47,4 @@ REM Set default configuration location
 SET "CONFIG=%JHOVE_HOME%conf\jhove.conf"
 
 REM Set class path and invoke Java
-java -classpath "%CP%" JhoveView -c "%CONFIG%" %*
+java -Xss1024k -classpath "%CP%" JhoveView -c "%CONFIG%" %*

--- a/jhove-installer/src/main/scripts/jhove.bat
+++ b/jhove-installer/src/main/scripts/jhove.bat
@@ -47,4 +47,4 @@ REM Set default configuration location
 SET "CONFIG=%JHOVE_HOME%conf\jhove.conf"
 
 REM Set class path and invoke Java
-java -classpath "%CP%" Jhove -c "%CONFIG%" %*
+java -Xss1024k -classpath "%CP%" Jhove -c "%CONFIG%" %*


### PR DESCRIPTION
This change is to add the `EPUB-ptc` extension module version 1.0. The module wraps the [W3C EPUBCheck validation tool](https://github.com/w3c/epubcheck) as a JHOVE module. 

Some notes in advance of full documentation:
1. Tests use examples derived from IDPF's EPUB 3 [samples ](https://github.com/IDPF/epub3-samples)and [test suite](https://github.com/IDPF/epub-testsuite) on GitHub and National Library of the Netherlands / Research [epubPolicyTests](https://github.com/KBNLresearch/epubPolicyTests), also on GitHub. These may be useful for additional test material.
2. The `checkSignatures()` method is based on the Library of Congress [EPUB2](https://www.loc.gov/preservation/digital/formats/fdd/fdd000278.shtml#sign)and [EPUB3](https://www.loc.gov/preservation/digital/formats/fdd/fdd000308.shtml#sign) documentation. For this `valid` is always set to `UNDETERMINED`. This check only looks at "magic numbers" and file extension. If the signature matches, it sets "well formed" to true. Note that it does not perform the additional package checks that contribute to "well formed"-ness in `parse()` so there is a small inconsistency there.
3. Well-formed/valid status is currently dependent on the messages returned by EPUBCheck (except when a non EPUB is passed and it throws an exception see [this issue](https://github.com/w3c/epubcheck/issues/1050)). The full list of possible messages and their severity according to EPUBCheck can be [seen here](https://github.com/w3c/epubcheck/blob/master/src/test/resources/com/adobe/epubcheck/test/command_line/listSeverities_expected_results.txt).
    * an EPUB is well formed if it has no messages with `(severity="FATAL") or (severity="ERROR" and message-id begins with "PKG-")`. In other words, fatal errors and package errors make the file "Not well formed".
    * If well formed, an EPUB is not valid if it has any messages with `severity="ERROR"`.
4. The EPUBCheck provides a lot of interesting properties that I've included in the JHOVE report. Some of them may affect preservation decisions, so I thought they seemed useful. For example, the presence of encryption, external fonts, or resources that are stored remotely but visually or aurally embedded in the EPUB. The result is an unusually large property/value section! You can review what is included [here](https://github.com/karenhanson/jhove/blob/f5cd4da535043ccacd0ea337f8d1a63e3d3c3fec/jhove-ext-modules/src/main/java/org/ithaka/portico/jhove/module/EpubModule.java#L362-L390) and [here](https://github.com/karenhanson/jhove/blob/epub-ext/jhove-ext-modules/src/main/java/org/ithaka/portico/jhove/module/epub/JhoveRepInfoReport.java#L401-L413).

Includes #460 from @karenhanson 