### PR TITLE
PDF: Correct and remove duplicate error code

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Tokenizer.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Tokenizer.java
@@ -309,7 +309,7 @@ public abstract class Tokenizer
                         // Invalid character in a number
                         _state = State.WHITESPACE;
                         _wsString = EMPTY;
-                        throw new PdfMalformedException (MessageConstants.PDF_HUL_65, _offset); // PDF-HUL-65
+                        throw new PdfMalformedException (MessageConstants.PDF_HUL_66, _offset);
                     }
                 }
                 else if (_state == (State.GREATER_THAN)) {

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Invalid data in document structure root
 PDF-HUL-63 = Invalid RoleMap
 PDF-HUL-64 = Unexpected EOF
 PDF-HUL-65 = Invalid character in hex string
-PDF-HUL-65 = Lexical error
 PDF-HUL-66 = Lexical error
 PDF-HUL-67 = Invalid character in hex string
 PDF-HUL-68 = Invalid cross-reference table

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_da.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_da.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Ugyldige data i dokumentstruktur rod
 PDF-HUL-63 = Ugyldig RoleMap
 PDF-HUL-64 = Uventet EOF
 PDF-HUL-65 = Ugyldigt tegn i hex streng
-PDF-HUL-65 = Ugyldigt tegn i hex streng
 PDF-HUL-66 = Leksikalsk fejl
 PDF-HUL-67 = Ugyldigt tegn i hex streng
 PDF-HUL-68 = Ugyldig krydsreference tabel

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_de.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_de.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Ungültige Daten in Dokumentenstruktur-Root
 PDF-HUL-63 = Ungültige RoleMap
 PDF-HUL-64 = Unerwartetes EOF (End-of-file)
 PDF-HUL-65 = Ungültiger Buchstabe in Hex String
-PDF-HUL-65 = Lexikalischer Fehler
 PDF-HUL-66 = Lexikalischer Fehler
 PDF-HUL-67 = Ungültiger Buchstabe in Hex String
 PDF-HUL-68 = Ungültige Querverweistabelle

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_fr.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_fr.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Données invalides dans la racine de structure de document
 PDF-HUL-63 = 'RoleMap' invalide
 PDF-HUL-64 = Fin de fichier inattendue
 PDF-HUL-65 = Caractère invalide dans une chaîne hexadécimale
-PDF-HUL-65 = Caractère invalide dans une chaîne hexadécimale
 PDF-HUL-66 = Erreur lexicale
 PDF-HUL-67 = Caractère invalide dans une chaîne hexadécimale
 PDF-HUL-68 = Table de références croisées non valide

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_nl.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_nl.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Ongeldige data in document structuur root
 PDF-HUL-63 = Ongeldige RoleMap
 PDF-HUL-64 = Onverwacht einde van het bestand
 PDF-HUL-65 = Ongeldig karakter in hex reeks
-PDF-HUL-65 = Ongeldig karakter in hex reeks
 PDF-HUL-66 = Lexicale fout
 PDF-HUL-67 = Ongeldig karakter in hex reeks
 PDF-HUL-68 = Ongeldige kruisverwijzingstabel

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_pt_BR.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages_pt_BR.properties
@@ -76,7 +76,6 @@ PDF-HUL-62 = Dados inválidos na raíz da estrutura do documento
 PDF-HUL-63 = RoleMap inválido
 PDF-HUL-64 = EOF inesperado
 PDF-HUL-65 = Caractere inválido na cadeia hexadecimal
-PDF-HUL-65 = Erro léxico
 PDF-HUL-66 = Erro léxico
 PDF-HUL-67 = Caractere inválido na cadeia hexadecimal
 PDF-HUL-68 = Tabela de referência cruzada inválida


### PR DESCRIPTION
PDF-HUL-65 was used by two different errors with conflicting entries in the resource files. The second error now uses the correct 'lexical error' string resource.