### PR TITLE
GUI: Always show a Message's child properties (e.g. IDs)

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -366,8 +366,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 				if (offset >= 0) {
 					mNode.add(new DefaultMutableTreeNode("Offset: "
 							+ Long.toString(offset)));
-				} else if (subMessage == null) {
-					mNode.setAllowsChildren(false);
 				}
 				msgNode.add(mNode);
 			}


### PR DESCRIPTION
Message IDs were being hidden from the GUI for informational and error messages lacking submessages or offsets. (As seen during the JHOVE webinar in December.)