### PR TITLE
TIFF: Continue validation even if data is unaligned

### DIFF
--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/TiffModule.java
@@ -1178,7 +1178,13 @@ public class TiffModule extends ModuleBase {
             if ((next & 1) != 0) {
                 String mess = MessageFormat.format(MessageConstants.TIFF_HUL_59.getMessage(), next);
                 JhoveMessage message = JhoveMessages.getMessageInstance(MessageConstants.TIFF_HUL_59.getId(), mess);
-                throw new TiffException(message);
+
+                if (_byteOffsetIsValid) {
+                    info.setMessage(new InfoMessage(message));
+                } else {
+                    info.setMessage(new ErrorMessage(message));
+                    info.setWellFormed(false);
+                }
             }
             if (list.size() > 50) {
                 throw new TiffException(MessageConstants.TIFF_HUL_60);

--- a/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
+++ b/jhove-modules/tiff-hul/src/main/java/edu/harvard/hul/ois/jhove/module/tiff/IFD.java
@@ -349,7 +349,8 @@ public abstract class IFD
 				_info.setMessage(new InfoMessage(message, _offset + 10 + 12*i));
 			    }
 			    else {
-				throw new TiffException(message,_offset + 10 + 12*i);
+			        _info.setMessage(new ErrorMessage(message, _offset + 10 + 12*i));
+			        _info.setWellFormed(false);
 			    }
                         }
                     }


### PR DESCRIPTION
Storing data unaligned to word or byte boundaries can decrease read performance but needn't halt file validation entirely as it doesn't prevent the file from being read. This will allow other potentially more serious issues to also be reported.

This commit also makes the 'byteoffset' configuration option affect the reporting of unaligned IFDs the same way it does unaligned IFD Entry values (by treating them as valid when set to 'true').