### PR TITLE
fix time replacement regex in test

### DIFF
--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/handler/JsonHandlerTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/handler/JsonHandlerTest.java
@@ -48,7 +48,7 @@ public class JsonHandlerTest {
 	private static final Logger LOGGER = Logger.getLogger(JsonHandlerTest.class
 			.getName());
 
-	private static final String TIME_PATTERN = "\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\+[0-9]{2}:[0-9]{2})?\"";
+	private static final String TIME_PATTERN = "\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2})?\"";
 	private static final String DATE_PATTERN = "\"date\":\"[^\"]+\"";
 	private static final String DATE_REPLACEMENT = "\"date\":\"2010-01-01\"";
 	private static final String RELEASE_PATTERN = "\"release\":\"[^\"]+\"";


### PR DESCRIPTION
Fixes a regex that's used to replace times in tests to account for timezones that have negative offsets.