### PR TITLE
Move _rawbytes.add() to end of loop in processLiteral() so does not add close paren character

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Literal.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/Literal.java
@@ -161,7 +161,6 @@ public class Literal
                 throw new EOFException (MessageConstants.PDF_HUL_10.getMessage()); // PDF-HUL-10
             }
             offset++;
-            _rawBytes.add (ch);
             if (_state == State.LITERAL) {
                 // We are still in a state of flux, determining the encoding
                 if (ch == FE) {
@@ -300,6 +299,7 @@ public class Literal
                     buffer.append ((char) utfch);
                 }
             }
+            _rawBytes.add (ch);
         }
     }
 


### PR DESCRIPTION
Resolves [issue #696](https://github.com/openpreserve/jhove/issues/696). 

In `Literal.processLiteral()` the close parenthesis character is included in the rawbytes sequence but not the string buffer. This causes a problem in `NameTreeNode.compareKey()` where shorter strings in UTF16 are incorrectly compared with longer strings that start the same way - because they match a null against a close parenthesis. Unless there is a reason to include close parenthesis in the _rawbytes, this appears to be a bug. If so, the fix is to move the `_rawbytes.add()` in `Literal.processLiteral()` to the end of the loop that builds the string so that the close parenthesis is not included in the _rawbytes. 

Noticed this update recently, so took a look: https://github.com/openpreserve/jhove/issues/358. Looks like these two fixes will work together since close parens that belong in the rawbytes will still be included.