### PR TITLE
Fixes #375: Handle class cast from indirect object to simple object

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -2302,8 +2302,8 @@ public class PdfModule extends ModuleBase {
 											if (parms != null) {
 												PdfSimpleObject kobj = null;
 												if (parms instanceof PdfDictionary) {
-													kobj = (PdfSimpleObject) ((PdfDictionary) parms)
-															.get(DICT_KEY_K);
+													PdfDictionary pdict = (PdfDictionary) parms;
+													kobj = (PdfSimpleObject) resolveIndirectObject(pdict.get(DICT_KEY_K));
 												}
 												/*
 												 * Note that the DecodeParms


### PR DESCRIPTION
This fix for issue #375 repairs a ClassCastException relating to casting from an indirect object to a simple object. This seems to be a common conversion throughout the PdfModule that has been handled using the `resolveIndirectObject` method. This fix simply passes the object causing the problem into that method. I didn't write a test since this seems to be a repeated feature of the code, and the test would involve getting permission to use the file supplied with the issue. Please let me know if I should write it anyway.

It looks like PR #596 may be responding to a similar issue. 