### PR TITLE
PATCH: Failing tests on GitHub Actions

### DIFF
--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-invalid.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-invalid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Source: view-source:https://www.loc.gov/standards/mods/v3/modsbook-chapter.xml -->
-<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 https://schema.openpreservation.org/ois/xml/xsd/jhove/test/mods-3-5.xsd">
     <titleInfo>
         <bogus>Models, Fantasies and Phantoms of Transition</bogus>
     </titleInfo>

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-well-formed.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/mods-well-formed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Source: view-source:https://www.loc.gov/standards/mods/v3/modsbook-chapter.xml -->
-<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 https://schema.openpreservation.org/ois/xml/xsd/jhove/test/mods-3-5.xsd">
     <titleInfo>
         <title>Models, Fantasies and Phantoms of Transition</title>
     </titleInfo>


### PR DESCRIPTION
Some time in September the JHOVE XML module tests started to fail. This was caused by a 403 error when trying to load XSD schema used in the two XML test files in this PR. The schema references in the test files load external schema located at <http://www.loc.gov/standards/>. These are behind a Cloudflare proxy which is the source of the 403 for requests from GitHub Actions only. The tests run fine when run locally, locally using different JDKs via Docker, on GitHub actions machines locally and on Travis.

The solution has been to copy the schema to an OPF hosted domain for test purposes <https://schema.openpreservation.org/ois/xml/xsd/jhove/test/>. A robust implementation of schema checking in JHOVE is the real solution.