### PR TITLE
MAINT: Update Maven dependencies

### DIFF
--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>javax.json</artifactId>
-        <version>1.1</version>
+        <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>1.5.1</version>
+      <version>1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -14,10 +14,6 @@
   <name>JHOVE Validation Modules</name>
   <description>The JHOVE HUL validation modules.</description>
 
-  <properties>
-    <jwat.version>1.0.3</jwat.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.openpreservation.jhove</groupId>
@@ -31,7 +27,6 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,10 @@
     <jacoco.version>0.8.7</jacoco.version>
     <java.source.version>1.8</java.source.version>
     <java.target.version>1.8</java.target.version>
+    <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
+    <jaxb.impl.version>4.0.1</jaxb.impl.version>
+    <jaxb.core.version>4.0.1</jaxb.core.version>
+    <junit.version>4.13.2</junit.version>
     <mvn.target.release>8</mvn.target.release>
     <jhove.timestamp>${maven.build.timestamp}</jhove.timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -186,62 +190,6 @@
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco.version}</version>
         </plugin>
-        <plugin>
-          <!--
-          This plugin's configuration is used to store Eclipse m2e settings
-          only. It has no influence on the Maven build itself.
-          -->
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>properties-maven-plugin</artifactId>
-                    <versionRange>[1.0-alpha-2,)</versionRange>
-                    <goals>
-                      <goal>
-                        set-system-properties
-                      </goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <versionRange>[1.0.0,)</versionRange>
-                    <goals>
-                      <goal>enforce</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <versionRange>[1.3,)</versionRange>
-                    <goals>
-                      <goal>run</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -272,8 +220,23 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>${junit.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${jaxb.impl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>${jaxb.core.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -282,17 +245,14 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>2.3.0.1</version>
     </dependency>
   </dependencies>
   <profiles>
@@ -355,8 +315,8 @@
             <configuration>
               <header>license/template/license.txt</header>
               <properties>
-                <owner>veraPDF Consortium</owner>
-                <email>info@verapdf.org</email>
+                <owner>Open Preservation Foundation</owner>
+                <email>info@openpreservation.org</email>
               </properties>
               <excludes>
                 <exclude>license/template/**</exclude>


### PR DESCRIPTION
- updated library dependencies where safe to do so;
- removed lifecycle-mapping-plugin for Eclipse;
- hunted out hard-coded versions in pom.xml files and replaced with properties;
- removed redundant `jwat.version` property; and
- fixed license header typo.