### PR TITLE
only validate xml when schema locations are known

### DIFF
--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -450,6 +450,7 @@ public class XmlModule extends ModuleBase {
 		// It should be noted that later on, when we check the namespace
 		// of the root element, if it has an associated URI, that will
 		// be used instead.
+		boolean hasRootSchema = false;
 		if (!schemaList.isEmpty()) {
 			SchemaInfo schItems = schemaList.get(0);
 			if (isNotEmpty(schItems.namespaceURI)) {
@@ -457,13 +458,18 @@ public class XmlModule extends ModuleBase {
 			} else if (isNotEmpty(schItems.location)) {
 				_textMD.setMarkup_language(schItems.location);
 			}
+
+			if (isNotEmpty(schItems.location)
+					|| (isNotEmpty(schItems.namespaceURI) && _localSchemas.containsKey(schItems.namespaceURI))) {
+				hasRootSchema = true;
+			}
 		} else if (isNotEmpty(dtdURI)) {
 			_textMD.setMarkup_language(dtdURI);
+			hasRootSchema = true;
 		}
 
 		if (parseIndex == 0) {
-			if ((handler.getDTDURI() != null || !schemaList.isEmpty())
-					&& canValidate) {
+			if (canValidate && hasRootSchema) {
 				return 1;
 			}
 			info.setValid(RepInfo.UNDETERMINED);

--- a/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
+++ b/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
@@ -9,6 +9,9 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 
@@ -38,6 +41,84 @@ public class XmlModuleTest {
         assertEquals(1, info.getSigMatch().size());
         assertEquals(MODULE_NAME, info.getSigMatch().get(0));
         assertEquals(RepInfo.TRUE, info.getWellFormed());
+    }
+
+    @Test
+    public void validateXmlSucceedsWhenHasRootSchema() {
+        String xml = "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\"" +
+                " xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" +
+                " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                " xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n" +
+                "  <dc:identifier>1234:example</dc:identifier>\n" +
+                "</oai_dc:dc>";
+        RepInfo info = new RepInfo("uri:test");
+
+        int parseIndex = module.parse(stream(xml), info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = module.parse(stream(xml), info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.TRUE, info.getValid());
+    }
+
+    @Test
+    public void doNotValidateXmlWhenMissingRootSchema() {
+        String xml = "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\"" +
+                " xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" +
+                " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+                "  <dc:identifier>1234:example</dc:identifier>\n" +
+                "</oai_dc:dc>";
+        RepInfo info = new RepInfo("uri:test");
+
+        int parseIndex = module.parse(stream(xml), info, 0);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.UNDETERMINED, info.getValid());
+    }
+
+    @Test
+    public void doNotValidateXmlWhenHasNoSchema() {
+        String xml = "<dc>\n" +
+                "  <identifier>1234:example</identifier>\n" +
+                "</dc>";
+        RepInfo info = new RepInfo("uri:test");
+
+        int parseIndex = module.parse(stream(xml), info, 0);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.UNDETERMINED, info.getValid());
+    }
+
+    @Test
+    public void validateXmlFailsWhenHasSchemaAndInvalid() {
+        String xml = "<oai_dc:dc xmlns:oai_dc=\"http://www.openarchives.org/OAI/2.0/oai_dc/\"" +
+                " xmlns:dc=\"http://purl.org/dc/elements/1.1/\"" +
+                " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                " xsi:schemaLocation=\"http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd\">\n" +
+                "  <dc:bogus>1234:example</dc:bogus>\n" +
+                "</oai_dc:dc>";
+        RepInfo info = new RepInfo("uri:test");
+
+        int parseIndex = module.parse(stream(xml), info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = module.parse(stream(xml), info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.FALSE, info.getValid());
+    }
+
+    private InputStream stream(String xml) {
+        return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-invalid.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-invalid.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Source: view-source:https://www.loc.gov/standards/mods/v3/modsbook-chapter.xml -->
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <titleInfo>
+        <bogus>Models, Fantasies and Phantoms of Transition</bogus>
+    </titleInfo>
+    <name type="personal">
+        <namePart type="given">Ash</namePart>
+        <namePart type="family">Amin</namePart>
+        <role>
+            <roleTerm type="text">author</roleTerm>
+        </role>
+    </name>
+    <typeOfResource>text</typeOfResource>
+    <relatedItem type="host">
+        <titleInfo>
+            <title>Post-Fordism</title>
+            <subTitle>A Reader</subTitle>
+        </titleInfo>
+        <name type="personal">
+            <namePart type="given">Ash</namePart>
+            <namePart type="family">Amin</namePart>
+            <role>
+                <roleTerm type="text">editor</roleTerm>
+            </role>
+        </name>
+        <originInfo eventType="publication">
+            <dateIssued>1994</dateIssued>
+            <publisher>Blackwell Publishers</publisher>
+            <place>
+                <placeTerm type="text">Oxford</placeTerm>
+            </place>
+        </originInfo>
+        <part>
+            <extent unit="page">
+                <start>23</start>
+                <end>45</end>
+            </extent>
+        </part>
+    </relatedItem>
+    <identifier>Amin1994a</identifier>
+</mods>

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-missing-root-schema.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-missing-root-schema.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Source: view-source:https://www.loc.gov/standards/mods/v3/modsbook-chapter.xml -->
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3">
+    <titleInfo>
+        <title>Models, Fantasies and Phantoms of Transition</title>
+    </titleInfo>
+    <name type="personal">
+        <namePart type="given">Ash</namePart>
+        <namePart type="family">Amin</namePart>
+        <role>
+            <roleTerm type="text">author</roleTerm>
+        </role>
+    </name>
+    <typeOfResource>text</typeOfResource>
+    <relatedItem type="host">
+        <titleInfo>
+            <title>Post-Fordism</title>
+            <subTitle>A Reader</subTitle>
+        </titleInfo>
+        <name type="personal">
+            <namePart type="given">Ash</namePart>
+            <namePart type="family">Amin</namePart>
+            <role>
+                <roleTerm type="text">editor</roleTerm>
+            </role>
+        </name>
+        <originInfo eventType="publication">
+            <dateIssued>1994</dateIssued>
+            <publisher>Blackwell Publishers</publisher>
+            <place>
+                <placeTerm type="text">Oxford</placeTerm>
+            </place>
+        </originInfo>
+        <part>
+            <extent unit="page">
+                <start>23</start>
+                <end>45</end>
+            </extent>
+        </part>
+    </relatedItem>
+    <identifier>Amin1994a</identifier>
+</mods>

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-well-formed.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-well-formed.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Source: view-source:https://www.loc.gov/standards/mods/v3/modsbook-chapter.xml -->
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+    <titleInfo>
+        <title>Models, Fantasies and Phantoms of Transition</title>
+    </titleInfo>
+    <name type="personal">
+        <namePart type="given">Ash</namePart>
+        <namePart type="family">Amin</namePart>
+        <role>
+            <roleTerm type="text">author</roleTerm>
+        </role>
+    </name>
+    <typeOfResource>text</typeOfResource>
+    <relatedItem type="host">
+        <titleInfo>
+            <title>Post-Fordism</title>
+            <subTitle>A Reader</subTitle>
+        </titleInfo>
+        <name type="personal">
+            <namePart type="given">Ash</namePart>
+            <namePart type="family">Amin</namePart>
+            <role>
+                <roleTerm type="text">editor</roleTerm>
+            </role>
+        </name>
+        <originInfo eventType="publication">
+            <dateIssued>1994</dateIssued>
+            <publisher>Blackwell Publishers</publisher>
+            <place>
+                <placeTerm type="text">Oxford</placeTerm>
+            </place>
+        </originInfo>
+        <part>
+            <extent unit="page">
+                <start>23</start>
+                <end>45</end>
+            </extent>
+        </part>
+    </relatedItem>
+    <identifier>Amin1994a</identifier>
+</mods>


### PR DESCRIPTION
Resolves https://github.com/openpreserve/jhove/issues/680

Changes the XML module to _not_ attempt to validate XML that does not have a known schema location.