### PR TITLE
Fix for #531

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -3002,8 +3002,15 @@ public class PdfModule extends ModuleBase {
 
 		try {
 			// Rotation property is inheritable
-			PdfSimpleObject rot = (PdfSimpleObject) page.get(DICT_KEY_ROTATE,
-					true);
+			PdfObject tempObj = page.get(DICT_KEY_ROTATE,
+							true);
+			PdfSimpleObject rot = null;
+			if (tempObj != null && tempObj instanceof PdfSimpleObject) {
+				rot = (PdfSimpleObject) tempObj;
+			} else if (tempObj != null && tempObj instanceof PdfIndirectObj) {
+				rot = (PdfSimpleObject) ((PdfIndirectObj) tempObj)
+						.getObject();
+			}
 			if (rot != null && rot.getIntValue() != 0) {
 				pagePropList.add(new Property(PROP_NAME_ROTATE,
 						PropertyType.INTEGER, new Integer(rot.getIntValue())));


### PR DESCRIPTION
Hi @carlwilson 

This pull request fixes #531 : because the Size keyword didn't exist the trailer wasn't parsed completly and some variable where null. So I did some changes so the variables are not null, because these lines are never reached
_xref: https://github.com/openpreserve/jhove/blob/de1f5fd8427a0e8365b44ec095e34bf4d2cde8ad/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java#L1325
_docCatDictRef: https://github.com/openpreserve/jhove/blob/de1f5fd8427a0e8365b44ec095e34bf4d2cde8ad/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java#L1339

I don't know my java code is up to your standards. Just give feedback so I can fix it.
I also left some debug code that's why there are 3 commits instead of one. sorry for the mess.

Sam