### PR TITLE
upgrade version of izpack

### DIFF
--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <installer.output.filename>jhove-xplt-installer-${project.version}.jar</installer.output.filename>
-    <izpack.version>5.0.10</izpack.version>
+    <izpack.version>5.1.2</izpack.version>
     <izpack.staging>${project.build.directory}/staging</izpack.staging>
     <izpack.target>${project.build.directory}</izpack.target>
     <izpack.scripts>${project.build.scriptSourceDirectory}</izpack.scripts>


### PR DESCRIPTION
The current version of izpack does not work due to missing dependencies:

```
[ERROR] Failed to execute goal org.codehaus.izpack:izpack-maven-plugin:5.0.10:izpack (default) on project jhove-installer: Execution default of goal org.codehaus.izpack:izpack-maven-plugin:5.0.10:izpack failed: Plugin org.codehaus.izpack:izpack-maven-plugin:5.0.10 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.icepdf.os:icepdf-core:jar:6.0.1, org.icepdf.os:icepdf-viewer:jar:6.0.1: Could not find artifact org.icepdf.os:icepdf-core:jar:6.0.1
```

Upgrading the version fixes the problem.