### PR TITLE
Remove extra "s" from "fonts" in Representation Info

### DIFF
--- a/modules/third-party/epub/index.html
+++ b/modules/third-party/epub/index.html
@@ -97,7 +97,7 @@ EPUB-specific properties are reported:
       </li>
       <li>Property "Fonts" of type PROPERTY and arity SET
         <ul>
-          <li>Property "Fonts" of type PROPERTY and arity SET
+          <li>Property "Font" of type PROPERTY and arity SET
             <ul>
               <li>Property "FontName" of type STRING and arity SCALAR</li>
               <li>Property "FontFile" of type STRING and arity SCALAR</li>


### PR DESCRIPTION
Fixing a minor typo - had "fonts" inside "fonts"... should be no "s" on the second layer.