### PR TITLE
FIX - Enhancement of JPEG-hul module to handle the APP14 marker segment

### DIFF
--- a/jhove-bbt/scripts/create-1.23-target.sh
+++ b/jhove-bbt/scripts/create-1.23-target.sh
@@ -54,6 +54,22 @@ echo "Executing baseline update"
 # Copying baseline for now we're not making any changes
 cp -R "${baselineRoot}" "${targetRoot}"
 
+# Copy AIFF files across for new AES metadata see https://github.com/openpreserve/jhove/pull/518
+if [[ -d "${candidateRoot}/examples/modules/AIFF-hul" ]]; then
+	echo "Copying valid AIFF examples."
+	cp -Rf "${candidateRoot}/examples/modules/AIFF-hul" "${targetRoot}/examples/modules/"
+fi
+
+# Copy JPEG files across for new AES metadata see https://github.com/openpreserve/jhove/pull/518
+if [[ -d "${candidateRoot}/examples/modules/JPEG-hul" ]]; then
+	echo "Copying valid JPEG examples."
+	cp -Rf "${candidateRoot}/examples/modules/JPEG-hul" "${targetRoot}/examples/modules/"
+fi
+if [[ -f "${candidateRoot}/examples/modules/audit-JPEG-hul.jhove.xml" ]]; then
+	echo "Copying JPEG audit file."
+	cp -Rf "${candidateRoot}/examples/modules/audit-JPEG-hul.jhove.xml" "${targetRoot}/examples/modules/"
+fi
+
 # Copy valid JP2K files across for new MIX metadata see https://github.com/openpreserve/jhove/pull/445
 if [[ -d "${candidateRoot}/examples/modules/JPEG2000-hul" ]]; then
 	echo "Copying valid JPEG2000 examples."
@@ -134,17 +150,19 @@ if [[ -f "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" ]];
 	cp -Rf "${candidateRoot}/examples/modules/PDF-hul/AA_Banner.pdf.jhove.xml" "${targetRoot}/examples/modules/PDF-hul/"
 fi
 
+
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.4.1">JPEG2000-hul<\/module>$/   <module release="1.4.2">JPEG2000-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <outputHandler release="1.8">XML/   <outputHandler release="1.9">XML/' {} \;
 find "${targetRoot}" -type f -name "audit-JPEG2000-hul.jhove.xml" -exec sed -i 's/^  <release>1.4.1<\/release>$/  <release>1.4.2<\/release>/' {} \;
 find "${targetRoot}" -type f -name "audit-JPEG2000-hul.jhove.xml" -exec sed -i 's/^  <date>2019-04-17<\/date>$/  <date>2019-10-18<\/date>/' {} \;
+
+find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.5.1">JPEG-hul<\/module>$/   <module release="1.5.2">JPEG-hul<\/module>/' {} \;
 
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.7.1">WAVE-hul<\/module>$/   <module release="1.8.1">WAVE-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's/^  <release>1.7.1<\/release>$/  <release>1.8.1<\/release>/' {} \;
 find "${targetRoot}" -type f -name "audit-WAVE-hul.jhove.xml" -exec sed -i 's/^  <date>2019-04-17<\/date>$/  <date>2019-12-10<\/date>/' {} \;
 
 find "${targetRoot}" -type f -name "*.aif.jhove.xml" -exec sed -i 's/^  <reportingModule release="1.5.1" date="2019-04-17">AIFF-hul<\/reportingModule>$/  <reportingModule release="1.6.1" date="2019-12-10">AIFF-hul<\/reportingModule>/' {} \;
-find "${targetRoot}" -type f -name "*.AIF.jhove.xml" -exec sed -i 's/^  <reportingModule release="1.5.1" date="2019-04-17">AIFF-hul<\/reportingModule>$/  <reportingModule release="1.6.1" date="2019-12-10">AIFF-hul<\/reportingModule>/' {} \;
 find "${targetRoot}" -type f -name "audit.jhove.xml" -exec sed -i 's/^   <module release="1.5.1">AIFF-hul<\/module>$/   <module release="1.6.1">AIFF-hul<\/module>/' {} \;
 find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's/^  <release>1.5.1<\/release>$/  <release>1.6.1<\/release>/' {} \;
 find "${targetRoot}" -type f -name "audit-AIFF-hul.jhove.xml" -exec sed -i 's/^  <date>2019-04-17<\/date>$/  <date>2019-12-10<\/date>/' {} \;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/NisoImageMetadata.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/NisoImageMetadata.java
@@ -53,8 +53,10 @@ public class NisoImageMetadata
     "CFA",
     "CIE Log2(L)",
     "CIE Log2(L)(u',v')",
-    "LinearRaw"
+    "LinearRaw",
+    "YCCK"
     };
+
     /** Index for 6.1.4.1 color space value labels. */
     public static final int [] COLORSPACE_INDEX = {
 	0, 1, 2, 3,
@@ -63,7 +65,8 @@ public class NisoImageMetadata
     32803,
     32844,
     32845,
-    34892
+    34892,
+    65535
     };
 
     /** 6.1.3.1 Compression scheme value labels. */

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -49,6 +49,7 @@ import edu.harvard.hul.ois.jhove.RepInfo;
 import edu.harvard.hul.ois.jhove.Signature;
 import edu.harvard.hul.ois.jhove.SignatureType;
 import edu.harvard.hul.ois.jhove.TextMDMetadata;
+import edu.harvard.hul.ois.jhove.Utils;
 import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
 
 /**
@@ -752,7 +753,7 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
 
 		// If the property would generate an empty element, don't output it,
 		// as this could result in a schema violation.
-		if (isPropertyEmpty(property, arity))
+		if (Utils.isPropertyEmpty(property, arity))
 			return;
 
 		boolean valueIsProperty = PropertyType.PROPERTY.equals(type);
@@ -872,102 +873,6 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
 		_writer.println(margn3 + elementEnd("values"));
 		_writer.println(margn2 + elementEnd("property"));
 		--_level;
-	}
-
-	/**
-	 * Checks if a property would produce an empty XML element, and returns true
-	 * if it would.
-	 */
-	private boolean isPropertyEmpty(Property property, PropertyArity arity) {
-		try {
-			if (arity.equals(PropertyArity.SET)) {
-				Set propSet = (Set) property.getValue();
-				return (propSet.isEmpty());
-			} else if (arity.equals(PropertyArity.LIST)) {
-				List propList = (List) property.getValue();
-				return (propList.isEmpty());
-			} else if (arity.equals(PropertyArity.MAP)) {
-				Map propMap = (Map) property.getValue();
-				return (propMap.isEmpty());
-			} else if (arity.equals(PropertyArity.ARRAY)) {
-				// Ack! Is there any easy way to do this?
-				boolean[] boolArray = null;
-				byte[] byteArray = null;
-				char[] charArray = null;
-				java.util.Date[] dateArray = null;
-				double[] doubleArray = null;
-				float[] floatArray = null;
-				int[] intArray = null;
-				long[] longArray = null;
-				Object[] objArray = null;
-				Property[] propArray = null;
-				short[] shortArray = null;
-				String[] stringArray = null;
-				Rational[] rationalArray = null;
-				NisoImageMetadata[] nisoArray = null;
-				AESAudioMetadata[] aesArray = null;
-				TextMDMetadata[] textMDArray = null;
-				int n = 0;
-
-				PropertyType propType = property.getType();
-				if (PropertyType.BOOLEAN.equals(propType)) {
-					boolArray = (boolean[]) property.getValue();
-					n = boolArray.length;
-				} else if (PropertyType.BYTE.equals(propType)) {
-					byteArray = (byte[]) property.getValue();
-					n = byteArray.length;
-				} else if (PropertyType.CHARACTER.equals(propType)) {
-					charArray = (char[]) property.getValue();
-					n = charArray.length;
-				} else if (PropertyType.DATE.equals(propType)) {
-					dateArray = (java.util.Date[]) property.getValue();
-					n = dateArray.length;
-				} else if (PropertyType.DOUBLE.equals(propType)) {
-					doubleArray = (double[]) property.getValue();
-					n = doubleArray.length;
-				} else if (PropertyType.FLOAT.equals(propType)) {
-					floatArray = (float[]) property.getValue();
-					n = floatArray.length;
-				} else if (PropertyType.INTEGER.equals(propType)) {
-					intArray = (int[]) property.getValue();
-					n = intArray.length;
-				} else if (PropertyType.LONG.equals(propType)) {
-					longArray = (long[]) property.getValue();
-					n = longArray.length;
-				} else if (PropertyType.OBJECT.equals(propType)) {
-					objArray = (Object[]) property.getValue();
-					n = objArray.length;
-				} else if (PropertyType.SHORT.equals(propType)) {
-					shortArray = (short[]) property.getValue();
-					n = shortArray.length;
-				} else if (PropertyType.STRING.equals(propType)) {
-					stringArray = (String[]) property.getValue();
-					n = stringArray.length;
-				} else if (PropertyType.RATIONAL.equals(propType)) {
-					rationalArray = (Rational[]) property.getValue();
-					n = rationalArray.length;
-				} else if (PropertyType.PROPERTY.equals(propType)) {
-					propArray = (Property[]) property.getValue();
-					n = propArray.length;
-				} else if (PropertyType.NISOIMAGEMETADATA.equals(propType)) {
-					nisoArray = (NisoImageMetadata[]) property.getValue();
-					n = nisoArray.length;
-				} else if (PropertyType.AESAUDIOMETADATA.equals(propType)) {
-					aesArray = (AESAudioMetadata[]) property.getValue();
-					n = aesArray.length;
-				} else if (PropertyType.TEXTMDMETADATA.equals(propType)) {
-					textMDArray = (TextMDMetadata[]) property.getValue();
-					n = textMDArray.length;
-				}
-				return (n == 0);
-			} else {
-				return property.getValue().toString().length() == 0;
-			}
-		} catch (Exception e) {
-			// If something goes seriously wrong, return true to punt the
-			// property
-			return true;
-		}
 	}
 
 	/*
@@ -4182,345 +4087,295 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
 		return s.substring(0, 1).toUpperCase(Locale.ROOT) + s.substring(1);
 	}
 
-	/**
-	 * Convert the color space value (which is based on the TIFF
-	 * PhotometricInterpretation convention) to one of the suggested values for
-	 * MIX 2.0
-	 */
-	private String photometricInterpretationToString(int n) {
-		String s = "Unknown";
-		switch (n) {
-		case 0:
-			s = "WhiteIsZero";
-			break;
-		case 1:
-			s = "BlackIsZero";
-			break;
-		case 2:
-			s = "RGB";
-			break;
-		case 3:
-			s = "PaletteColor";
-			break;
-		case 4:
-			s = "TransparencyMask";
-			break;
-		case 5:
-			s = "CMYK";
-			break;
-		case 6:
-			s = "YCbCr";
-			break;
-		case 8:
-			s = "CIELab";
-			break;
-		case 9:
-			s = "ICCLab";
-			break;
-		case 10:
-			s = "ITULab";
-			break;
-		case 32803:
-			s = "CFA";
-			break; // used by DNG
-		case 34892:
-			s = "LinearRaw";
-			break; // used by DNG
-		}
-		return s;
-	}
+    /** Convert the color space value (which is based on the TIFF
+     *  PhotometricInterpretation convention) to one of the suggested
+     *  values for MIX 2.0 */
+    private String photometricInterpretationToString (int n) {
+        String s = "Unknown";
+        switch (n) {
+        case 0: s = "WhiteIsZero"; break;
+        case 1: s = "BlackIsZero"; break;
+        case 2: s = "RGB"; break;
+        case 3: s = "PaletteColor"; break;
+        case 4: s = "TransparencyMask"; break;
+        case 5: s = "CMYK"; break;
+        case 6: s = "YCbCr"; break;
+        case 8: s = "CIELab"; break;
+        case 9: s = "ICCLab"; break;
+        case 10: s = "ITULab"; break;
+        case 32803: s = "CFA"; break;         // used by DNG
+        case 34892: s = "LinearRaw"; break;   // used by DNG
+        case 65535: s = "YCCK"; break;   // used by Adobe JPEG
+				default: break;
+        }
+        return s;
+    }
 
-	/**
-	 * Convert compression scheme value (based on the TIFF compression
-	 * convention) to a label
-	 */
-	private String compressionSchemeToString(int n) {
-		for (int i = 0; i < NisoImageMetadata.COMPRESSION_SCHEME_INDEX.length; i++) {
-			if (n == NisoImageMetadata.COMPRESSION_SCHEME_INDEX[i])
-				return NisoImageMetadata.COMPRESSION_SCHEME[i];
-		}
-		return Integer.toString(n);
-	}
+    /**
+     * Convert compression scheme value (based on the TIFF compression convention)
+     * to a label
+      */
+    private String compressionSchemeToString (int n) {
+        for (int i = 0; i < NisoImageMetadata.COMPRESSION_SCHEME_INDEX.length; i++) {
+        	if (n == NisoImageMetadata.COMPRESSION_SCHEME_INDEX[i])
+        		return NisoImageMetadata.COMPRESSION_SCHEME[i];
+        }
+        return Integer.toString(n);
+    }
 
-	/**
-	 * Display the audio metadata formatted according to the AES schema.
-	 *
-	 * @param aes
-	 *            AES audio metadata
-	 */
-	protected void showAESAudioMetadata(AESAudioMetadata aes) {
-		_level += 3;
-		final String margin = getIndent(_level);
-		final String margn2 = margin + " ";
-		final String margn3 = margn2 + " ";
-		final String margn4 = margn3 + " ";
-		final String margn5 = margn4 + " ";
-		// final String margn6 = margn5 + " ";
+    /**
+     * Display the audio metadata formatted according to
+     * the AES schema.
+     * @param aes AES audio metadata
+     */
+    protected void showAESAudioMetadata (AESAudioMetadata aes)
+    {
+        _level += 3;
+        final String margin = getIndent (_level);
+        final String margn2 = margin + " ";
+        final String margn3 = margn2 + " ";
+        final String margn4 = margn3 + " ";
+        final String margn5 = margn4 + " ";
+        //final String margn6 = margn5 + " ";
 
-		// ID strings. These are arbitrary, but must be unique
-		// within the document.
-		final String formatRegionID = "J1";
-		final String faceRegionID = "J2";
-		final String faceID = "J3";
-		final String audioObjectID = "J4";
-		final String streamIDBase = "J9";
+        // ID strings.  These are arbitrary, but must be unique
+        // within the document.
+        final String formatRegionID = "J1";
+        final String faceRegionID = "J2";
+        final String faceID = "J3";
+        final String audioObjectID = "J4";
+        final String streamIDBase = "J9";
 
-		_sampleRate = aes.getSampleRate();
+	_sampleRate = aes.getSampleRate ();
 
-		final String[][] attrs = {
-				{ "xmlns:aes", "http://www.aes.org/audioObject" },
-				{ "xmlns:tcf", "http://www.aes.org/tcf" },
-				{ "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" },
-				{ "ID", audioObjectID },
-				{ "analogDigitalFlag", aes.getAnalogDigitalFlag() },
-				{ "disposition", "Validated by JHOVE" },
-				{ "schemaVersion", "1.02b" } };
-		_writer.println(margin + elementStart("aes:audioObject", attrs));
-		String s = aes.getFormat();
-		if (s != null) {
-			String v = aes.getSpecificationVersion();
-			String[][] fmattrs = new String[1][2];
-			fmattrs[0][0] = "specificationVersion";
-			if (v != null) {
-				fmattrs[0][1] = v;
-			} else {
-				// Shouldn't happen
-				fmattrs[0][1] = "";
-			}
-			_writer.println(margn2 + element("aes:format", fmattrs, s));
-		}
-		s = aes.getAppSpecificData();
-		if (s != null) {
-			_writer.println(margn2 + element("aes:appSpecificData", s));
-		}
-		s = aes.getAudioDataEncoding();
-		if (s != null) {
-			_writer.println(margn2 + element("aes:audioDataEncoding", s));
-		}
-		int in = aes.getByteOrder();
-		if (in != AESAudioMetadata.NULL) {
-			_writer.println(margn2
-					+ element("aes:byteOrder",
-							in == AESAudioMetadata.BIG_ENDIAN ? "BIG_ENDIAN"
-									: "LITTLE_ENDIAN"));
-		}
-		long lin = aes.getFirstSampleOffset();
-		if (lin != AESAudioMetadata.NULL) {
-			_writer.println(margn2
-					+ element("aes:firstSampleOffset", Long.toString(lin)));
-		}
-		String[] use = aes.getUse();
-		if (use != null) {
-			String[][] uattrs = new String[][] { { "useType", use[0] },
-					{ "otherType", use[1] } };
-			_writer.println(margn2 + element("aes:use", uattrs));
-		}
-		s = aes.getPrimaryIdentifier();
-		if (s != null) {
-			String t = aes.getPrimaryIdentifierType();
-			String[][] idattrs = new String[1][2];
-			idattrs[0][0] = "identifierType";
-			if (t != null) {
-				idattrs[0][1] = t;
-			} else {
-				// Shouldn't happen
-				idattrs[0][1] = "";
-			}
-			_writer.println(margn2
-					+ element("aes:primaryIdentifier", idattrs, s));
-		}
+        final String [][] attrs = {{"xmlns:aes", "http://www.aes.org/audioObject"},
+                             {"xmlns:tcf", "http://www.aes.org/tcf"},
+ 			     {"xmlns:xsi",
+ 			      "http://www.w3.org/2001/XMLSchema-instance"},
+                             {"ID", audioObjectID },
+			     {"analogDigitalFlag",
+                              aes.getAnalogDigitalFlag ()},
+                             {"disposition",
+                              "Validated by JHOVE"},
+                             {"schemaVersion","1.02b"}};
+        _writer.println (margin + elementStart ("aes:audioObject", attrs));
+        String  s = aes.getFormat ();
+        if (s != null) {
+            String v = aes.getSpecificationVersion ();
+            String[][] fmattrs = new String[1][2];
+            fmattrs[0][0] = "specificationVersion";
+            if (v != null) {
+                fmattrs[0][1] = v;
+            }
+            else {
+                // Shouldn't happen
+                fmattrs[0][1] = "";
+            }
+            _writer.println (margn2 + element
+                ("aes:format", fmattrs, s));
+        }
+        s = aes.getAppSpecificData();
+        if (s != null) {
+            _writer.println (margn2 + element
+                ("aes:appSpecificData", s));
+        }
+        s = aes.getAudioDataEncoding ();
+        if (s != null) {
+            _writer.println (margn2 + element
+                ("aes:audioDataEncoding", s));
+        }
+	    int in = aes.getByteOrder ();
+	    if (in != AESAudioMetadata.NULL) {
+	       _writer.println (margn2 + element ("aes:byteOrder",
+					    in == AESAudioMetadata.BIG_ENDIAN ?
+					    "BIG_ENDIAN" : "LITTLE_ENDIAN"));
+        }
+        long lin = aes.getFirstSampleOffset ();
+        if (lin != AESAudioMetadata.NULL) {
+            _writer.println (margn2 + element ("aes:firstSampleOffset",
+                     Long.toString (lin)));
+        }
+        String[] use = aes.getUse ();
+        if (use != null) {
+            String[][] uattrs = new String [][]
+                { { "useType", use[0] },
+                  { "otherType", use[1] }};
+            _writer.println (margn2 + element ("aes:use", uattrs));
+        }
+        s = aes.getPrimaryIdentifier();
+        if (s != null) {
+            String t= aes.getPrimaryIdentifierType ();
+            String[][] idattrs = new String[1][2];
+            idattrs[0][0] = "identifierType";
+            if (t != null) {
+                idattrs[0][1] = t;
+            }
+            else {
+                // Shouldn't happen
+                idattrs[0][1] = "";
+            }
+            _writer.println (margn2 + element
+                ("aes:primaryIdentifier", idattrs, s));
+        }
 
-		// Add the face information, which is mostly filler.
-		// In the general case, it can contain multiple Faces;
-		// this isn't supported yet.
-		List<AESAudioMetadata.Face> facelist = aes.getFaceList();
-		if (!facelist.isEmpty()) {
-			final String[][] faceRegionAttrs = { { "ID", faceRegionID },
-					{ "formatRef", formatRegionID }, { "faceRef", faceID },
-					{ "label", "BuiltByJHOVE" } };
-			final String[][] faceAttrs = { { "direction", null },
-					{ "ID", faceID }, { "audioObjectRef", audioObjectID },
-					{ "label", "Face" } };
-			AESAudioMetadata.Face f = (AESAudioMetadata.Face) facelist.get(0);
-			faceAttrs[0][1] = f.getDirection();
-			_writer.println(margn2 + elementStart("aes:face", faceAttrs));
-			// Fill in a minimal time range.
-			AESAudioMetadata.TimeDesc startTime = f.getStartTime();
-			if (startTime != null) {
-				_writer.println(margn3 + elementStart("aes:timeline"));
-				writeAESTimeRange(margn3, startTime, f.getDuration());
-				_writer.println(margn3 + elementEnd("aes:timeline"));
-			}
+        // Add the face information, which is mostly filler.
+        // In the general case, it can contain multiple Faces;
+        // this isn't supported yet.
+        List facelist = aes.getFaceList ();
+        if (!facelist.isEmpty ()) {
+            final String [] [] faceRegionAttrs = {
+                { "ID", faceRegionID },
+                { "formatRef", formatRegionID },
+                { "faceRef", faceID },
+                { "label", "BuiltByJHOVE" }
+            };
+            final String [] [] faceAttrs = {
+                { "direction", null },
+                { "ID", faceID },
+                { "audioObjectRef", audioObjectID },
+                { "label", "Face" }
+            };
+            AESAudioMetadata.Face f =
+                (AESAudioMetadata.Face) facelist.get(0);
+            faceAttrs[0] [1] = f.getDirection();
+            _writer.println (margn2 + elementStart ("aes:face", faceAttrs));
+            // Fill in a minimal time range.
+            AESAudioMetadata.TimeDesc startTime = f.getStartTime();
+            if (startTime != null) {
+                 _writer.println (margn3 + elementStart ("aes:timeline"));
+                 writeAESTimeRange (margn3, startTime, f.getDuration());
+                 _writer.println (margn3 + elementEnd ("aes:timeline"));
+            }
 
-			// For the present, assume just one face region
-			AESAudioMetadata.FaceRegion facergn = f.getFaceRegion(0);
-			_writer.println(margn3
-					+ elementStart("aes:region", faceRegionAttrs));
-			_writer.println(margn4 + elementStart("aes:timeRange"));
-			writeAESTimeRange(margn3, facergn.getStartTime(),
-					facergn.getDuration());
-			_writer.println(margn4 + elementEnd("aes:timeRange"));
-			int nchan = aes.getNumChannels();
-			if (nchan != AESAudioMetadata.NULL) {
-				_writer.println(margn4
-						+ element("aes:numChannels", Integer.toString(nchan)));
-			}
-			String[] locs = aes.getMapLocations();
-			for (int ch = 0; ch < nchan; ch++) {
-				// write a stream element for each channel
-				String[][] streamAttrs = {
-						{ "ID", streamIDBase + Integer.toString(ch) },
-						{ "label", "JHOVE" }, { "faceRegionRef", faceRegionID }
+            // For the present, assume just one face region
+            AESAudioMetadata.FaceRegion facergn = f.getFaceRegion (0);
+             _writer.println (margn3 + elementStart ("aes:region", faceRegionAttrs));
+              _writer.println (margn4 + elementStart ("aes:timeRange"));
+              writeAESTimeRange (margn3,
+                    facergn.getStartTime (), facergn.getDuration ());
+              _writer.println (margn4 + elementEnd ("aes:timeRange"));
+              int nchan = aes.getNumChannels ();
+              if (nchan != AESAudioMetadata.NULL) {
+                _writer.println (margn4 + element ("aes:numChannels",
+                                Integer.toString (nchan)));
+              }
+              String[] locs = aes.getMapLocations ();
+              for (int ch = 0; ch < nchan; ch++) {
+                // write a stream element for each channel
+                String [] [] streamAttrs = {
+                    { "ID", streamIDBase + Integer.toString (ch) },
+                    { "label", "JHOVE" },
+                    { "faceRegionRef", faceRegionID }
 
-				};
-				_writer.println(margn4
-						+ elementStart("aes:stream", streamAttrs));
-				String[][] chanAttrs = {
-						{ "channelNum", Integer.toString(ch) },
-						{ "mapLocation", locs[ch] } };
-				_writer.println(margn5
-						+ element("aes:channelAssignment", chanAttrs));
-				_writer.println(margn4 + elementEnd("aes:stream"));
-			}
-			_writer.println(margn3 + elementEnd("aes:region"));
-			_writer.println(margn2 + elementEnd("aes:face"));
-		}
+                };
+                _writer.println (margn4 + elementStart ("aes:stream", streamAttrs));
+                String [] [] chanAttrs = {
+                    { "channelNum", Integer.toString(ch) },
+                    { "mapLocation", locs[ch] }
+                };
+                _writer.println (margn5 + element ("aes:channelAssignment", chanAttrs));
+                _writer.println (margn4 + elementEnd ("aes:stream"));
+              }
+             _writer.println (margn3 + elementEnd ("aes:region"));
+            _writer.println (margn2+ elementEnd ("aes:face"));
+        }
 
-		// In the general case, a FormatList can contain multiple
-		// FormatRegions. This doesn't happen with any of the current
-		// modules; if it's needed in the future, simply set up an
-		// iteration loop on formatList.
-		List<AESAudioMetadata.FormatRegion> flist = aes.getFormatList();
-		if (!flist.isEmpty()) {
-			AESAudioMetadata.FormatRegion rgn = (AESAudioMetadata.FormatRegion) flist
-					.get(0);
-			int bitDepth = rgn.getBitDepth();
-			double sampleRate = rgn.getSampleRate();
-			int wordSize = rgn.getWordSize();
-			String[] bitRed = rgn.getBitrateReduction();
-			// Build a FormatRegion subtree if at least one piece of data
-			// that goes into it is present.
-			if (bitDepth != AESAudioMetadata.NULL
-					|| sampleRate != AESAudioMetadata.NILL
-					|| wordSize != AESAudioMetadata.NULL) {
-				_writer.println(margn2 + elementStart("aes:formatList"));
-				String[][] frAttr = { { "ID", formatRegionID } };
-				_writer.println(margn3
-						+ elementStart("aes:formatRegion", frAttr));
-				if (bitDepth != AESAudioMetadata.NULL) {
-					_writer.println(margn4
-							+ element("aes:bitDepth",
-									Integer.toString(bitDepth)));
-				}
-				if (sampleRate != AESAudioMetadata.NILL) {
-					_writer.println(margn4
-							+ element("aes:sampleRate", formatters.get()
-									.format(sampleRate)));
-				}
-				if (wordSize != AESAudioMetadata.NULL) {
-					_writer.println(margn4
-							+ element("aes:wordSize",
-									Integer.toString(wordSize)));
-				}
-				if (bitRed != null) {
-					_writer.println(margn4
-							+ elementStart("aes:bitrateReduction"));
-					_writer.println(margn5
-							+ element("aes:codecName", bitRed[0]));
-					_writer.println(margn5
-							+ element("aes:codecNameVersion", bitRed[1]));
-					_writer.println(margn5
-							+ element("aes:codecCreatorApplication", bitRed[2]));
-					_writer.println(margn5
-							+ element("aes:codecCreatorApplicationVersion",
-									bitRed[3]));
-					_writer.println(margn5
-							+ element("aes:codecQuality", bitRed[4]));
-					_writer.println(margn5 + element("aes:dataRate", bitRed[5]));
-					_writer.println(margn5
-							+ element("aes:dataRateMode", bitRed[6]));
-					_writer.println(margn4 + elementEnd("aes:bitrateReduction"));
-				}
-				_writer.println(margn3 + elementEnd("aes:formatRegion"));
-				_writer.println(margn2 + elementEnd("aes:formatList"));
-			}
-		}
-		/* This should go somewhere, but where? */
-		// int nchan = aes.getNumChannels ();
-		// if (nchan != AESAudioMetadata.NULL) {
-		// _writer.println (margn2 + element ("aes:numChannels",
-		// Integer.toString (nchan)));
-		// }
+        // In the general case, a FormatList can contain multiple
+        // FormatRegions.  This doesn't happen with any of the current
+        // modules; if it's needed in the future, simply set up an
+        // iteration loop on formatList.
+        List flist = aes.getFormatList ();
+        if (!flist.isEmpty ()) {
+            AESAudioMetadata.FormatRegion rgn =
+                (AESAudioMetadata.FormatRegion) flist.get(0);
+            int bitDepth = rgn.getBitDepth ();
+            double sampleRate = rgn.getSampleRate ();
+            int wordSize = rgn.getWordSize ();
+            String[] bitRed = rgn.getBitrateReduction ();
+            // Build a FormatRegion subtree if at least one piece of data
+            // that goes into it is present.
+            if (bitDepth != AESAudioMetadata.NULL ||
+                    sampleRate != AESAudioMetadata.NILL ||
+                    wordSize != AESAudioMetadata.NULL) {
+                _writer.println (margn2 + elementStart ("aes:formatList"));
+                String[] [] frAttr = { { "ID", formatRegionID } };
+                _writer.println (margn3 + elementStart ("aes:formatRegion", frAttr));
+                if (bitDepth != AESAudioMetadata.NULL) {
+                    _writer.println (margn4 + element ("aes:bitDepth",
+                                Integer.toString (bitDepth)));
+                }
+                if (sampleRate != AESAudioMetadata.NILL) {
+                    _writer.println (margn4 + element ("aes:sampleRate",
+                                formatters.get().format (sampleRate)));
+                }
+                if (wordSize != AESAudioMetadata.NULL) {
+                    _writer.println (margn4 + element ("aes:wordSize",
+                                Integer.toString (wordSize)));
+                }
+                if (bitRed != null) {
+                    _writer.println (margn4 + elementStart ("aes:bitrateReduction"));
+                      _writer.println (margn5 + element
+                            ("aes:codecName", bitRed[0]));
+                      _writer.println (margn5 + element
+                            ("aes:codecNameVersion", bitRed[1]));
+                      _writer.println (margn5 + element
+                            ("aes:codecCreatorApplication", bitRed[2]));
+                      _writer.println (margn5 + element
+                            ("aes:codecCreatorApplicationVersion", bitRed[3]));
+                      _writer.println (margn5 + element
+                            ("aes:codecQuality", bitRed[4]));
+                      _writer.println (margn5 + element
+                            ("aes:dataRate", bitRed[5]));
+                      _writer.println (margn5 + element
+                            ("aes:dataRateMode", bitRed[6]));
+                    _writer.println (margn4 + elementEnd ("aes:bitrateReduction"));
+                }
+                _writer.println (margn3 + elementEnd ("aes:formatRegion"));
+                _writer.println (margn2 + elementEnd ("aes:formatList"));
+            }
+        }
+        /* This should go somewhere, but where? */
+//        int nchan = aes.getNumChannels ();
+//        if (nchan != AESAudioMetadata.NULL) {
+//            _writer.println (margn2 + element ("aes:numChannels",
+//                            Integer.toString (nchan)));
+//        }
 
-		_writer.println(margin + elementEnd("aes:audioObject"));
+        _writer.println (margin + elementEnd ("aes:audioObject"));
 
-		_level -= 3;
-	}
+        _level -= 3;
+    }
 
-	/*
-	 * Break out the writing of a timeRangeType element. This always gives a
-	 * start time of 0. This is all FAKE DATA for the moment.
-	 */
-	private void writeAESTimeRange(String baseIndent,
-			AESAudioMetadata.TimeDesc start, AESAudioMetadata.TimeDesc duration) {
-		final String margn1 = baseIndent + " ";
-		final String margn2 = margn1 + " ";
-		final String margn3 = margn2 + " ";
-		final String[][] attrs = { { "tcf:frameCount", "30" },
-				{ "tcf:timeBase", "1000" }, { "tcf:videoField", "FIELD_1" },
-				{ "tcf:countingMode", "NTSC_NON_DROP_FRAME" } };
-		final String[][] ffAttrs = { { "tcf:framing", "NOT_APPLICABLE" },
-				{ "xsi:type", "tcf:ntscFilmFramingType" } };
-		_writer.println(margn1 + elementStart("tcf:startTime", attrs));
-		_writer.println(margn2
-				+ element("tcf:hours", Long.toString(start.getHours())));
-		_writer.println(margn2
-				+ element("tcf:minutes", Long.toString(start.getMinutes())));
-		_writer.println(margn2
-				+ element("tcf:seconds", Long.toString(start.getSeconds())));
-		_writer.println(margn2
-				+ element("tcf:frames", Long.toString(start.getFrames())));
-		String[][] sampleAttrs = { { "tcf:sampleRate", "" } };
-		double sr = start.getSampleRate();
+    /* Break out the writing of a timeRangeType element.
+     * This always gives a start time of 0.  This is all
+     * FAKE DATA for the moment. */
+    private void writeAESTimeRange (String baseIndent,
+        AESAudioMetadata.TimeDesc start,
+        AESAudioMetadata.TimeDesc duration)
+    {
+        final String margn1 = baseIndent + " ";
+        final String margn2 = margn1 + " ";
+        final String [] [] attrs = {
+            { "tcf:frameCount", "30" },
+            { "tcf:timeBase", "1000" },
+            { "tcf:videoField", "FIELD_1" },
+            { "tcf:countingMode", "NTSC_NON_DROP_FRAME" }
+        };
+        _writer.println (margn1 + elementStart ("tcf:startTime", attrs));
+		_writer.println (margn2 + element ("tcf:hours",
+					   Long.toString (start.getHours ())));
+		_writer.println (margn2 + element ("tcf:minutes",
+					   Long.toString (start.getMinutes ())));
+		_writer.println (margn2 + element ("tcf:seconds",
+					   Long.toString (start.getSeconds ())));
+		_writer.println (margn2 + element ("tcf:frames",
+					   Long.toString (start.getFrames ()) ));
+        _writer.println (margn1 + elementEnd("tcf:startTime"));
+		double sr = start.getSampleRate ();
 		if (sr == 1.0) {
-			sr = _sampleRate;
+		    sr = _sampleRate;
 		}
-		sampleAttrs[0][1] = "S" + Integer.toString((int) sr);
-		_writer.println(margn2 + elementStart("tcf:samples", sampleAttrs));
-		_writer.println(margn3
-				+ element("tcf:numberOfSamples",
-						Long.toString(start.getSamples())));
-		_writer.println(margn2 + elementEnd("tcf:samples"));
-		_writer.println(margn2 + element("tcf:filmFraming", ffAttrs));
-		_writer.println(margn1 + elementEnd("tcf:startTime"));
-
-		if (duration != null) {
-			_writer.println(margn1 + elementStart("tcf:duration", attrs));
-			_writer.println(margn2
-					+ element("tcf:hours", Long.toString(duration.getHours())));
-			_writer.println(margn2
-					+ element("tcf:minutes",
-							Long.toString(duration.getMinutes())));
-			_writer.println(margn2
-					+ element("tcf:seconds",
-							Long.toString(duration.getSeconds())));
-			_writer.println(margn2
-					+ element("tcf:frames", Long.toString(duration.getFrames())));
-			sr = duration.getSampleRate();
-			if (sr == 1.0) {
-				sr = _sampleRate;
-			}
-			sampleAttrs[0][1] = "S" + Integer.toString((int) sr);
-			_writer.println(margn2 + elementStart("tcf:samples", sampleAttrs));
-			_writer.println(margn3
-					+ element("tcf:numberOfSamples",
-							Long.toString(duration.getSamples())));
-			_writer.println(margn2 + elementEnd("tcf:samples"));
-			_writer.println(margn2 + element("tcf:filmFraming", ffAttrs));
-			_writer.println(margn1 + elementEnd("tcf:duration"));
-		}
-	}
-
+    }
 	/*
 	 * Clean up a URI string by escaping forbidden characters. We assume
 	 * (perhaps dangerously) that a % is the start of an already escaped

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>jpeg-hul</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -69,8 +69,8 @@
       <executable targetfile="$INSTALL_PATH/bin/html-hul-1.4.1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg2000-hul-1.4.1.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/jpeg2000-hul-1.4.1.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg-hul-1.5.1.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/jpeg-hul-1.5.1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/jpeg-hul-1.5.2.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/jpeg-hul-1.5.2.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/pdf-hul-1.12.1.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/pdf-hul-1.12.1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/tiff-hul-1.9.1.jar"/>

--- a/jhove-modules/jpeg-hul/pom.xml
+++ b/jhove-modules/jpeg-hul/pom.xml
@@ -6,7 +6,7 @@
     <version>1.23.0-SNAPSHOT</version>
   </parent>
   <artifactId>jpeg-hul</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2</version>
   <name>JHOVE JPEG Module HUL</name>
   <description>JPEG module developed by Harvard University Library</description>
 

--- a/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
+++ b/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/JpegModule.java
@@ -20,6 +20,7 @@
 package edu.harvard.hul.ois.jhove.module;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.File;
@@ -28,12 +29,10 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.xml.parsers.SAXParserFactory;
@@ -64,6 +63,8 @@ import edu.harvard.hul.ois.jhove.Signature;
 import edu.harvard.hul.ois.jhove.SignatureType;
 import edu.harvard.hul.ois.jhove.SignatureUseType;
 import edu.harvard.hul.ois.jhove.XMPHandler;
+import edu.harvard.hul.ois.jhove.messages.JhoveMessage;
+import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
 import edu.harvard.hul.ois.jhove.module.jpeg.ArithConditioning;
 import edu.harvard.hul.ois.jhove.module.jpeg.JpegExif;
 import edu.harvard.hul.ois.jhove.module.jpeg.JpegStrings;
@@ -108,18 +109,18 @@ public class JpegModule extends ModuleBase {
 	 ******************************************************************/
 	private static final String NISO_IMAGE_MD = "NisoImageMetadata";
 	private static final String NAME = "JPEG-hul";
-	private static final String RELEASE = "1.5.1";
-  private static final int [] DATE = { 2019, 04, 17 };
+	private static final String RELEASE = "1.5.2";
+  private static final int [] DATE = { 2019, 11, 05 };
 	private static final String[] FORMAT = { "JPEG", "ISO/IEC 10918-1:1994",
 			"Joint Photographic Experts Group", "JFIF",
 			"JPEG File Interchange Format", "SPIFF", "ISO/IEC 10918-3:1997",
 			"Still Picture Interchange File Format", "JTIP",
 			"ISO/IEC 10918-3:1997", "JPEG Tiled Image Pyramid", "JPEG-LS",
-			"ISO/IEC 14495" };
+			"ISO/IEC 14495", "Adobe JPEG", "ISO/IEC 10918-6:2013" };
 	private static final String COVERAGE = "JPEG (ISO/IEC 10918-1:1994), JFIF 1.02, "
 			+ "SPIFF (ISO/IEC 10918-3:1997), "
 			+ "Exif 2.0, 2.1 (JEIDA-49-1998), 2.2 (JEITA CP-3451), 2.21 (JEITA CP-3451A), and 2.3 (JEITA CP-3451C), "
-			+ "JTIP (ISO/IEC 10918-3:1997), JPEG-LS (ISO/IEC 14495)";
+			+ "JTIP (ISO/IEC 10918-3:1997), JPEG-LS (ISO/IEC 14495), Adobe JPEG (ISO/IEC 10918-6:2013)";
 	private static final String[] MIMETYPE = { "image/jpeg" };
 	private static final String WELLFORMED = "A JPEG file is well-formed if "
 			+ "the first three bytes are 0xFFD8FF, it consists of one or more "
@@ -128,10 +129,11 @@ public class JpegModule extends ModuleBase {
 			+ "terminated";
 	private static final String VALIDITY = "A JPEG file is valid if "
 			+ "well-formed; the first non-comment segment is APP0 (with "
-			+ "identifier 0x4A46494600, indicating JFIF or JTIP), APP1 (with "
-			+ "identifier (0x457869660000, indicating Exif), APP8 (with "
-			+ "identifier 0x545049464600, indicating SPIFF), or JPG7 (or SOF55, "
-			+ "indicating JPEG-LS); D8 marker occurs only at the beginning of "
+			+ "identifier 0x4A46494600, indicating JFIF or JTIP, with 1, 3 or 4 components), "
+			+ "APP1 (with identifier (0x457869660000, indicating Exif, and only 3 components), "
+			+ "APP8 (with identifier 0x545049464600, indicating SPIFF), "
+			+ "or JPG7 (or SOF55, indicating JPEG-LS); "
+			+ "D8 marker occurs only at the beginning of "
 			+ "the file; any DTT segments are preceded by DTI segments; and all "
 			+ "DTI segment tiling type have a value of 0, 1, or 2";
 	private static final String REPINFO = "Additional representation "
@@ -145,6 +147,12 @@ public class JpegModule extends ModuleBase {
 	/******************************************************************
 	 * PRIVATE INSTANCE FIELDS.
 	 ******************************************************************/
+    private static final int CS_GRAYSCALE = 1;
+    private static final int CS_RGB = 2;
+    private static final int CS_PALETTE = 3;
+    private static final int CS_YCC = 6; // YcbCr
+    private static final int CS_CMYK = 5;
+    private static final int CS_YCCK = 65535; // not existing !!!
 
 	/*
 	 * Profile names. These are just informal identifiers, and probably will be
@@ -154,6 +162,7 @@ public class JpegModule extends ModuleBase {
 	protected String spiffProfileName = "SPIFF";
 	protected String exifProfileName = "Exif";
 	protected String jpeglProfileName = "JPEG-L";
+    protected String adobeProfileName = "Adobe JPEG";
 
 	/* a NumberFormat for handling the minor part of version numbers */
 	protected NumberFormat minorFmt;
@@ -235,6 +244,9 @@ public class JpegModule extends ModuleBase {
 	/* Exif profile if one is satisfied, more specific than just Exif */
 	protected String _exifProfileText;
 
+    /* Flag indicating an APP14 Adobe segment has been read */
+    protected boolean _seenAdobe;
+
 	/* Flag indicating lack of a JFIF segment has been reported */
 	protected boolean _reportedJFIF;
 
@@ -255,9 +267,6 @@ public class JpegModule extends ModuleBase {
 	 */
 	protected List<boolean[]> _expList;
 
-	/* Set of compression types used. */
-	protected Set _compressSet;
-
 	/* Capability 0 byte, from VER segment. -1 if none. */
 	protected int _capability0;
 
@@ -266,6 +275,12 @@ public class JpegModule extends ModuleBase {
 
 	/* Fixed value for first 3 bytes */
 	private static final int[] sigByte = { 0XFF, 0XD8, 0XFF };
+
+    /* Transform flag from the Adobe marker segment. */
+    protected byte _transformFlag = -1;
+
+    /* Keep all the chunks of an ICC profile */
+    protected ByteArrayOutputStream _baosIccProfile = null;
 
 	/* Resolution units. */
 	protected int _units;
@@ -348,6 +363,16 @@ public class JpegModule extends ModuleBase {
 				DocumentType.STANDARD);
 		doc.setPublisher(isoAgent);
 		_specification.add(doc);
+
+        // Define ISO Adobe extensions
+        doc = new Document(
+                "ISO/IEC 10918-6:2013(E), Digital compression"
+                        + "and coding of continuous-tone still-images: "
+                        + "Application to printing systems", DocumentType.STANDARD);
+        doc.setPublisher(isoAgent);
+        doc.setIdentifier(new Identifier("ITU-T Rec. T.872 (06/12)",
+                IdentifierType.CCITT));
+        _specification.add(doc);
 
 		// Define JEITA Exif 2.3 doc
 		doc = new Document(
@@ -521,14 +546,14 @@ public class JpegModule extends ModuleBase {
 				if (dataPlowing) {
 					for (;;) {
 						dbyt = readUnsignedByte(_dstream, this);
-						if (dbyt == 0XFF) {
+						if (dbyt == 0xFF) {
 							sawFF = true;
 							// multiple FF's count same as one
 						} else if (sawFF) {
 							// Note use of JPEG-L check. For a
 							// standard JPEG check, we would use
 							// (dbyt != 0)
-							if ((dbyt & 0X80) != 0) {
+							if ((dbyt & 0x80) != 0) {
 								dataPlowing = false;
 								break;
 							}
@@ -538,7 +563,7 @@ public class JpegModule extends ModuleBase {
 					}
 				} else {
 					dbyt = readUnsignedByte(_dstream, this);
-					if (dbyt != 0XFF) {
+					if (dbyt != 0xFF) {
 						info.setMessage(new ErrorMessage(
 								MessageConstants.JPEG_HUL_7,
 								String.format(MessageConstants.JPEG_HUL_7_SUB.getMessage(), dbyt),
@@ -548,7 +573,7 @@ public class JpegModule extends ModuleBase {
 					}
 					// There can be padding bytes equal to FF,
 					// so read till we get one that isn't.
-					while (dbyt == 0XFF) {
+					while (dbyt == 0xFF) {
 						dbyt = readUnsignedByte(_dstream, this);
 					}
 				}
@@ -561,10 +586,10 @@ public class JpegModule extends ModuleBase {
 					info.setValid(false);
 					_reportedJFIF = true;
 				}
-				if (dbyt >= 0XD0 && dbyt <= 0XD7) {
+				if (dbyt >= 0xD0 && dbyt <= 0xD7) {
 					// RST[m] -- Restart with modulo 8 count 0-7
 					dataPlowing = true;
-				} else if (dbyt >= 0XF7 && dbyt <= 0XFD) {
+				} else if (dbyt >= 0xF7 && dbyt <= 0xFD) {
 					// JPGn extension
 					readJPEGExtension(dbyt, info);
 				} else
@@ -573,98 +598,102 @@ public class JpegModule extends ModuleBase {
 						// Byte stuffing -- ignore
 						break;
 
-					case 0XC0:
-					case 0XC1:
-					case 0XC2:
-					case 0XC3:
-					case 0XC5:
-					case 0XC6:
-					case 0XC7:
-					case 0XC9:
-					case 0XCA:
-					case 0XCB:
-					case 0XCD:
-					case 0XCE:
-					case 0XCF:
+					case 0xC0:
+					case 0xC1:
+					case 0xC2:
+					case 0xC3:
+					case 0xC5:
+					case 0xC6:
+					case 0xC7:
+					case 0xC9:
+					case 0xCA:
+					case 0xCB:
+					case 0xCD:
+					case 0xCE:
+					case 0xCF:
 						// SOF(n) marker; value indicates encoding type
 						readSOF(dbyt, info);
 						break;
 
-					case 0XC4:
+					case 0xC4:
 						// DHT -- define Huffman tables
 						skipSegment(info);
 						break;
 
-					case 0XCC:
+					case 0xCC:
 						// DAC -- define arithmetic coding conditioning
 						readDAC(info);
 						break;
 
-					case 0XD9:
+					case 0xD9:
 						// EOI
 						break loop1;
 
-					case 0XDA:
+					case 0xDA:
 						// SOS -- start of scan. This is followed by data.
 						skipSegment(info);
 						++_numScans;
 						dataPlowing = true;
 						break;
 
-					case 0XDB:
+					case 0xDB:
 						// DQT -- define quantization tables
 						readDQT(info);
 						break;
 
-					case 0XDC:
+					case 0xDC:
 						// DNL -- define number of lines
 						skipSegment(info);
 						break;
 
-					case 0XDD:
+					case 0xDD:
 						// DRI -- define restart interval
 						readDRI(info);
 						break;
 
-					case 0XDE:
+					case 0xDE:
 						// DHP -- define hierarchical progression
 						readDHP(info);
 						break;
 
-					case 0XDF:
+					case 0xDF:
 						// EXP -- Expand reference component
 						readEXP(info);
 						break;
 
-					case 0XE0:
+					case 0xE0:
 						// APP0 extension
 						readAPP0(info);
 						break;
 
-					case 0XE8:
+					case 0xE1:
+						readAPP1(info);
+						break;
+
+					case 0xE2:
+						readAPP2(info);
+						break;
+
+					case 0xE8:
 						// APP8 extension
 						readAPP8(info);
 						break;
 
-					case 0XE1:
-						readAPP1(info);
-						break;
+                    case 0xEE:
+                    	readAPP14(info);
+                    	break;
 
-					case 0XE2:
-						readAPP2(info);
-						break;
-					case 0XE3:
-					case 0XE4:
-					case 0XE5:
-					case 0XE6:
-					case 0XE7:
-					case 0XE9:
-					case 0XEA:
-					case 0XEB:
-					case 0XEC:
-					case 0XED:
-					case 0XEE:
-					case 0XEF:
+                    case 0xE3:
+					case 0xE4:
+					case 0xE5:
+					case 0xE6:
+					case 0xE7:
+					case 0xE9:
+					case 0xEA:
+					case 0xEB:
+					case 0xEC:
+					case 0xED:
+					case 0xEF:
 						// Appn extensions which we don't handle specially,
 						// but do report the existence thereof
 						reportAppExt(dbyt, info);
@@ -803,6 +832,9 @@ public class JpegModule extends ModuleBase {
 		if (_seenJPEGL) {
 			info.setProfile(jpeglProfileName);
 		}
+        if (_seenAdobe) {
+            info.setProfile(adobeProfileName);
+        }
 		/*
 		 * Create a new property list containing the count of the images and the
 		 * list of image properties.
@@ -866,7 +898,7 @@ public class JpegModule extends ModuleBase {
 	@Override
 	protected void initParse() {
 		super.initParse();
-		_imageList = new LinkedList();
+		_imageList = new LinkedList<Property>();
 		_tiling = null;
 		_restartInterval = -1;
 		_seenSOF = false;
@@ -876,6 +908,7 @@ public class JpegModule extends ModuleBase {
 		_seenJPEGL = false;
 		_spiffDir = null;
 		_seenExif = false;
+		_seenAdobe = false;
 		_reportedSigMatch = false;
 		_exifProfileOK = false;
 		_exifProfileText = null;
@@ -889,12 +922,13 @@ public class JpegModule extends ModuleBase {
 		_quantTables = new LinkedList<QuantizationTable>();
 		_arithCondTables = new LinkedList<ArithConditioning>();
 		_srsList = new LinkedList<SRS>();
-		_compressSet = new HashSet();
 		_expList = new LinkedList<boolean[]>();
 		_exifProp = null;
 		_xmpProp = null;
 		_capability0 = -1;
 		_capability1 = -1;
+		_transformFlag = -1;
+		_baosIccProfile = new ByteArrayOutputStream();
 	}
 
 	/**
@@ -1006,7 +1040,7 @@ public class JpegModule extends ModuleBase {
 				NisoImageMetadata thumbNiso = new NisoImageMetadata();
 				thumbNiso.setImageWidth(xThumbPix);
 				thumbNiso.setImageLength(yThumbPix);
-				thumbNiso.setColorSpace(2); // RGB
+				thumbNiso.setColorSpace(CS_RGB); // RGB
 				thumbNiso.setCompressionScheme(1); // uncompressed
 				thumbNiso.setPixelSize(8);
 
@@ -1018,20 +1052,20 @@ public class JpegModule extends ModuleBase {
 						thumbPropList);
 				_imageList.add(thumbProp);
 			}
-			_niso.setColorSpace(6); // JFIF header implies Yc[b]c[r]
+			_niso.setColorSpace(CS_YCC); // JFIF header usually implies YCbCr
 			skipBytes(_dstream, 3 * xThumbPix * yThumbPix, this);
 		} else if (equalArray(ident, jfxxByte)) {
 			int extCode = readUnsignedByte(_dstream, this);
 			switch (extCode) {
-			// The extension codes 0X10, 0X11, and 0X13 indicate
+			// The extension codes 0x10, 0x11, and 0x13 indicate
 			// different thumbnail formats.
 
-			// 0X10 indicates that the thumbnail is itself a JPEG
+			// 0x10 indicates that the thumbnail is itself a JPEG
 			// stream! Yech! Have to call the module recursively?
 			// Skip for now.
-			case 0X11:
+			case 0x11:
 				// thumbnail, palette color, 1 byte/pixel (fall through)
-			case 0X13:
+			case 0x13:
 				// thumbnail, RGB, 3 bytes/pixel
 				// Both of these have the same relevant information, the
 				// width and height. We just grab those and skip the rest.
@@ -1041,7 +1075,7 @@ public class JpegModule extends ModuleBase {
 				NisoImageMetadata thumbNiso = new NisoImageMetadata();
 				thumbNiso.setImageWidth(xThumbPix);
 				thumbNiso.setImageLength(yThumbPix);
-				thumbNiso.setColorSpace(extCode == 0X13 ? 2 : 3);
+				thumbNiso.setColorSpace(extCode == 0x13 ? CS_RGB : CS_PALETTE);
 				thumbNiso.setCompressionScheme(1); // uncompressed
 				thumbNiso.setPixelSize(8);
 				List<Property> thumbPropList = new LinkedList<Property>();
@@ -1069,9 +1103,9 @@ public class JpegModule extends ModuleBase {
 	 * TIFF file embedded in the segment.
 	 */
 	protected void readAPP1(RepInfo info) throws IOException {
-		final int[] exifByte = { 0X45, 0X78, 0X69, 0X66, 0X00, 0X00 };
+		final int[] exifByte = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
 		// First 6 bytes of xmpStr
-		final int[] xmpByte = { 0X68, 0X74, 0X74, 0X70, 0X3A, 0X2F };
+		final int[] xmpByte = { 0x68, 0x74, 0x74, 0x70, 0x3A, 0x2F };
 		final String xmpStr = "http://ns.adobe.com/xap/1.0/";
 		reportAppExt(0XE1, info);
 
@@ -1112,7 +1146,16 @@ public class JpegModule extends ModuleBase {
 				List<Message> list = exifInfo.getMessage();
 				int size = list.size();
 				for (int i = 0; i < size; i++) {
-					info.setMessage(list.get(i));
+					Message msg = list.get(i);
+					// Skip message JPEG deprecated in TIFF !!!
+					if (msg instanceof InfoMessage) {
+						InfoMessage imsg = (InfoMessage)msg;
+						if (!"TIFF-HUL-61".equals(imsg.getId())) {
+							info.setMessage(imsg);
+						}
+					} else {
+						info.setMessage(msg);
+					}
 				}
 
 				_exifProp = exifInfo.getProperty("Exif");
@@ -1127,7 +1170,9 @@ public class JpegModule extends ModuleBase {
 					extractExifNisoData(je.getExifNiso());
 				}
 			}
-			_exifProfileOK = je.isExifProfileOK();
+			if (_niso.getSamplesPerPixel() == 3) { // EXIF images only have 3 components
+				_exifProfileOK = je.isExifProfileOK();
+			}
 			_exifProfileText = je.getProfileText();
 		} else if (equalArray(ident, xmpByte) && length >= 32) {
 			// Check if the rest of xmpStr matches
@@ -1161,14 +1206,14 @@ public class JpegModule extends ModuleBase {
 	 * directory entry. We have already read the APP8 marker itself.
 	 */
 	protected void readAPP8(RepInfo info) throws IOException {
-		final int[] spiffByte = { 0X53, 0X50, 0X49, 0X46, 0X46, 0X00 };
+		final int[] spiffByte = { 0x53, 0x50, 0x49, 0x46, 0x46, 0x00 };
 
 		/* Seeing an APP8 segment counts as seeing a signature. */
 		if (!_reportedSigMatch) {
 			info.setSigMatch(_name);
 			_reportedSigMatch = true;
 		}
-		reportAppExt(0XE8, info);
+		reportAppExt(0xE8, info);
 
 		int length = readUnsignedShort(_dstream);
 		int[] ident = new int[6];
@@ -1264,31 +1309,25 @@ public class JpegModule extends ModuleBase {
 		int numberOfChunks = readUnsignedByte(_dstream, this);
 		int profileLength = length - SEQUENCE_LENGTH - 2 - 2;
 
-		if (numberOfChunks != 1) {
-			if (chunkNumber == 1) {
-				// report only once
-				info.setMessage(new InfoMessage(
-						MessageConstants.INF_EXIF_APP2_MULTI_REPORT, _nByte));
-			}
-			skipBytes(_dstream, profileLength, this);
-			return;
-		}
 		// Read the iccprofile data
 		byte[] iccProfile = new byte[profileLength];
 		readByteBuf(_dstream, iccProfile, this);
-		try {
-			// Validate and record the name
-			String desc = NisoImageMetadata
-					.extractIccProfileDescription(iccProfile);
-			if (desc != null) {
-				_niso.setProfileName(desc);
+		_baosIccProfile.write(iccProfile);
+		if (chunkNumber == numberOfChunks) {
+			// Last chunk for the ICC Profile
+			try {
+				// Validate and record the name
+				String desc = NisoImageMetadata.extractIccProfileDescription(
+						_baosIccProfile.toByteArray());
+				if (desc != null) {
+					_niso.setProfileName(desc);
+				}
+			} catch (IllegalArgumentException ie) {
+				info.setMessage(new ErrorMessage(
+						MessageConstants.JPEG_HUL_11, ie.getMessage(),
+						_nByte));
 			}
-		} catch (IllegalArgumentException ie) {
-			info.setMessage(new ErrorMessage(
-					MessageConstants.JPEG_HUL_11, ie.getMessage(),
-					_nByte));
 		}
-
 	}
 
 	/* Read the VER marker, and set version information accordingly */
@@ -1362,7 +1401,53 @@ public class JpegModule extends ModuleBase {
 		_srsList.add(new SRS(vertOffset, horOffset, vertSize, horSize));
 	}
 
-	/*
+    /*
+     * Reads an APP14 marker segment. This indicates a Adobe file.
+     * We have already read the APP14 marker itself.
+     */
+    protected void readAPP14(RepInfo info) throws IOException {
+        final String ADOBE_SEQUENCE = "Adobe\0";
+        final int SEQUENCE_LENGTH = 6;
+        reportAppExt(0xEE, info);
+
+        int length = readUnsignedShort(_dstream);
+        if (length < 8) {
+            // Guard against pathological short packets.
+            skipBytes(_dstream, length - 2, this);
+            return;
+        }
+
+        byte[] ident = new byte[SEQUENCE_LENGTH];
+        for (int i = 0; i < SEQUENCE_LENGTH; i++) {
+            ident[i] = (byte)readUnsignedByte(_dstream, this);
+        }
+        String sIdent = new String(ident, "US-ASCII");
+
+        int skip = length - SEQUENCE_LENGTH - 2;
+        if (!ADOBE_SEQUENCE.equalsIgnoreCase(sIdent)) {
+        	// This is not a APP14 segment containing an Adobe
+        	skipBytes(_dstream, skip, this);
+        	return;
+        }
+        // This is a Adobe marker.
+        _seenAdobe = true;
+
+        // Skip the head of the segment
+        while (skip > 1) {
+            readUnsignedByte(_dstream, this); // version (byte), flags0 (int), flags1 (int)
+            skip--;
+        }
+        _transformFlag = (byte)readUnsignedByte(_dstream, this);
+        skip--;
+        if (_transformFlag > 2) {
+            String mess = String.format(MessageConstants.JPEG_HUL_12.getMessage(), _transformFlag);
+            JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.JPEG_HUL_12.getId(), mess);
+            info.setMessage(new ErrorMessage(message, _nByte));
+            info.setValid(false);
+        }
+    }
+
+    /*
 	 * Accumulate reports of APPn segments into a property. It's tempting to
 	 * report information about the segment, since many APPn segments have ASCII
 	 * identifiers, but there's no guarantee of any content beyond the length
@@ -1372,12 +1457,12 @@ public class JpegModule extends ModuleBase {
 	 */
 	protected void reportAppExt(int dbyt, RepInfo info) {
 		String appStr = "APP";
-		if (dbyt <= 0XE9) {
+		if (dbyt <= 0xE9) {
 			// 0-9
-			appStr += (char) (dbyt - 0XE0 + 0X30);
+			appStr += (char) (dbyt - 0xE0 + 0x30);
 		} else {
 			// 10-15
-			appStr += "1" + (char) (dbyt - 0XEA + 0X30);
+			appStr += "1" + (char) (dbyt - 0xEA + 0x30);
 		}
 		_appSegsList.add(appStr);
 	}
@@ -1389,12 +1474,28 @@ public class JpegModule extends ModuleBase {
 	 * frames.
 	 */
 	protected void readSOF(int dbyt, RepInfo info) throws IOException {
-		int length = readUnsignedShort(_dstream);
-		int precision = readUnsignedByte(_dstream, this);
-		int nLines = readUnsignedShort(_dstream);
-		int samPerLine = readUnsignedShort(_dstream);
-		int numComps = readUnsignedByte(_dstream, this);
-		skipBytes(_dstream, length - 8, this);
+        final int[] UC_RGB = new int[] {82, 71, 66};
+        final int[] LC_RGB = new int[] {114, 103, 98};
+
+        int length = readUnsignedShort(_dstream);
+        int precision = readUnsignedByte(_dstream, this);
+        int nLines = readUnsignedShort(_dstream);
+        int samPerLine = readUnsignedShort(_dstream);
+        int numComps = readUnsignedByte(_dstream, this);
+        int[] componentsId = new int[numComps];
+        int skip = length - 8;
+        for (int i = 0; i < numComps; i++) {
+            componentsId[i] = readUnsignedByte(_dstream, this);
+            skip--;
+            readUnsignedByte(_dstream); // samplingFactor
+            skip--;
+            readUnsignedByte(_dstream, this); // qtableSelector
+            skip--;
+        }
+        if (skip > 0) {
+            skipBytes(_dstream, skip, this);
+        }
+		
 		if (!_seenSOF) {
 			_niso.setImageLength(nLines);
 			_niso.setImageWidth(samPerLine);
@@ -1405,8 +1506,55 @@ public class JpegModule extends ModuleBase {
 			_niso.setBitsPerSample(bps);
 			_niso.setSamplesPerPixel(numComps);
 			_propList.add(new Property("CompressionType", PropertyType.STRING,
-					JpegStrings.COMPRESSION_TYPE[dbyt - 0XC0]));
+					JpegStrings.COMPRESSION_TYPE[dbyt - 0xC0]));
 			_seenSOF = true;
+
+            // Define the colorspace
+            switch (numComps) {
+                case 1: // 1 component
+                _niso.setColorSpace(CS_GRAYSCALE); // grayscale
+                break;
+                case 3: // 3 components
+                if (_seenJFIF && _seenJFIFFirst) {
+                    _niso.setColorSpace(CS_YCC); // YCbCr
+                } else {
+                    switch (_transformFlag) {
+                        case -1:
+                        if (equalArray(componentsId, UC_RGB) || equalArray(componentsId, LC_RGB)) {
+                            _niso.setColorSpace(CS_RGB); // RGB
+                        } else {
+                            _niso.setColorSpace(CS_YCC); // YCbCr
+                        }
+                        break;
+                        case 0:
+                        _niso.setColorSpace(CS_RGB); // RGB
+                        break;
+                        case 1:
+                        default:
+                        _niso.setColorSpace(CS_YCC); // YCbCr
+                        break;
+                    }
+                }
+                break;
+                case 4: // 4 components
+                switch (_transformFlag) {
+                    case -1:
+                    case 0:
+                    _niso.setColorSpace(CS_CMYK);
+                    break;
+                    case 2:
+                    default:
+                    _niso.setColorSpace(CS_YCCK);
+                    break;
+                }
+                break;
+                default: // others ?!?
+                String mess = String.format(MessageConstants.JPEG_HUL_13.getMessage(), numComps);
+                JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.JPEG_HUL_13.getId(), mess);
+                info.setMessage(new ErrorMessage(message, _nByte));
+                info.setValid(false);
+                break;
+            }
 		}
 	}
 

--- a/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/MessageConstants.java
+++ b/jhove-modules/jpeg-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg/MessageConstants.java
@@ -56,6 +56,8 @@ public enum MessageConstants {
 	public static final JhoveMessage JPEG_HUL_9 = messageFactory.getMessage("JPEG-HUL-9");
 	public static final JhoveMessage JPEG_HUL_10 = messageFactory.getMessage("JPEG-HUL-10");
 	public static final JhoveMessage JPEG_HUL_11 = messageFactory.getMessage("JPEG-HUL-11");
+	public static final JhoveMessage JPEG_HUL_12 = messageFactory.getMessage("JPEG-HUL-12");
+	public static final JhoveMessage JPEG_HUL_13 = messageFactory.getMessage("JPEG-HUL-13");
 
 	public static final JhoveMessage JHOVE_1 = messageFactory.getMessage("JHOVE-1");
 }

--- a/jhove-modules/jpeg-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/jpeg/ErrorMessages.properties
+++ b/jhove-modules/jpeg-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/jpeg/ErrorMessages.properties
@@ -10,5 +10,7 @@ JPEG-HUL-8 = SPIFF marker not at beginning of file
 JPEG-HUL-9 = File does not begin with SPIFF, Exif or JFIF segment
 JPEG-HUL-10 = Unrecognized tiling data
 JPEG-HUL-11 = "Invalid ICCProfile in APP2 segment; message 
+JPEG-HUL-12=Adobe marker segment, bad transformFlag value %d
+JPEG-HUL-13=Unknown colorspace with number of components of %d
 
 JHOVE-1 = Error creating temporary file. Check your configuration: 


### PR DESCRIPTION
Calculate the appropriate colorspace depending on the number of components and the segments
Add the "Adobe JPEG" profile and the information on the corresponding ISO/IEC 10918-6:2013
Suppress the warning message about deprecated JPEG compression scheme coming from the TIFF module
Add more control on the validity of the format :
- 3 components only for EXIF
- 1, 3 or 4 components for other profiles
Add a YCCK colorspace value to the niso property
The JPEG module goes to version 1.5.2
Fixes #297

FIX - Tests
- copied the `AIFF-hul` and `JPEG-hul` example results for new AES metadata;
- threaded use of utility classes through fix; and
- fixed installer version number issue.

Includes #518 submitted by @tledoux 