### PR TITLE
 New error message to clarify exception in cross-reference

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1556,8 +1556,10 @@ public class PdfModule extends ModuleBase {
 			return false;
 		} catch (Exception e) {
 			info.setValid(false);
+			String mess = MessageFormat.format(MessageConstants.PDF_HUL_151.getMessage(), e.getMessage());
+			JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.PDF_HUL_151.getId(), mess);
 			info.setMessage(
-					new ErrorMessage(e.getMessage(), _parser.getOffset()));
+					new ErrorMessage(message, _parser.getOffset())); //PDF-HUL-151
 		}
 		return true;
 	}

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -188,6 +188,7 @@ public enum MessageConstants {
 	public static final JhoveMessage PDF_HUL_148 = messageFactory.getMessage("PDF-HUL-148");
 	public static final JhoveMessage PDF_HUL_149 = messageFactory.getMessage("PDF-HUL-149");
 	public static final JhoveMessage PDF_HUL_150 = messageFactory.getMessage("PDF-HUL-150");
+	public static final JhoveMessage PDF_HUL_151 = messageFactory.getMessage("PDF-HUL-151");
 
 	/**
 	 * Logger Messages

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -153,3 +153,4 @@ PDF-HUL-147 = Page tree node not found.
 PDF-HUL-148 = PDF minor version number is greater than 7.
 PDF-HUL-149 = Invalid indirect destination - referenced object ''{0}'' cannot be found
 PDF-HUL-150 = Cross-reference stream must be a stream
+PDF-HUL-151 = An error occurred reading the cross-reference

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -153,4 +153,4 @@ PDF-HUL-147 = Page tree node not found.
 PDF-HUL-148 = PDF minor version number is greater than 7.
 PDF-HUL-149 = Invalid indirect destination - referenced object ''{0}'' cannot be found
 PDF-HUL-150 = Cross-reference stream must be a stream
-PDF-HUL-151 = An error occurred reading the cross-reference
+PDF-HUL-151 = Unexpected error occurred while attempting to read the cross-reference table


### PR DESCRIPTION
When processing https://github.com/mozilla/pdf.js/blob/master/test/pdfs/issue6652.pdf the error is 6. This change will make it clear that there is a problem with the cross-reference table