### PR TITLE
Extension level support added

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -208,6 +208,12 @@ public class PdfModule extends ModuleBase {
 	private static final String DICT_KEY_PAGE_LABELS = "PageLabels";
 	private static final String DICT_KEY_TYPE = "Type";
 	private static final String DICT_KEY_VERSION = "Version";
+	private static final String DICT_KEY_EXTENSIONS = "Extensions";
+	private static final String DICT_KEY_EXTENSIONLEVEL = "ExtensionLevel";
+	private static final String DICT_KEY_BASEVERSION = "BaseVersion";
+	private static final String PROP_NAME_BASEVERSION = DICT_KEY_BASEVERSION;
+	private static final String PROP_NAME_EXTENSIONLEVEL = DICT_KEY_EXTENSIONLEVEL;
+	private static final String PROP_NAME_DEVELOPERPREFIX = "DeveloperPrefix";
 	private static final String DICT_KEY_NAME = "Name";
 	private static final String DICT_KEY_NAMES = DICT_KEY_NAME + "s";
 	private static final String DICT_KEY_EMBEDDED_FILES = "EmbeddedFiles";
@@ -1727,7 +1733,7 @@ public class PdfModule extends ModuleBase {
 									// There is an unknown developer prefix
 									info.setWellFormed(false);
 									info.setMessage(new ErrorMessage(MessageConstants.PDF_HUL_154, 
-											developerPrefixKey.toString())); // PDF-HUL-152
+											developerPrefixKey.toString())); // PDF-HUL-154
 								}
 							}
 						}

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1682,6 +1682,57 @@ public class PdfModule extends ModuleBase {
 					throw new PdfInvalidException(MessageConstants.PDF_HUL_88); // PDF-HUL-88
 				}
 			}
+			
+			// If extensions are defined get the extensionlevel information and the baseVersion from the extensions
+			PdfObject extensions = _docCatDict.get(DICT_KEY_EXTENSIONS);
+			if (extensions != null) {
+				if (extensions instanceof PdfDictionary) {
+					Iterator<PdfObject> extensionsIter = ((PdfDictionary) extensions).iterator();
+					while (extensionsIter.hasNext()) {
+							PdfDictionary  extension = (PdfDictionary) extensionsIter.next(); 
+							 Set<String> developerPrefixKeys = ((PdfDictionary) extensions).getKeys();
+							 for (String developerPrefixKey : developerPrefixKeys) {
+								 if (PdfStrings.PREFIXNAMESREGISTY.contains(developerPrefixKey.toString())) {
+									 p = new Property(PROP_NAME_DEVELOPERPREFIX, PropertyType.STRING, 
+											 developerPrefixKey.toString());
+									 _docCatalogList.add(p);
+									 PdfSimpleObject BaseVersion = (PdfSimpleObject) 
+												extension.get(DICT_KEY_BASEVERSION);
+										String infoVersString = _version;
+										String versString = BaseVersion.getStringValue();
+										double ver = Double.parseDouble(versString);
+										double infoVer = Double.parseDouble(infoVersString);
+										try {
+											if (infoVer != ver) {
+												String mess = MessageFormat.format(
+														MessageConstants.PDF_HUL_87.getMessage(),
+														infoVersString, ver);
+												JhoveMessage message = JhoveMessages.getMessageInstance(
+														MessageConstants.PDF_HUL_87.getId(), mess);
+												info.setMessage(new InfoMessage(message));
+											} else {
+												p = new Property(PROP_NAME_BASEVERSION, PropertyType.STRING, ver);
+												_docCatalogList.add(p);
+											}
+										} catch (NumberFormatException e) {
+											throw new PdfInvalidException(MessageConstants.PDF_HUL_88); // PDF-HUL-88
+										}
+										PdfSimpleObject extensionLevel = (PdfSimpleObject) extension.get(DICT_KEY_EXTENSIONLEVEL);
+										if (extensionLevel != null) {
+											p = new Property(PROP_NAME_EXTENSIONLEVEL, PropertyType.INTEGER,
+													extensionLevel.getIntValue());
+											_docCatalogList.add(p);
+										}
+								} else {
+									// There is an unknown developer prefix
+									info.setWellFormed(false);
+									info.setMessage(new ErrorMessage(MessageConstants.PDF_HUL_154, 
+											developerPrefixKey.toString())); // PDF-HUL-152
+								}
+							}
+						}
+					}
+				}
 
 			// Get the Names dictionary in order to grab the
 			// EmbeddedFiles and Dests entries.

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -188,6 +188,10 @@ public enum MessageConstants {
 	public static final JhoveMessage PDF_HUL_148 = messageFactory.getMessage("PDF-HUL-148");
 	public static final JhoveMessage PDF_HUL_149 = messageFactory.getMessage("PDF-HUL-149");
 	public static final JhoveMessage PDF_HUL_150 = messageFactory.getMessage("PDF-HUL-150");
+	public static final JhoveMessage PDF_HUL_151 = messageFactory.getMessage("PDF-HUL-151");
+	public static final JhoveMessage PDF_HUL_152 = messageFactory.getMessage("PDF-HUL-152");
+	public static final JhoveMessage PDF_HUL_153 = messageFactory.getMessage("PDF-HUL-153");
+	public static final JhoveMessage PDF_HUL_154 = messageFactory.getMessage("PDF-HUL-154");
 
 	/**
 	 * Logger Messages

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfDictionary.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfDictionary.java
@@ -61,6 +61,12 @@ public class PdfDictionary extends PdfObject
     {
         return _entries.size() <= PDFA_IMPLEMENTATION_LIMIT;
     }
+    
+    /** Returns a KeySet with all keys of a dictionary **/
+    public Set<String> getKeys()
+    {
+        return _entries.keySet();
+    }
 
     /**
      *  Returns an iterator which will successively return

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
@@ -5,6 +5,9 @@
 
 package edu.harvard.hul.ois.jhove.module.pdf;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *  A class for holding arrays of informative strings that will go into 
  *  properties of a PDF object. 

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfStrings.java
@@ -93,6 +93,66 @@ public class PdfStrings
         "ReadOnly"        // 7
     };
 
+    /** PDF Prefix names registry
+     *  * This is a list with Prefixes of the PDF Prefix Names register. It is used as a dictionary for the developer
+     *  prefix of developer extensions.
+     *  Described in 3.6.4 Extensions to PDF: 
+     *  https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/adobe_supplement_iso32000.pdf
+     *  Maintained in: https://github.com/adobe/pdf-names-list
+     * . */
+    public final static List<String> PREFIXNAMESREGISTY = new ArrayList<String>() {{
+		add("ADBE"); // Adobe
+    	add("ITXT"); // 1T3XT BVBA
+    	add("CIP4"); // International Cooperation for the Integration of Process in Prepress, Press and Postpress Association
+    	add("FOPN"); // FileOpen Systems Inc.
+    	add("SNLF"); // SNL Financial, LC
+    	add("K3SD"); // Kanrikogaku Kenkyusho, Ltd.,  Meguro Office
+    	add("CRDF"); // Autonomy Cardiff
+    	add("PDTH"); // PDF Thingys
+    	add("GURG"); // Gurnet Group LLC
+    	add("USCT"); // Administrative Office of the U.S. Courts
+    	add("MTSJ"); // Mekentosj BV
+    	add("AJIc"); // Aji, LLC
+    	add("GFSw"); // Goofyfootsoftware
+    	add("LTUd"); // Office of the Chief Archivist of Lithuania
+    	add("MSFT"); // Microsoft Corporation
+    	add("wgss"); // Wacom Co, Ltd
+    	add("bPRO"); // BiPRO e.V.
+    	add("HEBD"); // H-E-B Grocery
+    	add("iPDF"); // InteractivePDF.org
+    	add("CALS"); // Callas Software gmbh
+    	add("OOPS"); // JNJ
+    	add("KWSQ"); // Kawseq Consulting Pty Ltd
+    	add("PIER"); // Pierre Choutet
+    	add("SCIN"); // Scinaptic Communications
+    	add("VSMA"); // Visma Software International AS
+    	add("MSMO"); // Mortgage Industry Standards Maintenance Organization
+    	add("DUFF"); // Adlib Publishing Systems
+    	add("ADLB"); // ALSTOM (Switzerland) Ltd
+    	add("FNBC"); // Andrea Vacandio, Sejda.org
+    	add("sjda"); // ZETO Sp. z o.o. w Lublinie
+    	add("ZETO"); // Setasign
+    	add("SETA"); // SOFHA Gmbh
+    	add("SOFH"); // AcroScript
+    	add("ASGJ"); // UAB "Superita"
+    	add("WRPC"); // Instituto Nacional de Tecnologia da Informação
+    	add("PBAD"); // China Finacial Certification Authority Co.Ltd
+    	add("cfca"); // China Finacial Certification Authority Co.Ltd
+    	add("CFCA"); // Timeslice Ltd
+    	add("TMSL"); // Wacom Co, Ltd
+    	add("WGSS"); // Reindl-IT
+    	add("SRIT"); // Global Graphics
+    	add("GGSL"); // Evansco, LLC
+    	add("EVSC"); // PDFlib GmbH
+    	add("Plib"); // Walters Kluwer TeamMate
+    	add("WKTM"); // Normex s.r.o.
+    	add("NORM"); // PDF Association
+    	add("pdfa"); // Michael Klink
+    	add("MKLx"); // ISO (via the 3D PDF Consortium)
+    	add("ISO_"); // ISO TC130/WG2 as described in ISO 21812
+    	add("GTSm"); // 1T3XT BVBA
+    }};
+    
     /** A private constructor just to make sure nobody
        instantiates the class by mistake. */
     private PdfStrings ()

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -153,3 +153,7 @@ PDF-HUL-147 = Page tree node not found.
 PDF-HUL-148 = PDF minor version number is greater than 7.
 PDF-HUL-149 = Invalid indirect destination - referenced object ''{0}'' cannot be found
 PDF-HUL-150 = Cross-reference stream must be a stream
+PDF-HUL-151 = Unexpected error occurred while attempting to read the cross-reference table
+PDF-HUL-152 = Encrypt dictionary has no OE key or it has a null value
+PDF-HUL-153 = Encrypt dictionary has no UE key or it has a null value
+PDF-HUL-154 = Unknown Developer Prefix:


### PR DESCRIPTION
Hi @carlwilson 

As discussed I created code for parsing the Extension Level information in a PDF. According to https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/adobe_supplement_iso32000.pdf a pdf can have Extensions. This code prints out which extension level a PDF supports and also the vendor of the extension.
Also check if the information appears in the right location of the output. I think the code is in a good spot, but I'm not sure if the output is. I didn't change anything in the output, this is the default location.

Sam