### PR TITLE
XML documentation review fixes

### DIFF
--- a/css/jhove.css
+++ b/css/jhove.css
@@ -17,3 +17,11 @@ body {
 header a.btn {
   margin-top: 20px;
 }
+
+dt {
+  margin-bottom: 10px;
+}
+
+dd {
+  margin-left: 10px;
+}

--- a/modules/xml/index.html
+++ b/modules/xml/index.html
@@ -25,10 +25,12 @@ title: XML-hul Module
   <code>jhove ... -m XML-hul [-x <var>sax-class</var>] ...</code>
 </blockquote>
 
+<h3>XML Parser Options</h3>
+
 <p>
   The XML-hul module can use any XML parser that conforms to the
   <a href="http://www.saxproject.org">SAX2</a> interfaces.
-  Note that if the SAX2 optional LexicalHandler interface isn't
+  Note that if the optional SAX2 LexicalHandler interface isn't
   supported by the parser, JHOVE will only be able to report a
   restricted set of representation information.
 </p>
@@ -45,55 +47,54 @@ title: XML-hul Module
   </li>
   <li>
     The value of the <code>edu.harvard.hul.ois.jhove.saxClass</code>
-    property in the properties file
-    <code>${<var>user.home</var>}/jhove/jhove.properties</code>
-    properties file, where <code>${<var>user.home</var>}</code>
-    is the standard Java <var>user.home</var> property; or
+    property in the <code>${<var>user.home</var>}/jhove/jhove.properties</code>
+    Java properties file, where <code>${<var>user.home</var>}</code>
+    is the standard Java <code>user.home</code> property; or
   </li>
   <li>
-    The default parser of the <a href="http://java.sun.com/j2se/">J2SE</a>
-    1.4 Java Runtime Environment (JRE).
+    The default parser of your Java Runtime Environment (JRE).
   </li>
 </ol>
 
 <p>
-  For example, if you are using Xerces, you will have to specify the
-  parser class as <code>org.apache.xerces.parsers.SAXParser</code>.
+  For example, if you would like to use the latest
+  <a href="http://xerces.apache.org/">Apache Xerces</a>,
+  you would need to specify <var>sax-class</var> as
+  <code>org.apache.xerces.parsers.SAXParser</code>.
 </p>
 
-<p>
-  Note that testing indicates that the default
-  <a href="http://xml.apache.org/crimson/">Crimson</a> parser included
-  in <a href="http://www.sun.com/">Sun's</a>
-  <a href="http://java.sun.com/j2se/">J2SE</a>
-  <a href="http://java.sun.com/j2se/desktopjava/jre/">JRE</a>
-  does not support validation by <a href="http://www.w3.org/">XML</a>
-  <a href="http://www.w3.org/XML/Schema">Schema</a>.
-  The <a href="http://www.apache.org/">Apache</a>
-  <a href="http://xml.apache.org/xerces2-j/">Xerces</a> parser does
-  validate against Schemas;
-  other commercial and open source parsers may also validate against
-  Schemas. (JSTOR and the Harvard University Library do not endorse or
-  recommend the use of any particular XML parser; the previous
-  discussion is provided solely for information purposes.)
-</p>
+<h3>Module Configuration Options</h3>
 
 <p>
   This module can be <a href="/getting-started/config/">configured</a>
   with the following parameters:
 </p>
 
-<ul>
-  <li>
-    <code>schema=[namespace];[schemaLocation]...</code> in order to
-    provide local schemas during the parsing of the file.
-  </li>
-  <li>
-    <code>withTextMD=true</code> to ask for the output of a
-    <a href="/references#textmd">textMD</a> block in the text technical
-     properties.
-  </li>
-</ul>
+<dl>
+  <dt>schema=<var>schema-URL</var>;<var>local-schema-path</var></dt>
+  <dd>
+    <p>
+      Specifies the local schema file to use for validation in place
+      of any occurrences of the external schema in an XML document.
+      Using a local file is typically faster and more reliable than
+      retrieving files over a network such as the internet, and is
+      recommended when processing large volumes of XML. This parameter
+      can be declared as many times as necessary.
+    </p>
+    <p>
+      Example:
+      <code>schema=http://example.com/schema.xsd;C:\schemas\example.com\schema.xsd</code>
+    </p>
+  </dd>
+
+  <dt>withtextmd=<var>true</var></dt>
+  <dd>
+    <p>
+      Indicates that <a href="/references#textmd">textMD</a> metadata
+      should be included as part of a document's representation information.
+    </p>
+  </dd>
+</dl>
 
 <h2 id="coverage">2 Coverage</h2>
 
@@ -123,15 +124,15 @@ title: XML-hul Module
 <p>
   Note that the concept of validity applies only to XML files that
   explicitly reference a DTD or XML Schema. JHOVE can determine if
-  either of these conditions are met and if so, it will invoke
-  automatically the SAX2 parser in a validating mode. Otherwise, the
+  either of these conditions are met and if so, it will automatically
+  invoke the SAX2 parser in a validating mode. Otherwise, the
   parser is invoked in a manner that only checks for well-formedness.
 </p>
 
 <h2 id="repinfo">5 Representation Information</h2>
 
 <p>
-  The MIME type is reported as: application/xml
+  The MIME type is reported as: text/xml
 </p>
 
 <p>

--- a/modules/xml/index.html
+++ b/modules/xml/index.html
@@ -5,213 +5,234 @@ title: XML-hul Module
 <html lang="en">
 {% include header.html %}
 <body role="document">
-
 {% include navbar.html nav=site.data.navbar %}
 <div class="container" role="main">
+
 <h1>XML-hul Module</h1>
 
-<a class="name" name="introduction">
-<h2>1 Introduction</h2>
-</a>
+<h2 id="introduction">1 Introduction</h2>
 
 <p>
-The XML-hul module recognizes and validates the XML (Extensible Markup
-Language) format.
-[<a href="/references#xml">XML</a>].
-</p><p>
-The module is invoked by the:
+  The XML-hul module recognizes and validates the XML (Extensible Markup
+  Language) format [<a href="/references#xml">XML</a>].
 </p>
-<blockquote>
-<pre>
-jhove ... -m XML-hul [-x <em>sax-class</em>] ...
-</pre>
-</blockquote>
-command line option.
 
 <p>
-The XML-hul module can use any XML parser that conforms to the
-<a href="http://www.saxproject.org">SAX2</a> interfaces.
-Note that if the SAX2 optional LexicalHandler interface isn't supported by the
-parser, JHOVE will only be able to report a restricted set of
-representation information.
-</p><p>
-The actual parser used is either:
-</p><ol>
-<li> The parser specified by the <tt>-x <em>sax-class</em></tt> command line
-option (whose class file <em>must</em> be found on the CLASSPATH at the
-time of execution);
-<li> The value of the <tt>edu.harvard.hul.ois.jhove.saxClass</tt> property
-in the properties file
-<tt>${<em>user.home</em>}/jhove/jhove.properties</tt> properties file,
-where <tt>${<em>user.home</em>}</tt>
-is the standard Java <tt>user.home</tt> property; or
-<li> The default parser of the
-<a href="http://java.sun.com/j2se/">J2SE</a> 1.4
-Java Runtime Environment (JRE).
+  The module can be invoked with the following command-line options:
+</p>
+
+<blockquote>
+  <code>jhove ... -m XML-hul [-x <var>sax-class</var>] ...</code>
+</blockquote>
+
+<p>
+  The XML-hul module can use any XML parser that conforms to the
+  <a href="http://www.saxproject.org">SAX2</a> interfaces.
+  Note that if the SAX2 optional LexicalHandler interface isn't
+  supported by the parser, JHOVE will only be able to report a
+  restricted set of representation information.
+</p>
+
+<p>
+  The actual parser used is either:
+</p>
+
+<ol>
+  <li>
+    The parser specified by the <code>-x <var>sax-class</var></code>
+    command-line option (whose class file <em>must</em> be found on the
+    CLASSPATH at the time of execution);
+  </li>
+  <li>
+    The value of the <code>edu.harvard.hul.ois.jhove.saxClass</code>
+    property in the properties file
+    <code>${<var>user.home</var>}/jhove/jhove.properties</code>
+    properties file, where <code>${<var>user.home</var>}</code>
+    is the standard Java <var>user.home</var> property; or
+  </li>
+  <li>
+    The default parser of the <a href="http://java.sun.com/j2se/">J2SE</a>
+    1.4 Java Runtime Environment (JRE).
+  </li>
 </ol>
 
 <p>
-For example, if you are using Xerces, you will have to specify the parser class as
-<code>org.apache.xerces.parsers.SAXParser</code>.
-<p>
-Note that testing indicates that the default
-<a href="http://xml.apache.org/crimson/">Crimson</a> parser included in
-<a href="http://www.sun.com/">Sun's</a>
-<a href="http://java.sun.com/j2se/">J2SE</a>
-<a href="http://java.sun.com/j2se/desktopjava/jre/">JRE</a>
-does not support validation by <a href="http://www.w3.org/">XML</a>
-<a href="http://www.w3.org/XML/Schema">Schema</a>.
-The <a href="http://www.apache.org/">Apache</a>
-<a href="http://xml.apache.org/xerces2-j/">Xerces</a> parser does validate
-against Schemas;
-other commercial and open source parsers may also validate against Schemas.
-(JSTOR and the Harvard University Library do not endorse or recommend
-the use of any particular XML parser; the previous discussion is provided
-solely for information purposes.)
+  For example, if you are using Xerces, you will have to specify the
+  parser class as <code>org.apache.xerces.parsers.SAXParser</code>.
 </p>
 
 <p>
-This module can be <a href="/getting-started/config/">configured</a> with the following parameters:
-</p>
-<ul>
-<li><tt>withTextMD=true</tt> to ask for the output of a <a href="/references#textmd">textMD</a> block in the text technical properties.</li>
-<li><tt>schema=[namespace];[schemaLocation]...</tt> in order to provide local schemas during the parsing of the file</li>
-</ul>
-
-
-<a class="name" name="coverage">
-<h2>2 Coverage</h2></a>
-
-<p>
-The XML-hul module recognizes and validates the following public profiles:
-</p>
-<ul>
-<li> XML 1.0 [<a href="/references#xml">XML</a>]
-</ul>
-
-<a class="name" name="well-formedness">
-<h2>3 Well-Formedness</h2></a>
-
-<p>
-JHOVE uses the criteria for XML well-formedness defined by
-[<a href="/references#xml">XML</a>].
-</p>
-
-<a class="name" name="validity">
-<h2>4 Validity</h2></a>
-
-<p>
-JHOVE uses the criteria for XML validity defined by
-[<a href="/references#xml">XML</a>].
+  Note that testing indicates that the default
+  <a href="http://xml.apache.org/crimson/">Crimson</a> parser included
+  in <a href="http://www.sun.com/">Sun's</a>
+  <a href="http://java.sun.com/j2se/">J2SE</a>
+  <a href="http://java.sun.com/j2se/desktopjava/jre/">JRE</a>
+  does not support validation by <a href="http://www.w3.org/">XML</a>
+  <a href="http://www.w3.org/XML/Schema">Schema</a>.
+  The <a href="http://www.apache.org/">Apache</a>
+  <a href="http://xml.apache.org/xerces2-j/">Xerces</a> parser does
+  validate against Schemas;
+  other commercial and open source parsers may also validate against
+  Schemas. (JSTOR and the Harvard University Library do not endorse or
+  recommend the use of any particular XML parser; the previous
+  discussion is provided solely for information purposes.)
 </p>
 
 <p>
-Note that the concept of validity applies only to XML files that explicitly
-reference a DTD or XML Schema.
-JHOVE can determine if either of these conditions are met and if so,
-it will invoke automatically the SAX2 parser in a validating mode.
-Otherwise, the parser is invoked in a manner that only checks for
-well-formedness.
+  This module can be <a href="/getting-started/config/">configured</a>
+  with the following parameters:
 </p>
 
-<a class="name" name="repinfo">
-<h2>5 Representation Information</h2></a>
+<ul>
+  <li>
+    <code>schema=[namespace];[schemaLocation]...</code> in order to
+    provide local schemas during the parsing of the file.
+  </li>
+  <li>
+    <code>withTextMD=true</code> to ask for the output of a
+    <a href="/references#textmd">textMD</a> block in the text technical
+     properties.
+  </li>
+</ul>
+
+<h2 id="coverage">2 Coverage</h2>
 
 <p>
-The MIME type is reported as: application/xml
+  The XML-hul module recognizes and validates the following public
+  profiles:
+</p>
+
+<ul>
+  <li>XML 1.0 [<a href="/references#xml">XML</a>]</li>
+</ul>
+
+<h2 id="well-formedness">3 Well-Formedness</h2>
+
+<p>
+  JHOVE uses the criteria for XML well-formedness defined by
+  [<a href="/references#xml">XML</a>].
+</p>
+
+<h2 id="validity">4 Validity</h2>
+
+<p>
+  JHOVE uses the criteria for XML validity defined by
+  [<a href="/references#xml">XML</a>].
 </p>
 
 <p>
-In addition to the standard JHOVE
-<a href="/documentation#repinfo">representation information</a>, the following
-XML-specific properties are reported:
+  Note that the concept of validity applies only to XML files that
+  explicitly reference a DTD or XML Schema. JHOVE can determine if
+  either of these conditions are met and if so, it will invoke
+  automatically the SAX2 parser in a validating mode. Otherwise, the
+  parser is invoked in a manner that only checks for well-formedness.
+</p>
+
+<h2 id="repinfo">5 Representation Information</h2>
+
+<p>
+  The MIME type is reported as: application/xml
+</p>
+
+<p>
+  In addition to the standard JHOVE
+  <a href="/documentation#repinfo">representation information</a>,
+  the following XML-specific properties are reported:
+</p>
+
 <ul>
-<li> Property "XMLMetadata" of type PROPERTY and arity LIST
-<ul>
-<li> Property "Version" of type STRING and arity SCALAR
-<li> Property "Encoding" of type STRING and arity SCALAR
-<li> Property "Standalone" of type BOOLEAN and arity SCALAR
-<li> Property "DTD" of type PROPERTY and arity LIST (if a DTD is specified)
-<ul>
-<li> Property "PublicID" of type STRING and arity SCALAR
-<li> Property "SystemID" of type STRING and arity SCALAR
-<li> Property "InternalSubset" of type BOOLEAN and arity SCALAR
-</ul>
-<li> Property "Schemas" of type PROPERTY and arity LIST (if an XML Schema
-is specified)
-<ul>
-<li> Property "Schema" of type PROPERTY and arity ARRAY
-<ul>
-<li> Property "NamespaceURI" of type STRING and arity SCALAR
-<li> Property "SchemaLocation" of type STRING and arity SCALAR
-</ul>
-</ul>
-<li> Property "Root" of type STRING and arity SCALAR
-<li> Property "Namespaces" of type PROPERTY and arity LIST
-<ul>
-<li> Property "Namespace" of type PROPERTY and arity ARRAY
-<ul>
-<li> Property "Prefix" of type STRING and arity SCALAR
-<li> Property "URI" of type STRING and arity SCALAR
-</ul>
-</ul>
-<li> Property "Notations" of type PROPERTY and arity LIST (if there are any)
-<ul>
-<li> Property "Notation" of type PROPERTY and arity SCALAR
-<ul>
-<li> Property "Name" of type STRING and arity SCALAR
-<li> Property "PublicID" of type STRING and arity SCALAR (if non-null)
-<li> Property "SystemID" of type STRING and arity SCALAR (if non-null)
-</ul>
-</ul>
-<li> Property "CharacterReferences" of type SCALAR and arity LIST
-<li> Property "Entities" of type PROPERTY and arity LIST
-(if there are any)
-<ul>
-<li> Property "Entity" of type PROPERTY and arity SCALAR
-<ul>
-<li> Property "Name" of type STRING and arity SCALAR
-<li> Property "Type" of type STRING and arity SCALAR<br>
-must be: "Internal", "External parsed", or "External unparsed"
-<li> Property "Value" of type STRING and arity SCALAR (if internal)
-<li> Property "PublicID" of type STRING and arity SCALAR (if external
-and non-null)
-<li> Property "SystemID" of type STRING and arity SCALAR (if external
-and non-null)
-<li> Property "Notation" of type STRING and arity SCALAR (if unparsed)
-</ul>
-</ul>
-<li> Property "ProcessingInstructions" of type PROPERTY and arity LIST
-(if there are any)
-<ul>
-<li> Property "ProcessingInstruction" of type PROPERTY and arity SCALAR
-<ul>
-<li> Property "Target" of type STRING and arity SCALAR
-<li> Property "Data" of type STRING and arity SCALAR
-</ul>
-</ul>
-<li> Property "Comments" of type PROPERTY and arity LIST (if there are any)
-<ul>
-<li> Property "Comment" of type STRING and arity SCALAR
-</ul>
-<li> If withTextMD, Property "TextMDMetadata" of type TextMDMetadata and arity SCALAR</li>
-</ul>
+  <li>Property "XMLMetadata" of type PROPERTY and arity LIST
+    <ul>
+      <li>Property "Version" of type STRING and arity SCALAR</li>
+      <li>Property "Encoding" of type STRING and arity SCALAR</li>
+      <li>Property "Standalone" of type BOOLEAN and arity SCALAR</li>
+      <li>Property "DTD" of type PROPERTY and arity LIST (if a DTD is specified)
+        <ul>
+          <li>Property "PublicID" of type STRING and arity SCALAR</li>
+          <li>Property "SystemID" of type STRING and arity SCALAR</li>
+          <li>Property "InternalSubset" of type BOOLEAN and arity SCALAR</li>
+        </ul>
+      </li>
+      <li>Property "Schemas" of type PROPERTY and arity LIST (if schemas are specified)
+        <ul>
+          <li>Property "Schema" of type PROPERTY and arity ARRAY
+            <ul>
+              <li>Property "NamespaceURI" of type STRING and arity SCALAR</li>
+              <li>Property "SchemaLocation" of type STRING and arity SCALAR</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Property "Root" of type STRING and arity SCALAR</li>
+      <li>Property "Namespaces" of type PROPERTY and arity LIST
+        <ul>
+          <li>Property "Namespace" of type PROPERTY and arity ARRAY
+            <ul>
+              <li>Property "Prefix" of type STRING and arity SCALAR</li>
+              <li>Property "URI" of type STRING and arity SCALAR</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Property "Notations" of type PROPERTY and arity LIST (if there are any)
+        <ul>
+          <li>Property "Notation" of type PROPERTY and arity SCALAR
+            <ul>
+              <li>Property "Name" of type STRING and arity SCALAR</li>
+              <li>Property "PublicID" of type STRING and arity SCALAR (if non-null)</li>
+              <li>Property "SystemID" of type STRING and arity SCALAR (if non-null)</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Property "CharacterReferences" of type SCALAR and arity LIST</li>
+      <li>Property "Entities" of type PROPERTY and arity LIST (if there are any)
+        <ul>
+          <li>Property "Entity" of type PROPERTY and arity SCALAR
+            <ul>
+              <li>Property "Name" of type STRING and arity SCALAR</li>
+              <li>Property "Type" of type STRING and arity SCALAR<br/>
+                  must be: "Internal", "External parsed", or "External unparsed"</li>
+              <li>Property "Value" of type STRING and arity SCALAR (if internal)</li>
+              <li>Property "PublicID" of type STRING and arity SCALAR (if external and non-null)</li>
+              <li>Property "SystemID" of type STRING and arity SCALAR (if external and non-null)</li>
+              <li>Property "Notation" of type STRING and arity SCALAR (if unparsed)</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Property "ProcessingInstructions" of type PROPERTY and arity LIST (if there are any)
+        <ul>
+          <li>Property "ProcessingInstruction" of type PROPERTY and arity SCALAR
+            <ul>
+              <li>Property "Target" of type STRING and arity SCALAR</li>
+              <li>Property "Data" of type STRING and arity SCALAR</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>Property "Comments" of type PROPERTY and arity LIST (if there are any)
+        <ul>
+          <li>Property "Comment" of type STRING and arity SCALAR</li>
+        </ul>
+      </li>
+      <li>Property "TextMDMetadata" of type TextMDMetadata and arity SCALAR (if configured)</li>
+    </ul>
+  </li>
 </ul>
 
 <p>
-Note that the notations and entities reported above are only those that appear
-in the XML file, not all of those that are defined in the DTD or XML Schema
-associated with the file.
+  Note that the notations and entities reported above are only those
+  that appear in the XML file, not all of those that are defined in the
+  DTD or XML Schema associated with the file.
 </p>
 
-<a class="name" name="extras">
-<h2>6 Additional Module Properties</h2>
-</a>
+<h2 id="extras">6 Additional Module Properties</h2>
 
-<p></p>
 <ul>
-<li> Nominal file extension: .xml
+  <li>Nominal file extension: .xml</li>
 </ul>
+
 </div>
 {% include footer.html %}
 </body>


### PR DESCRIPTION
- Removed obsolete information concerning the old Java XML parser.
  Xerces replaced Crimson as Java's default SAX parser in Java 1.5
  and we no longer support Java versions older than 1.8.
- Corrected the module parameter documentation for specifying local
  schema files to indicate schema URLs instead of schema namespaces.
  (May partially address issue #314.)
- Modified styling of definition lists to improve term separation.
- Corrected MIME type information.
- Modernized HTML