### PR TITLE
missing Encryption Algorithm

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
@@ -18,7 +18,8 @@ public class PdfStrings
         "40-bit RC4 or AES",
         "40-bit or greater RC4 or AES",
         "Unpublished",
-        "Document-defined"
+        "Document-defined",
+        "256-bit AES"
     };
 
     /** Flags for FontDescriptor.  In PDF notation, bit 1


### PR DESCRIPTION
Hi @carlwilson 
According to https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/adobe_supplement_iso32000.pdf is AESv3 a new Encryption Algorithm. It is added as an extension from Extension level 3 onward.
An example file is: https://github.com/qpdf/qpdf/blob/master/qpdf/qtest/qpdf/copied-positive-P.pdf

Now PDF-HUL-93 is the error, but with this patch this problem is solved.