### PR TITLE
Re-prioritize logging levels for core events

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/HandlerBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/HandlerBase.java
@@ -108,7 +108,7 @@ public abstract class HandlerBase
         // action logically belongs in the handler package, so we name
         // this logger accordingly.
         _logger = Logger.getLogger ("edu.harvard.hul.ois.jhove.handler");
-        _logger.info ("Initializing " + name);
+        _logger.fine ("Initializing " + name);
         _name    = name;
         _release = release;
 	_encoding = "UTF-8";

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ModuleBase.java
@@ -148,7 +148,7 @@ public abstract class ModuleBase implements Module {
 		// action logically belongs in the module package, so we name
 		// this logger accordingly.
 		_logger = Logger.getLogger("edu.harvard.hul.ois.jhove.module");
-		_logger.info("Initializing " + name);
+		_logger.fine("Initializing " + name);
 		_name = name;
 		_release = release;
 
@@ -774,7 +774,7 @@ public abstract class ModuleBase implements Module {
 	 * initParse() should call super.initParse().
 	 */
 	protected void initParse() {
-		_logger.info(_name + " called initParse");
+		_logger.fine(_name + " called initParse");
 		_checksumFinished = false;
 		_nByte = 0;
 		_crc32 = new CRC32();

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -491,7 +491,6 @@ public class TiffModule extends ModuleBase {
         }
 
         _raf = raf;
-        _logger.info("TiffModule parsing file");
         initParse();
         info.setModule(this);
         info.setMimeType(_mimeType[0]);


### PR DESCRIPTION
This lowers a few 'info'-level events to 'fine' in an attempt to make the info. log less cluttered with low-level events and a bit more informative for general users. Also disambiguates a number of generic exception handlers to handle their more specific sub-types.