### PR TITLE
WAVE: Fix variable formatting in message translations

### DIFF
--- a/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/iff/ErrorMessages_de.properties
+++ b/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/iff/ErrorMessages_de.properties
@@ -1,2 +1,2 @@
 IFF-HUL-1 = Ungültiges Zeichen in Block ID
-IFF-HUL-1-SUB = Zeichen = 0x
+IFF-HUL-1-SUB = Zeichen = 0x%02X

--- a/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/iff/ErrorMessages_pt_BR.properties
+++ b/jhove-modules/aiff-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/iff/ErrorMessages_pt_BR.properties
@@ -1,2 +1,2 @@
 IFF-HUL-1 = Caractere inválido no trecho ID
-IFF-HUL-1-SUB = Caractere = 0x
+IFF-HUL-1-SUB = Caractere = 0x%02X

--- a/jhove-modules/wave-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/wave/ErrorMessages_pt_BR.properties
+++ b/jhove-modules/wave-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/wave/ErrorMessages_pt_BR.properties
@@ -1,27 +1,30 @@
 WAVE-HUL-1 = Arquivo não começa com cabeçalho RIFF
 WAVE-HUL-2 = Tipo de forma no cabeçalho RIFF não é WAVE
 WAVE-HUL-3 = Inesperado fim de arquivo
-WAVE-HUL-4 = Exceção lendo arquivo: S5
+WAVE-HUL-3-SUB = Bytes faltando = %s
+WAVE-HUL-3-SUB-2 = Trecho truncado = "%s"
+WAVE-HUL-4 = Exceção lendo arquivo: %s
 WAVE-HUL-5 = Nenhum trecho Format encontrado
 WAVE-HUL-6 = Trecho com comprimento inválido
-WAVE-HUL-7 = Trecho não reconhecido ignorado: %s
-WAVE-HUL-8 = Trechos duplicados para o tipo: %s
+WAVE-HUL-7 = Trecho não reconhecido ignorado: "%s"
+WAVE-HUL-8 = Trechos duplicados para o tipo: "%s"
 WAVE-HUL-9 = Tipo de lista desconhecido no trecho Associated Data List
-WAVE-HUL-10 = Ignorado trecho Associated Data do tipo: %s
+WAVE-HUL-9-SUB = Tipo = "%s"
+WAVE-HUL-10 = Ignorado trecho Associated Data do tipo: "%s"
 WAVE-HUL-11 = O trecho Exif User Comment é muito curto
 WAVE-HUL-12 = Comprimento incorreto para trecho Exif Version
 WAVE-HUL-13 = SAXException ao ler trecho Link
 WAVE-HUL-14 = ParserConfigurationException ao ler trecho Link
-WAVE-HUL-15 = Trecho List contém tipo desconhecido: %s
-WAVE-HUL-16 = Ignorado trecho Info List do tipo: %s
-WAVE-HUL-17 = Ignorado trecho Associated Data do tipo: %s
-WAVE-HUL-18 = Ignorado trecho Associated Data do tipo: %s
-WAVE-HUL-19 = Ignorado trecho Info List do tipo: %s
+WAVE-HUL-15 = Trecho List contém tipo desconhecido: "%s"
+WAVE-HUL-17 = Ignorado trecho Exif List do tipo: "%s"
+WAVE-HUL-18 = Ignorado trecho Associated Data do tipo: "%s"
+WAVE-HUL-19 = Ignorado trecho Info List do tipo: "%s"
 WAVE-HUL-20 = Valor inválido para formato em trecho Peak Envelope
 WAVE-HUL-21 = Valor inválido para pointsPerValue em trecho Peak Envelope
 WAVE-HUL-22 = Arquivo muito grande para ser validado
 WAVE-HUL-23 = O trecho Data Size 64 não está no local requerido
 WAVE-HUL-24 = Nenhum trecho Data encontrado
 WAVE-HUL-25 = Trecho Data aparece antes do trecho Format
-WAVE-HUL-26 = Ignorados dados não reconhecidos no trecho: %s
+WAVE-HUL-26 = Ignorados dados não reconhecidos no trecho
+WAVE-HUL-26-SUB = Trecho = "%s"; Bytes = %s; Nulo = %s
 WAVE-HUL-27 = Versão BWF não reconhecida: %s


### PR DESCRIPTION
Also added translations for the recently created submessage strings into the older Brazilian translation.