### PR TITLE
WIP: Add manpage

### DIFF
--- a/man/jhove.1
+++ b/man/jhove.1
@@ -1,0 +1,44 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH JHOVE 1 "August 28, 2007"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+JHOVE \- identify, validate, and characterize digital objects.
+.SH SYNOPSIS
+.B jhove
+.RI [ options ] " files" ...
+.br
+.B jhoveview
+.SH DESCRIPTION
+This manual page documents briefly the
+.B jhove
+and
+.B jhoveview
+commands.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+\fBjhoveview\fP has a graphical user interface and no significant command line options.
+\fBjhove\fP has a command line interface, see full documentation in
+online at http://hul.harvard.edu/jhove/using.html#invocation.
+
+.SH AUTHOR
+JHOVE is copyright JSTOR and the President and Fellows of Harvard College, and
+the authors are not listed in the program source code.
+.PP
+This manual page was written by Jeff Breidenbach <jab@debian.org>,
+for the Debian project (but may be used by others).


### PR DESCRIPTION
Andrea and I caught up today, couple of things we need to do to bring a Manpage into JHove. 

* [x] Bring the Debian [manpage](https://manpages.ubuntu.com/manpages/xenial/man1/jhove.1.html) into the source code to build off. And ensure that the original author is credited, and that there is a trail in the code. Additional ref: [here](https://qa.debian.org/developer.php?login=jab@debian.org). The page written around the time of JHove 1.6. 
* [ ] Create the documentation itself.
* [ ] Fixup documentation with [markup](https://www.linuxjournal.com/article/1158), or transform with [Pandoc](https://eddieantonio.ca/blog/2015/12/18/authoring-manpages-in-markdown-with-pandoc/).
* [ ] Update the migration scripts to install somewhere like `/usr/share/man/man1/`. 

We're planning on starting in [HackMD](https://hackmd.io/IlVo_W9VTcK3aH_iQSPjIw?both), and share from there. Folks can feel free to sign-up and request access to help. 

```
A manpage exists for JHOVE but never made it back to to the JHOVE
code base. This commit brings that work into the mainline branch.

Co-authored-by: Jeff Breidenbach <jab@debian.org>
Co-authored-by: andreakb <andreakathleenbyrne@gmail.com>
```
