### PR TITLE
Wrong Error message Id in Test

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1039,7 +1039,14 @@ public class PdfModule extends ModuleBase {
 	}
 
 	protected boolean parseHeader(RepInfo info) throws IOException {
-		PdfHeader header = PdfHeader.parseHeader(_parser);
+		PdfHeader header = null;
+		try {
+			header = PdfHeader.parseHeader(_parser);
+		} catch (PdfMalformedException e) {
+			info.setWellFormed(false);
+			info.setMessage(new ErrorMessage(MessageConstants.PDF_HUL_154, 0L)); // PDF-HUL-154
+			return false;
+		}
 		if (header == null) {
 			info.setWellFormed(false);
 			info.setMessage(new ErrorMessage(MessageConstants.PDF_HUL_137, 0L)); // PDF-HUL-137

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -188,9 +188,10 @@ public enum MessageConstants {
 	public static final JhoveMessage PDF_HUL_148 = messageFactory.getMessage("PDF-HUL-148");
 	public static final JhoveMessage PDF_HUL_149 = messageFactory.getMessage("PDF-HUL-149");
 	public static final JhoveMessage PDF_HUL_150 = messageFactory.getMessage("PDF-HUL-150");
-        public static final JhoveMessage PDF_HUL_151 = messageFactory.getMessage("PDF-HUL-151");
+    public static final JhoveMessage PDF_HUL_151 = messageFactory.getMessage("PDF-HUL-151");
 	public static final JhoveMessage PDF_HUL_152 = messageFactory.getMessage("PDF-HUL-152");
 	public static final JhoveMessage PDF_HUL_153 = messageFactory.getMessage("PDF-HUL-153");
+	public static final JhoveMessage PDF_HUL_154 = messageFactory.getMessage("PDF-HUL-154");
 
 	/**
 	 * Logger Messages

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/PdfHeader.java
@@ -2,6 +2,8 @@ package edu.harvard.hul.ois.jhove.module.pdf;
 
 import java.io.IOException;
 
+import edu.harvard.hul.ois.jhove.ErrorMessage;
+
 /**
  * Simple class that is the a prototype of a proper header parser class. The aim
  * was to introduce a simple version check for the PDF/A minor version number,
@@ -110,8 +112,9 @@ public final class PdfHeader {
 	 * @return a new {@link PdfHeader} instance derived using the supplied
 	 *         {@link Parser} or <code>null</code> when no header could be found
 	 *         and parsed.
+	 * @throws PdfMalformedException 
 	 */
-	public static PdfHeader parseHeader(final Parser parser) {
+	public static PdfHeader parseHeader(final Parser parser) throws PdfMalformedException {
 		Token token = null;
 		String value = null;
 		boolean isPdfACompliant = false;
@@ -137,7 +140,11 @@ public final class PdfHeader {
 			if (token instanceof Comment) {
 				value = ((Comment) token).getValue();
 				if (value.indexOf(PDF_VER1_HEADER_PREFIX) == 0) {
-					version = value.substring(4, 7);
+					try {
+						version = value.substring(4, 7);
+					} catch (IndexOutOfBoundsException e ){
+						 throw new PdfMalformedException(MessageConstants.PDF_HUL_154); // PDF-HUL-154
+					}
 					isPdfACompliant = true;
 					break;
 				}

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -155,4 +155,4 @@ PDF-HUL-150 = Cross-reference stream must be a stream
 PDF-HUL-151 = Unexpected error occurred while attempting to read the cross-reference table
 PDF-HUL-152 = Encrypt dictionary has no OE key or it has a null value
 PDF-HUL-153 = Encrypt dictionary has no UE key or it has a null value
-PDF-HUL-154 = Error parsing PDF Header
+PDF-HUL-154 = Error parsing mandatory version number from PDF header

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -155,3 +155,4 @@ PDF-HUL-150 = Cross-reference stream must be a stream
 PDF-HUL-151 = Unexpected error occurred while attempting to read the cross-reference table
 PDF-HUL-152 = Encrypt dictionary has no OE key or it has a null value
 PDF-HUL-153 = Encrypt dictionary has no UE key or it has a null value
+PDF-HUL-154 = Error parsing PDF Header

--- a/jhove-modules/pdf-hul/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/DocCatTests.java
+++ b/jhove-modules/pdf-hul/src/test/java/edu/harvard/hul/ois/jhove/module/pdf/DocCatTests.java
@@ -94,7 +94,7 @@ public class DocCatTests {
 	public final void testPageRefIncorrect() throws URISyntaxException {
 		TestUtils.testValidateResource(this.module, catPageRefIncorrectPath,
 				RepInfo.FALSE, RepInfo.FALSE,
-				MessageConstants.PDF_HUL_95.getMessage());
+				MessageConstants.PDF_HUL_96.getMessage());
 	}
 
 	/**


### PR DESCRIPTION
The test testPageRefIncorrect returns Error code PDF_HUL_96 instead of PDF_HUL_95