### PR TITLE
FEAT: Docker image for JHOVE

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -20,6 +20,10 @@ Please use [GitHub issues](https://github.com/openpreserve/jhove/issues/new/) to
 
     docker run --rm openpreserve/jhove -m JPEG-hul -h XML "https://openpreservation.org/wp-content/uploads/2019/12/veraPDF-shadow-160x83.jpg"
 
+### Grab output to a local file
+
+    docker run --rm openpreserve/jhove -m JPEG-hul -h XML "https://openpreservation.org/wp-content/uploads/2019/12/veraPDF-shadow-160x83.jpg" - > jhove-output.xml
+
 ## Building the Docker image
 
 You'll need Maven installed locally to wrangle the project version, otherwise pass your own. From the project root run:

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,27 @@
+# JHOVE Docker image
+
+The [`Dockerfile`](Dockerfile) in this directory builds a Docker image for JHOVE. The image is based on the [Debian Linux](https://www.debian.org/) distribution and contains the JHOVE application and a custom Java runtime built using the [Eclipse Temurin Docker image](https://hub.docker.com/_/eclipse-temurin). The JHOVE image is available from [Docker Hub](https://hub.docker.com/r/openpreserve/jhove/) and can be pulled with the command:
+
+    docker pull openpreserve/jhove
+
+Please use [GitHub issues](https://github.com/openpreserve/jhove/issues/new/) to report any problems with the Docker image.
+
+## Examples
+
+### Test JHOVE image by reporting module versions
+
+    docker run --rm openpreserve/jhove
+
+### Validate an XML file in JHOVE project root
+
+    docker run --rm -v $(pwd):$(pwd) -w $(pwd) openpreserve/jhove -m XML-hul -h XML ./docker-install.xml
+
+### Validate a PNG file online
+
+    docker run --rm openpreserve/jhove -m JPEG-hul -h XML "https://openpreservation.org/wp-content/uploads/2019/12/veraPDF-shadow-160x83.jpg"
+
+## Building the Docker image
+
+You'll need Maven installed locally to wrangle the project version, otherwise pass your own. From the project root run:
+
+    docker build --build-arg JHOVE_VERSION="$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout=true)"  -t openpreserve/jhove-test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# First build the app on a maven open jdk 11 container
+FROM maven:3-eclipse-temurin-11-focal as dev-builder
+ARG JHOVE_VERSION
+ENV JHOVE_VERSION=${JHOVE_VERSION:-1.27.0-SNAPSHOT}
+
+# Copy the current dev source branch to a local build dir
+COPY . /build/jhove/
+WORKDIR /build/jhove
+
+RUN mvn clean package && java -jar jhove-installer/target/jhove-xplt-installer-${JHOVE_VERSION}.jar docker-install.xml
+
+# Now build a Java JRE for the Alpine application image
+# https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
+FROM eclipse-temurin:11 as jre-builder
+
+# Create a custom Java runtime
+RUN "$JAVA_HOME/bin/jlink" \
+         --add-modules java.base,java.logging,java.xml,jdk.crypto.ec \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+# Now the final application image
+FROM debian:bullseye-slim
+
+# Set for additional arguments passed to the java run command, no default
+ARG JAVA_OPTS
+ENV JAVA_OPTS=$JAVA_OPTS
+# Specify the veraPDF REST version if you want to (to be used in build automation)
+ARG JHOVE_VERSION
+ENV JHOVE_VERSION=${JHOVE_VERSION:-1.27.0-SNAPSHOT}
+
+# Copy the JRE from the previous stage
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
+
+# Since this is a running network service we'll create an unprivileged account
+# which will be used to perform the rest of the work and run the actual service:
+RUN useradd --system --user-group --home-dir=/opt/jhove jhove
+RUN mkdir --parents /var/opt/jhove/logs && chown -R jhove:jhove /var/opt/jhove
+
+USER jhove
+
+WORKDIR /opt/jhove
+# Copy the application from the previous stage
+COPY --from=dev-builder /opt/jhove/ /opt/jhove/
+
+ENTRYPOINT ["/opt/jhove/jhove"]

--- a/docker-install.xml
+++ b/docker-install.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<AutomatedInstallation langpack="eng">
+    <com.izforge.izpack.panels.htmlinfo.HTMLInfoPanel id="welcome"/>
+    <com.izforge.izpack.panels.target.TargetPanel id="install_dir">
+        <installpath>/opt/jhove</installpath>
+    </com.izforge.izpack.panels.target.TargetPanel>
+    <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">
+        <pack index="0" name="JHOVE Application" selected="true"/>
+        <pack index="1" name="JHOVE Shell Scripts" selected="true"/>
+        <pack index="2" name="JHOVE External Modules" selected="true"/>
+    </com.izforge.izpack.panels.packs.PacksPanel>
+    <com.izforge.izpack.panels.install.InstallPanel id="install"/>
+    <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>
+</AutomatedInstallation>


### PR DESCRIPTION
- three stage build:
  1. Build JHOVE application
  2. Build minimal JRE using jlink
  3. Create JHOVE image from build results
- documentation in DOCKER.md.