### PR TITLE
FEAT: Configurable language codes

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ConfigHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ConfigHandler.java
@@ -8,15 +8,19 @@ package edu.harvard.hul.ois.jhove;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.*;
-import org.xml.sax.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
 
 /**
- *  SAX Parser for the configuration file.
+ * SAX Parser for the configuration file.
  */
 public class ConfigHandler
-    extends org.xml.sax.helpers.DefaultHandler
-{
+        extends DefaultHandler {
     /******************************************************************
      * PRIVATE INSTANCE FIELDS.
      ******************************************************************/
@@ -25,18 +29,20 @@ public class ConfigHandler
     protected StringBuffer _content;
 
     /** The schema name */
-    private final static String configSchemaName =
-        "jhoveConfig.xsd";
-    
-    /** The list of handlers.  Each element in the List is an
-     *  array of two Strings representing the class and the initialization
-     *  string. */
+    private static final String configSchemaName = "jhoveConfig.xsd";
+
+    /**
+     * The list of handlers. Each element in the List is an
+     * array of two Strings representing the class and the initialization
+     * string.
+     */
     private List<String[]> _handler;
 
-    /** The list of handler parameters.  Each element in the List is
-     *  a List of Strings (which may be empty but not null) representing 
-     *  parameters to be passed to the module.  List elements are in
-     *  one-to-one correspondence with _handler.
+    /**
+     * The list of handler parameters. Each element in the List is
+     * a List of Strings (which may be empty but not null) representing
+     * parameters to be passed to the module. List elements are in
+     * one-to-one correspondence with _handler.
      */
     protected List<List<String>> _handlerParams;
     private String _init;
@@ -44,17 +50,21 @@ public class ConfigHandler
     private String _tempDir;
     private String _mixVsn;
     private String _encoding;
+    private String language = "";
     private String _logLevel;
     private int _bufferSize;
     private String _jhoveHome;
     private int _sigBytes;
-    
+
     protected boolean _isHandler;
-    
-    /* _isModule is protected rather than private so that subclasses
-     * can add elements to the module element. */
+    protected boolean _isLanguage = false;
+
+    /*
+     * _isModule is protected rather than private so that subclasses
+     * can add elements to the module element.
+     */
     protected boolean _isModule;
-    
+
     private boolean _isTempDir;
     private boolean _isMixVsn;
     private boolean _isEncoding;
@@ -63,15 +73,18 @@ public class ConfigHandler
     private boolean _isLogLevel;
     private boolean _isSigBytes;
 
-    /** The list of modules.  Each element in the List is an
-     *  array of two Strings representing the class and the initialization
-     *  string. */
+    /**
+     * The list of modules. Each element in the List is an
+     * array of two Strings representing the class and the initialization
+     * string.
+     */
     protected List<ModuleInfo> _module;
-    
-    /** The list of module parameters.  Each element in the List is
-     *  a List of Strings (which may be empty but not null) representing 
-     *  parameters to be passed to the module.  List elements are in
-     *  one-to-one correspondence with _module.
+
+    /**
+     * The list of module parameters. Each element in the List is
+     * a List of Strings (which may be empty but not null) representing
+     * parameters to be passed to the module. List elements are in
+     * one-to-one correspondence with _module.
      */
     protected List<List<String>> _modParams;
 
@@ -79,17 +92,16 @@ public class ConfigHandler
      * CLASS CONSTRUCTOR.
      ******************************************************************/
 
-    /** 
-     *  Creates a ConfigHandler.
+    /**
+     * Creates a ConfigHandler.
      */
-    public ConfigHandler ()
-    {
-        _module  = new ArrayList<> ();
-        _handler = new ArrayList<> ();
-        _modParams = new ArrayList<> ();
-        _handlerParams = new ArrayList<> ();
+    public ConfigHandler() {
+        _module = new ArrayList<>();
+        _handler = new ArrayList<>();
+        _modParams = new ArrayList<>();
+        _handlerParams = new ArrayList<>();
 
-        _isModule  = false;
+        _isModule = false;
         _isHandler = false;
         _isTempDir = false;
         _isEncoding = false;
@@ -98,10 +110,10 @@ public class ConfigHandler
         _isLogLevel = false;
 
         _bufferSize = -1;
-        _encoding   = null;
-        _tempDir    = null;
-        _mixVsn     = null;
-        _sigBytes   = 1024;
+        _encoding = null;
+        _tempDir = null;
+        _mixVsn = null;
+        _sigBytes = 1024;
         _logLevel = null;
     }
 
@@ -112,272 +124,252 @@ public class ConfigHandler
      ******************************************************************/
 
     /**
-     *  Returns the List of Modules specified by the config file.
-     *  Each element of the List is a String[2] whose elements are
-     *  the module class name and initialization value.
+     * Returns the List of Modules specified by the config file.
+     * Each element of the List is a String[2] whose elements are
+     * the module class name and initialization value.
      *
-     *  @see Module
+     * @see Module
      */
-    public List<ModuleInfo> getModule ()
-    {
+    public List<ModuleInfo> getModule() {
         return _module;
     }
-    
+
     /**
-     *  Returns the List of module parameters specified by the config file.
-     *  Each element of the List is a List (possibly empty) of Strings
-     *  whose elements are parameters to pass to the module.  The
-     *  values returned by <code>getModuleParams()</code> are in 
-     *  one-to-one correspondence with those return by <code>getModule()</code>.
+     * Returns the List of module parameters specified by the config file.
+     * Each element of the List is a List (possibly empty) of Strings
+     * whose elements are parameters to pass to the module. The
+     * values returned by <code>getModuleParams()</code> are in
+     * one-to-one correspondence with those return by <code>getModule()</code>.
      */
-    public List<List<String>> getModuleParams ()
-    {
+    public List<List<String>> getModuleParams() {
         return _modParams;
     }
 
     /**
-     *  Returns the List of handler parameters specified by the config file.
-     *  Each element of the List is a List (possibly empty) of Strings
-     *  whose elements are parameters to pass to the output handler.  The
-     *  values returned by <code>getHandlerParams()</code> are in 
-     *  one-to-one correspondence with those return by <code>getHandler()</code>.
+     * Returns the List of handler parameters specified by the config file.
+     * Each element of the List is a List (possibly empty) of Strings
+     * whose elements are parameters to pass to the output handler. The
+     * values returned by <code>getHandlerParams()</code> are in
+     * one-to-one correspondence with those return by <code>getHandler()</code>.
      */
-    public List<List<String>> getHandlerParams ()
-    {
+    public List<List<String>> getHandlerParams() {
         return _handlerParams;
     }
 
     /**
-     *  Returns the List of OutputHandlers specified by the config file.
+     * Returns the List of OutputHandlers specified by the config file.
      *
-     *  @see OutputHandler
+     * @see OutputHandler
      */
-    public List<String[]> getHandler ()
-    {
+    public List<String[]> getHandler() {
         return _handler;
     }
 
     /**
-     *  Returns the temporary directory path specified by the config file,
-     *  with final path separator.
+     * Returns the temporary directory path specified by the config file,
+     * with final path separator.
      */
-    public String getTempDir ()
-    {
+    public String getTempDir() {
         return _tempDir;
     }
-    
-    /** Returns the MIX schema version specified by the config file.
-     *  Acceptable values are "0.2" and "1.0" and "2.0".
+
+    /**
+     * Returns the MIX schema version specified by the config file.
+     * Acceptable values are "0.2" and "1.0" and "2.0".
      */
-    public String getMixVsn () 
-    {
+    public String getMixVsn() {
         return _mixVsn;
     }
-    
-    /** Returns the number of bytes to examine when looking for an
-     *  indefinitely positioned signature, or checking the first
-     *  sigBytes bytes of a file in lieu of a signature.
+
+    /**
+     * Returns the number of bytes to examine when looking for an
+     * indefinitely positioned signature, or checking the first
+     * sigBytes bytes of a file in lieu of a signature.
      */
-    public int getSigBytes ()
-    {
+    public int getSigBytes() {
         return _sigBytes;
     }
 
     /**
-     *  Returns the character encoding specified by the config file.
+     * Returns the character encoding specified by the config file.
      */
-    public String getEncoding ()
-    {
+    public String getEncoding() {
         return _encoding;
     }
 
     /**
-     *           Returns the buffer size specified in the config file.
+     * Returns the buffer size specified in the config file.
      *
-     * @return   the buffer size, or -1 if none specified
+     * @return the buffer size, or -1 if none specified
      */
-    public int getBufferSize ()
-    {
-	return _bufferSize;
+    public int getBufferSize() {
+        return _bufferSize;
     }
 
     /**
-     *  Returns the path to the application's home directory,
-     *  with final path separator.
+     * Returns the path to the application's home directory,
+     * with final path separator.
      */
-    public String getJhoveHome ()
-    {
+    public String getJhoveHome() {
         return _jhoveHome;
     }
-    
+
     /**
-     *  Returns the name of the desired log level.  This should be the
-     *  name of one of the predefined values of java.util.logging.Level,
-     *  e.g., "WARNING", "INFO", "ALL".  The default level is SEVERE. 
+     * Returns the name of the desired log level. This should be the
+     * name of one of the predefined values of java.util.logging.Level,
+     * e.g., "WARNING", "INFO", "ALL". The default level is SEVERE.
      */
-    public String getLogLevel ()
-    {
+    public String getLogLevel() {
         return _logLevel;
     }
 
+    /**
+     * @return a language code if set
+     */
+    public String getLanguage() {
+        return this.language;
+    }
 
     /******************************************************************
      * SAX parser methods.
      ******************************************************************/
 
-    /** 
-     *  SAX parser callback method.
+    /**
+     * SAX parser callback method.
      */
     @Override
-    public void startElement (String namespaceURI, String localName,
-			      String rawName, Attributes atts)
-    {
-        _content = new StringBuffer ();
-        
-        if ("module".equals (rawName)) {
-            _isModule  = true;
+    public void startElement(String namespaceURI, String localName,
+            String rawName, Attributes atts) {
+        _content = new StringBuffer();
+
+        if ("module".equals(rawName)) {
+            _isModule = true;
             _init = null;
-            _param = new ArrayList<> (1);
+            _param = new ArrayList<>(1);
             _class = null;
-        }
-        else if ("outputHandler".equals (rawName)) {
+        } else if ("outputHandler".equals(rawName)) {
             _isHandler = true;
             _init = null;
-            _param = new ArrayList<> (1);
+            _param = new ArrayList<>(1);
             _class = null;
-        }
-        else if ("tempDirectory".equals (rawName)) {
+        } else if ("languageCode".equals(rawName)) {
+            _isLanguage = true;
+            _init = null;
+            _param = new ArrayList<>(1);
+            _class = null;
+        } else if ("tempDirectory".equals(rawName)) {
             _isTempDir = true;
-        }
-        else if ("mixVersion".equals (rawName)) {
+        } else if ("mixVersion".equals(rawName)) {
             _isMixVsn = true;
-        }
-        else if ("defaultEncoding".equals (rawName)) {
+        } else if ("defaultEncoding".equals(rawName)) {
             _isEncoding = true;
-        }
-        else if ("bufferSize".equals (rawName)) {
+        } else if ("bufferSize".equals(rawName)) {
             _isBufferSize = true;
-        }
-        else if ("jhoveHome".equals (rawName)) {
+        } else if ("jhoveHome".equals(rawName)) {
             _isJhoveHome = true;
-        }
-        else if ("logLevel".equals (rawName)) {
+        } else if ("logLevel".equals(rawName)) {
             _isLogLevel = true;
-        }
-        else if ("sigBytes".equals (rawName)) {
+        } else if ("sigBytes".equals(rawName)) {
             _isSigBytes = true;
         }
     }
 
-    /** 
-     *  SAX parser callback method.
+    /**
+     * SAX parser callback method.
      */
     @Override
-    public void characters (char [] ch, int start, int length)
-    {
-	_content.append (ch, start, length);
+    public void characters(char[] ch, int start, int length) {
+        _content.append(ch, start, length);
     }
 
-    /** 
-     *  SAX parser callback method.
+    /**
+     * SAX parser callback method.
      */
     @Override
-    public void endElement (String namespaceURI, String localName,
-			    String rawName)
-    {
+    public void endElement(String namespaceURI, String localName,
+            String rawName) {
         if (_isModule) {
-            if ("class".equals (rawName)) {
-                _class = _content.toString ();
-        }
-        else if ("init".equals (rawName)) {
-            _init = _content.toString ();
-        }
-        else if ("param".equals (rawName)) {
-            _param.add (_content.toString ());
-        }
-	    else if ("module".equals (rawName)) {
-            ModuleInfo modInfo = new ModuleInfo( _class, _init);
-            _module.add (modInfo);
-            _modParams.add (_param);
-            _isModule = false;
-	    }
-	}
-	else if (_isHandler) {
-	    if ("class".equals (rawName)) {
-		_class = _content.toString ();
-	    }
-	    else if ("init".equals (rawName)) {
-		_init = _content.toString ();
-	    }
-            else if ("param".equals (rawName)) {
-                _param.add (_content.toString ());
+            if ("class".equals(rawName)) {
+                _class = _content.toString();
+            } else if ("init".equals(rawName)) {
+                _init = _content.toString();
+            } else if ("param".equals(rawName)) {
+                _param.add(_content.toString());
+            } else if ("module".equals(rawName)) {
+                ModuleInfo modInfo = new ModuleInfo(_class, _init);
+                _module.add(modInfo);
+                _modParams.add(_param);
+                _isModule = false;
             }
-	    else if ("outputHandler".equals (rawName)) {
-		String [] tuple = { _class, _init };
-		_handler.add (tuple);
-                _handlerParams.add (_param);
-		_isHandler = false;
-	    }
-	}
-        else if (_isTempDir) {
-            _tempDir = _content.toString ().trim ();
+        } else if (_isHandler) {
+            if ("class".equals(rawName)) {
+                _class = _content.toString();
+            } else if ("init".equals(rawName)) {
+                _init = _content.toString();
+            } else if ("param".equals(rawName)) {
+                _param.add(_content.toString());
+            } else if ("outputHandler".equals(rawName)) {
+                String[] tuple = { _class, _init };
+                _handler.add(tuple);
+                _handlerParams.add(_param);
+                _isHandler = false;
+            }
+        } else if (_isLanguage) {
+            language = _content.toString().trim();
+            _isLanguage = false;
+        } else if (_isTempDir) {
+            _tempDir = _content.toString().trim();
             _isTempDir = false;
-        }
-        else if (_isMixVsn) {
-            _mixVsn =  _content.toString ().trim ();
+        } else if (_isMixVsn) {
+            _mixVsn = _content.toString().trim();
             _isMixVsn = false;
-        }
-        else if (_isSigBytes) {
+        } else if (_isSigBytes) {
             try {
-                _sigBytes = Integer.parseInt (_content.toString ().trim ());
+                _sigBytes = Integer.parseInt(_content.toString().trim());
+            } catch (NumberFormatException e) {
             }
-            catch (NumberFormatException e) {}
             _isSigBytes = false;
-        }
-        else if (_isEncoding) {
-            _encoding = _content.toString ().trim ();
+        } else if (_isEncoding) {
+            _encoding = _content.toString().trim();
             _isEncoding = false;
-        }
-        else if (_isJhoveHome) {
-            _jhoveHome = _content.toString ().trim ();
+        } else if (_isJhoveHome) {
+            _jhoveHome = _content.toString().trim();
             _isJhoveHome = false;
-        }
-        else if (_isLogLevel) {
-            _logLevel = _content.toString ().trim ();
+        } else if (_isLogLevel) {
+            _logLevel = _content.toString().trim();
             _isLogLevel = false;
+        } else if (_isBufferSize) {
+            try {
+                _bufferSize = Integer.parseInt(_content.toString().trim());
+            } catch (NumberFormatException e) {
+                /* Just ignore a malformed number */
+            }
+            _isBufferSize = false;
         }
-	else if (_isBufferSize) {
-	    try {
-		_bufferSize = Integer.parseInt (_content.toString ().trim ());
-	    }
-	    catch (NumberFormatException e) {
-		/* Just ignore a malformed number */
-	    }
-	    _isBufferSize = false;
-	}
     }
-    
-    /** EntityResolver designed to locate the config schema. It tries to find it
-     *  as a local resource.
-     *  
-     *  It appears that not all SAX implementations will actually call this
-     *  function for schema resolution, so this isn't a guarantee that the
-     *  schema in the config file won't be called directly. But hopefully
-     *  it will cut down on the burden on the server with the official
-     *  schema copy.
+
+    /**
+     * EntityResolver designed to locate the config schema. It tries to find it
+     * as a local resource.
+     * 
+     * It appears that not all SAX implementations will actually call this
+     * function for schema resolution, so this isn't a guarantee that the
+     * schema in the config file won't be called directly. But hopefully
+     * it will cut down on the burden on the server with the official
+     * schema copy.
      */
     @Override
-    public InputSource resolveEntity (String publicId, String systemId)
-                    throws SAXException, IOException {
-        if (systemId.endsWith (configSchemaName)) {
+    public InputSource resolveEntity(String publicId, String systemId)
+            throws SAXException, IOException {
+        if (systemId.endsWith(configSchemaName)) {
             try {
                 URL resURL = this.getClass().getResource(configSchemaName);
-                InputStream strm = resURL.openStream ();
-                return new InputSource (strm);
+                InputStream strm = resURL.openStream();
+                return new InputSource(strm);
+            } catch (Exception e) {
             }
-            catch (Exception e) {}
         }
         // If we couldn't get the local resource, use default location methods
-        return super.resolveEntity (publicId, systemId);
+        return super.resolveEntity(publicId, systemId);
     }
 }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/JhoveBase.java
@@ -262,6 +262,11 @@ public class JhoveBase {
         // if necessary.
         _jhoveHome = configHandler.getJhoveHome();
 
+        // Set language code if changed in properties
+        if (!configHandler.getLanguage().isEmpty()) {
+            System.setProperty("module.language", configHandler.getLanguage());
+        }
+
         _encoding = configHandler.getEncoding();
         if (_encoding == null) {
             _encoding = getFromProperties(ENCODING_PROPERTY);

--- a/jhove-core/src/main/resources/edu/harvard/hul/ois/jhove/jhoveConfig.xsd
+++ b/jhove-core/src/main/resources/edu/harvard/hul/ois/jhove/jhoveConfig.xsd
@@ -21,6 +21,11 @@
       <xs:documentation>Default character encoding used by the output handlers.</xs:documentation>
      </xs:annotation>
     </xs:element>
+    <xs:element name="languageCode" type="xs:string" minOccurs="0" maxOccurs="1">
+     <xs:annotation>
+      <xs:documentation>Override the default localisation with your own internationalisation code.</xs:documentation>
+     </xs:annotation>
+    </xs:element>
     <xs:element name="tempDirectory" type="xs:string" minOccurs="0">
      <xs:annotation>
       <xs:documentation>Optional directory in which temporary files are created. Default value is the current working directory.</xs:documentation>

--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/ConfigHandlerTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/ConfigHandlerTest.java
@@ -1,0 +1,68 @@
+package edu.harvard.hul.ois.jhove;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.xml.sax.SAXException;
+
+import edu.harvard.hul.ois.jhove.messages.JhoveMessage;
+import edu.harvard.hul.ois.jhove.messages.JhoveMessageFactory;
+import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
+
+@RunWith(JUnit4.class)
+public class ConfigHandlerTest {
+    @Test
+    public void testFrench() throws ParserConfigurationException, SAXException, IOException {
+        ConfigHandler configHandler = this.loadHandler("jhove_lang_fr_test.conf");
+        System.setProperty("module.language", configHandler.getLanguage());
+        JhoveMessageFactory messageFactory = JhoveMessages.getInstance("edu.harvard.hul.ois.jhove.messages.ErrorMessages");
+        JhoveMessage msg = messageFactory.getMessage("MSG");
+        assertEquals("French", msg.getMessage());
+    }
+
+    @Test
+    public void testDanish() throws ParserConfigurationException, SAXException, IOException {
+        ConfigHandler configHandler = this.loadHandler("jhove_lang_da_test.conf");
+        System.setProperty("module.language", configHandler.getLanguage());
+        JhoveMessageFactory messageFactory = JhoveMessages.getInstance("edu.harvard.hul.ois.jhove.messages.ErrorMessages");
+        JhoveMessage msg = messageFactory.getMessage("MSG");
+        assertEquals("Danish", msg.getMessage());
+    }
+
+    @Test
+    public void testUnknown() throws ParserConfigurationException, SAXException, IOException {
+        ConfigHandler configHandler = this.loadHandler("jhove_lang_jp_test.conf");
+        System.setProperty("module.language", configHandler.getLanguage());
+        JhoveMessageFactory messageFactory = JhoveMessages.getInstance("edu.harvard.hul.ois.jhove.messages.ErrorMessages");
+        JhoveMessage msg = messageFactory.getMessage("MSG");
+        assertEquals("English", msg.getMessage());
+    }
+
+    @Test
+    public void testBad() throws ParserConfigurationException, SAXException, IOException {
+        ConfigHandler configHandler = this.loadHandler("jhove_lang_bad_test.conf");
+        System.setProperty("module.language", configHandler.getLanguage());
+        JhoveMessageFactory messageFactory = JhoveMessages.getInstance("edu.harvard.hul.ois.jhove.messages.ErrorMessages");
+        JhoveMessage msg = messageFactory.getMessage("MSG");
+        assertEquals("English", msg.getMessage());
+    }
+
+    private ConfigHandler loadHandler(final String confFileName) throws ParserConfigurationException, SAXException, IOException {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParser saxParser = factory.newSAXParser();
+        ConfigHandler configHandler = new ConfigHandler();
+        try (InputStream is = this.getClass().getResourceAsStream(confFileName)) {
+            saxParser.parse(is, configHandler);
+        }
+        return configHandler;
+    }
+}

--- a/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_bad_test.conf
+++ b/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_bad_test.conf
@@ -4,8 +4,9 @@
  xmlns="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig"
  xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig
                      https://schema.openpreservation.org/ois/xml/xsd/jhove/1.26/jhoveConfig.xsd">
- <jhoveHome>$INSTALL_PATH</jhoveHome>
+ <jhoveHome>/home/example/jhove</jhoveHome>
  <defaultEncoding>utf-8</defaultEncoding>
+ <languageCode>abcde</languageCode>
  <bufferSize>131072</bufferSize>
  <module>
   <class>edu.harvard.hul.ois.jhove.module.AiffModule</class>

--- a/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_da_test.conf
+++ b/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_da_test.conf
@@ -4,7 +4,8 @@
  xmlns="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig"
  xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig
                      https://schema.openpreservation.org/ois/xml/xsd/jhove/1.26/jhoveConfig.xsd">
- <jhoveHome>$INSTALL_PATH</jhoveHome>
+ <jhoveHome>/home/example/jhove</jhoveHome>
+ <languageCode>da</languageCode>
  <defaultEncoding>utf-8</defaultEncoding>
  <bufferSize>131072</bufferSize>
  <module>

--- a/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_fr_test.conf
+++ b/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_fr_test.conf
@@ -4,7 +4,8 @@
  xmlns="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig"
  xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig
                      https://schema.openpreservation.org/ois/xml/xsd/jhove/1.26/jhoveConfig.xsd">
- <jhoveHome>$INSTALL_PATH</jhoveHome>
+ <jhoveHome>/home/example/jhove</jhoveHome>
+ <languageCode>fr</languageCode>
  <defaultEncoding>utf-8</defaultEncoding>
  <bufferSize>131072</bufferSize>
  <module>

--- a/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_jp_test.conf
+++ b/jhove-core/src/test/resources/edu/harvard/hul/ois/jhove/jhove_lang_jp_test.conf
@@ -4,7 +4,8 @@
  xmlns="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig"
  xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove/jhoveConfig
                      https://schema.openpreservation.org/ois/xml/xsd/jhove/1.26/jhoveConfig.xsd">
- <jhoveHome>$INSTALL_PATH</jhoveHome>
+ <jhoveHome>/home/example/jhove</jhoveHome>
+ <languageCode>jp</languageCode>
  <defaultEncoding>utf-8</defaultEncoding>
  <bufferSize>131072</bufferSize>
  <module>


### PR DESCRIPTION
- added `<languageCode>` element to `jhoveConfig.xsd` and `ConfigHandler`;
- set the `module.language` property in `JhoveBase`;
- changed config schema location to OPF servers;
- tests for ConfigHandler language, including defaults for bad values; and
- tidied `ConfigHandler` formatting some.

This builds on the work done by @leefrank9527 in #693, thanks. Closes #643