### PR TITLE
FIX - JHOVE GUI property display issues

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -6,6 +6,7 @@
 package edu.harvard.hul.ois.jhove.viewer;
 
 import java.text.DateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -438,11 +439,25 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 		if (null != typ)
 			switch (typ) {
 			case INTEGER: {
-				addToNode(node, (Integer[]) pVal);
+				if (pVal instanceof int[]) {
+					Integer[] vals = Arrays.stream((int[])pVal) // IntStream
+							.boxed()				// Stream<Integer>
+							.toArray(Integer[]::new);
+					addToNode(node, vals);
+				} else {
+					addToNode(node, (Integer[]) pVal);
+				}
 				break;
 			}
 			case LONG: {
-				addToNode(node, (Long[]) pVal);
+				if (pVal instanceof long[]) {
+					Long[] vals = Arrays.stream((long[])pVal) // IntStream
+							.boxed()				// Stream<Integer>
+							.toArray(Long[]::new);
+					addToNode(node, vals);
+				} else {
+					addToNode(node, (Long[]) pVal);
+				}
 				break;
 			}
 			case BOOLEAN: {
@@ -1475,7 +1490,11 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 	 */
 	private <E> void addToNode(DefaultMutableTreeNode node, E[] array) {
 		for (E element : array) {
-			node.add(new DefaultMutableTreeNode(element));
+			if (element instanceof Property) {
+				node.add(propToNode((Property) element));
+			} else {
+				node.add(new DefaultMutableTreeNode(element));
+			}
 		}
 	}
 }


### PR DESCRIPTION
- added fix to `RepTreeRoot.addToNode()` that ensures `Property` elements are rendered correctly; and
- hack patch for `addArrayMembers()` to ensure that primitive `int[]`s and `long[]`s are converted to `Integer[]`s and `Long[]`s respectively.

Fixes #558 and #559