### PR TITLE
FEAT: Filter duplicate messages

### DIFF
--- a/jhove-bbt/scripts/create-1.27-target.sh
+++ b/jhove-bbt/scripts/create-1.27-target.sh
@@ -149,6 +149,47 @@ find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/severity="e
 
 # Copy the XML result of regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml follwing https://github.com/openpreserve/jhove/pull/784
 if [[ -f "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" ]]; then
-echo " - PR:748 JPEG result patch 1."
+echo " - PR:784 JPEG result patch 1."
 	cp "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" "${targetRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml"
+fi
+
+# Finally copy the files affected by the duplicate error removal
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml"
 fi

--- a/jhove-bbt/scripts/create-1.27-target.sh
+++ b/jhove-bbt/scripts/create-1.27-target.sh
@@ -140,11 +140,15 @@ echo " - PR:748 JPEG result patch 1."
 	cp "${candidateRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml" "${targetRoot}/examples/modules/JPEG-hul/20150213_140637.jpg.jhove.xml"
 fi
 
-# Place IDs into all of the JP2K messages that have errors, there's only one code.
+# Place IDs into all of the JP2K messages that have errors, there's only one code. This is for https://github.com/openpreserve/jhove/pull/832
 find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/offset="0" severity="error>"/offset="0" severity="error" id="JPEG2000-HUL-5">/' {} \;
 find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/offset="11" severity="error>"/offset="11" severity="error" id="JPEG2000-HUL-5">/' {} \;
 find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/offset="95" severity="error>"/offset="95" severity="error" id="JPEG2000-HUL-5">/' {} \;
 find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/offset="594" severity="error>"/offset="594" severity="error" id="JPEG2000-HUL-5">/' {} \;
 find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/severity="error">/severity="error" id="JHOVE-CORE-5">/' {} \;
 
- offset="95" severity="error"
+# Copy the XML result of regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml follwing https://github.com/openpreserve/jhove/pull/784
+if [[ -f "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" ]]; then
+echo " - PR:748 JPEG result patch 1."
+	cp "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" "${targetRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml"
+fi

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
@@ -11,9 +11,7 @@ import edu.harvard.hul.ois.jhove.messages.JhoveMessage;
  * This class encapsulates an error message from a Module, representing
  * a problem in the content being analyzed.
  */
-public class ErrorMessage extends Message {
-
-	private static final String prefix = "Error";
+public final class ErrorMessage extends Message {
 
 	/******************************************************************
 	 * CLASS CONSTRUCTOR.
@@ -67,11 +65,6 @@ public class ErrorMessage extends Message {
 	 */
 	public ErrorMessage(JhoveMessage message, String subMessage,
 			long offset) {
-		super(message, subMessage, offset);
-	}
-
-	@Override
-	public String getPrefix() {
-		return prefix;
+        super(message, subMessage, offset, "Error");
 	}
 }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
@@ -24,7 +24,7 @@ public final class ErrorMessage extends Message {
 	 *            The message text and its identifier.
 	 */
 	public ErrorMessage(JhoveMessage message) {
-		super(message);
+        this(message, NULL);
 	}
 
 	/**
@@ -37,7 +37,7 @@ public final class ErrorMessage extends Message {
 	 *            was detected.
 	 */
 	public ErrorMessage(JhoveMessage message, long offset) {
-		super(message, offset);
+        this(message, message.getSubMessage(), offset);
 	}
 
 	/**
@@ -49,7 +49,7 @@ public final class ErrorMessage extends Message {
 	 *            Human-readable additional information.
 	 */
 	public ErrorMessage(JhoveMessage message, String subMessage) {
-		super(message, subMessage);
+        this(message, subMessage, NULL);
 	}
 
 	/**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
@@ -12,10 +12,7 @@ import edu.harvard.hul.ois.jhove.messages.JhoveMessage;
  * information (not necessarily a problem) about the content being analyzed
  * or the way that JHOVE deals with it.
  */
-public class InfoMessage extends Message {
-
-	private static final String prefix = "Info";
-
+public final class InfoMessage extends Message {
 	/**
 	 * Creates an InfoMessage with an identifier.
 	 * 
@@ -63,11 +60,6 @@ public class InfoMessage extends Message {
 	 *            situation being described.
 	 */
 	public InfoMessage(JhoveMessage message, String subMessage, long offset) {
-		super(message, subMessage, offset);
-	}
-
-	@Override
-	public String getPrefix() {
-		return prefix;
+        super(message, subMessage, offset, "Info");
 	}
 }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
@@ -20,7 +20,7 @@ public final class InfoMessage extends Message {
 	 *            The message text and its identifier.
 	 */
 	public InfoMessage(JhoveMessage message) {
-		super(message);
+        this(message, NULL);
 	}
 
 	/**
@@ -33,7 +33,7 @@ public final class InfoMessage extends Message {
 	 *            situation being described.
 	 */
 	public InfoMessage(JhoveMessage message, long offset) {
-		super(message, offset);
+        this(message, message.getSubMessage(), offset);
 	}
 
 	/**
@@ -45,7 +45,7 @@ public final class InfoMessage extends Message {
 	 *            Human-readable additional information.
 	 */
 	public InfoMessage(JhoveMessage message, String subMessage) {
-		super(message, subMessage);
+        this(message, subMessage, NULL);
 	}
 
 	/**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
@@ -23,18 +23,19 @@ public abstract class Message {
 	 * PRIVATE INSTANCE FIELDS.
 	 ******************************************************************/
 
-	protected final JhoveMessage message;
+    protected final JhoveMessage jhoveMessage;
 
 	/** Additional information. */
-	protected final String _subMessage;
+    protected final String subMessage;
 
 	/** Byte offset to which message applies. */
-	protected final long _offset;
+    protected final long offset;
+
+    protected final String prefix;
 
 	/******************************************************************
 	 * CLASS CONSTRUCTOR.
 	 ******************************************************************/
-
 
 	/**
 	 * Creates a Message with an identifier.
@@ -44,7 +45,7 @@ public abstract class Message {
 	 *            The message text and its identifier.
 	 */
 	protected Message(final JhoveMessage message) {
-		this(message, message.getSubMessage(), NULL);
+        this(message, message.getSubMessage());
 	}
 
 	/**
@@ -61,7 +62,7 @@ public abstract class Message {
 	 *            Human-readable additional information.
 	 */
 	protected Message(final JhoveMessage message, final String subMessage) {
-		this(message, subMessage, NULL);
+        this(message, subMessage, NULL, "");
 	}
 
 	/**
@@ -78,7 +79,7 @@ public abstract class Message {
 	 *            Byte offset associated with the message.
 	 */
 	protected Message(final JhoveMessage message, final long offset) {
-		this(message, message.getSubMessage(), offset);
+        this(message, message.getSubMessage(), offset, "");
 	}
 
 	/**
@@ -96,12 +97,13 @@ public abstract class Message {
 	 * @param offset
 	 *            Byte offset associated with the message.
 	 */
-	protected Message(final JhoveMessage message, String subMessage,
-			long offset) {
+    protected Message(final JhoveMessage message, final String subMessage,
+            final long offset, final String prefix) {
 		super();
-		this.message = message;
-		this._subMessage = (subMessage.isEmpty()) ? null : subMessage;
-		this._offset = offset;
+        this.jhoveMessage = message;
+        this.subMessage = (subMessage.isEmpty()) ? null : subMessage;
+        this.offset = offset;
+        this.prefix = prefix;
 	}
 
 	/******************************************************************
@@ -114,36 +116,81 @@ public abstract class Message {
 	 * Returns the message text.
 	 */
 	public String getMessage() {
-		return this.message.getMessage();
+        return this.jhoveMessage.getMessage();
 	}
 
 	/**
 	 * Returns the submessage text.
 	 */
 	public String getSubMessage() {
-		return this._subMessage;
+        return this.subMessage;
 	}
 
 	/**
 	 * Returns the offset to which this message is related.
 	 */
 	public long getOffset() {
-		return this._offset;
+        return this.offset;
 	}
 
 	/**
 	 * Returns the message's identifier.
 	 */
 	public String getId() {
-		return this.message.getId();
+        return this.jhoveMessage.getId();
 	}
 
 	public JhoveMessage getJhoveMessage() {
-		return this.message;
+        return this.jhoveMessage;
 	}
 
-	@SuppressWarnings("static-method")
 	public String getPrefix() {
-		return "";
+        return this.prefix;
 	}
+
+    @Override
+    public String toString() {
+        return "Message [message=" + jhoveMessage + ", _subMessage=" + subMessage + ", _offset=" + offset + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((jhoveMessage == null) ? 0 : jhoveMessage.hashCode());
+        result = prime * result + ((subMessage == null) ? 0 : subMessage.hashCode());
+        result = prime * result + (int) (offset ^ (offset >>> 32));
+        result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Message other = (Message) obj;
+        if (jhoveMessage == null) {
+            if (other.jhoveMessage != null)
+                return false;
+        } else if (!jhoveMessage.equals(other.jhoveMessage))
+            return false;
+        if (subMessage == null) {
+            if (other.subMessage != null)
+                return false;
+        } else if (!subMessage.equals(other.subMessage))
+            return false;
+        if (offset != other.offset)
+            return false;
+        if (prefix == null) {
+            if (other.prefix != null)
+                return false;
+        } else if (!prefix.equals(other.prefix))
+            return false;
+        return true;
+    }
+
 }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
@@ -39,51 +39,6 @@ public abstract class Message {
 
 	/**
 	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly, since Message is abstract.
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 */
-	protected Message(final JhoveMessage message) {
-        this(message, message.getSubMessage());
-	}
-
-	/**
-	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly,
-	 * since Message is abstract. The second argument
-	 * adds secondary details to the primary message;
-	 * the message will typically be displayed in the
-	 * form "message: subMessage".
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 * @param subMessage
-	 *            Human-readable additional information.
-	 */
-	protected Message(final JhoveMessage message, final String subMessage) {
-        this(message, subMessage, NULL, "");
-	}
-
-	/**
-	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly,
-	 * since Message is abstract. The second argument
-	 * adds secondary details to the primary message;
-	 * the message will typically be displayed in the
-	 * form "message: subMessage".
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 * @param offset
-	 *            Byte offset associated with the message.
-	 */
-	protected Message(final JhoveMessage message, final long offset) {
-        this(message, message.getSubMessage(), offset, "");
-	}
-
-	/**
-	 * Creates a Message with an identifier.
 	 * This constructor cannot be invoked directly,
 	 * since Message is abstract. The second argument
 	 * adds secondary details to the primary message;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
@@ -226,7 +226,13 @@ public class RepInfo implements Cloneable {
      *  Returns the message list stored in this object
      */
     public List<Message> getMessage() {
-        return Collections.unmodifiableList(new ArrayList<Message>(_message));
+        List<Message> messages = new ArrayList<Message>(_message);
+        Collections.sort(messages, new Comparator<Message>() {
+            public int compare(Message m1, Message m2) {
+                return (int) m1.getOffset() - (int) m2.getOffset();
+            }
+        });
+        return messages;
     }
 
     /**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
@@ -11,11 +11,11 @@ import java.util.*;
  *  This class encapsulates representation information, as defined 
  *  by ISO/IEC 14721, about a content stream.
  *
- *  @see <a href="http://wwwclassic.ccsds.org/documents/pdf/CCSDS-650.0-B-1.pdf">ISO/IEC
+ * @see <a href=
+ *      "http://wwwclassic.ccsds.org/documents/pdf/CCSDS-650.0-B-1.pdf">ISO/IEC
  *       14721 (PDF)</a>
  */
-public class RepInfo implements Cloneable
-{
+public class RepInfo implements Cloneable {
     /******************************************************************
      * PRIVATE INSTANCE FIELDS.
      ******************************************************************/
@@ -26,13 +26,14 @@ public class RepInfo implements Cloneable
     /** Consistency flag. */
     private boolean _consistent;
 
-    /** Validity flag.  A ternary variable which can have a value
-     *  of TRUE, FALSE, or UNDETERMINED. */
+    /**
+     * Validity flag. A ternary variable which can have a value
+     * of TRUE, FALSE, or UNDETERMINED.
+     */
     private int _valid;
     
     /** Values for _valid */
-    public final static int
-        TRUE = 1,
+    public final static int TRUE = 1,
         FALSE = 0,
         UNDETERMINED = -1;
 
@@ -49,7 +50,7 @@ public class RepInfo implements Cloneable
     private Date _lastModified;
 
     /** List of diagnostic and informative messages. */
-    private List<Message> _message;
+    private Set<Message> _message;
 
     /** MIME media type. */
     private String _mimeType;
@@ -75,8 +76,10 @@ public class RepInfo implements Cloneable
     /** Flag indicating _uri is a URL if true. */
     private boolean _urlFlag;
 
-    /** Well-formed flag. A ternary variable which can have a value
-     *  of TRUE, FALSE, or UNDETERMINED. */
+    /**
+     * Well-formed flag. A ternary variable which can have a value
+     * of TRUE, FALSE, or UNDETERMINED.
+     */
     private int _wellFormed;
 
     /** Version of format which applies. */
@@ -94,8 +97,7 @@ public class RepInfo implements Cloneable
      *
      *  @param uri   Object file pathname or URI
      */
-    public RepInfo (String uri)
-    {
+    public RepInfo(String uri) {
 	init (uri);
     }
 
@@ -107,14 +109,12 @@ public class RepInfo implements Cloneable
      *  @param uri       Object file pathname or URI
      *  @param external  External representation information
      */
-    public RepInfo (String uri, RepInfo external)
-    {
+    public RepInfo(String uri, RepInfo external) {
 	init (uri);
 	_external = external;
     }
 
-    private void init (String uri)
-    {
+    private void init(String uri) {
         _uri = uri;
         _size = -1;
         _wellFormed = TRUE;
@@ -123,7 +123,7 @@ public class RepInfo implements Cloneable
         _valid = TRUE;
         
         _checksum = new ArrayList<> ();
-        _message  = new ArrayList<> ();
+        _message = new HashSet<>();
         _profile  = new ArrayList<> ();
         _property = new TreeMap<> ();
         _sigMatch = new ArrayList<> ();
@@ -141,18 +141,16 @@ public class RepInfo implements Cloneable
      *  is attached directly to the clone.
      */
     @Override
-    public Object clone () 
-    {
+    public Object clone() {
 	RepInfo newri;
 	try {
 	    newri = (RepInfo) super.clone ();
-	}
-	catch (CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
 	    return null;   // should never happen
 	}
 
         newri._checksum = new ArrayList<> (_checksum);
-        newri._message = new ArrayList<>(_message);
+        newri._message = new HashSet<>(_message);
         newri._profile = new ArrayList<> (_profile);
         newri._sigMatch = new ArrayList<> (_sigMatch);
         newri._property = new TreeMap<> (_property);
@@ -165,8 +163,7 @@ public class RepInfo implements Cloneable
      *  This is a "shallow" copy; it is assumed that the parameter
      *  object is a temporary one that will not be further modified.
      */
-    public void copy (RepInfo info)
-    {
+    public void copy(RepInfo info) {
         _checksum = info._checksum;
         _consistent = info._consistent;
         _created = info._created;
@@ -196,8 +193,7 @@ public class RepInfo implements Cloneable
     /**
      *   Returns this object's list of Checksums
      */
-    public List<Checksum> getChecksum ()
-    {
+    public List<Checksum> getChecksum() {
         return _checksum;
     }
 
@@ -206,16 +202,14 @@ public class RepInfo implements Cloneable
      *   date is not automatically generated, but must be explicitly
      *   stored.
      **/
-    public Date getCreated ()
-    {
+    public Date getCreated() {
         return _created;
     }
 
     /**
      *   Return the format identifier
      */
-    public String getFormat ()
-    {
+    public String getFormat() {
         return _format;
     }
 
@@ -224,40 +218,35 @@ public class RepInfo implements Cloneable
      *   date is not automatically generated, but must be explicitly
      *   stored.
      **/
-    public Date getLastModified ()
-    {
+    public Date getLastModified() {
         return _lastModified;
     }
 
     /**
      *  Returns the message list stored in this object
      */
-    public List<Message> getMessage ()
-    {
-        return _message;
+    public List<Message> getMessage() {
+        return Collections.unmodifiableList(new ArrayList<Message>(_message));
     }
 
     /**
      *  Returns the MIME type string stored in this object
      */
-    public String getMimeType ()
-    {
+    public String getMimeType() {
         return _mimeType;
     }
 
     /**
      * Return the module.
      */
-    public Module getModule ()
-    {
+    public Module getModule() {
         return _module;
     }
 
     /**
      *  Returns the list of profiles (Strings) stored in this object
      */
-    public List<String> getProfile ()
-    {
+    public List<String> getProfile() {
         return _profile;
     }
 
@@ -266,8 +255,7 @@ public class RepInfo implements Cloneable
      *  Property map contains key-value pairs whose key is a 
      *  <code>String</code> and whose value is a <code>Property</code>.
      */
-    public Map<String, Property> getProperty ()
-    {
+    public Map<String, Property> getProperty() {
         return _property;
     }
 
@@ -276,8 +264,7 @@ public class RepInfo implements Cloneable
      *
      *  @param name  The name of the Property.
      */
-    public Property getProperty (String name)
-    {
+    public Property getProperty(String name) {
         Property property = null;
         if (_property.size () > 0) {
             property = _property.get (name);
@@ -289,16 +276,14 @@ public class RepInfo implements Cloneable
     /**
      *  Returns the size property stored in this object.
      */
-    public long getSize ()
-    {
+    public long getSize() {
         return _size;
     }
 
     /**
      *  Returns the URI property stored in this object.
      */
-    public String getUri ()
-    {
+    public String getUri() {
         return _uri;
     }
 
@@ -306,16 +291,14 @@ public class RepInfo implements Cloneable
      *  Returns a flag which, if <code>true</code>, indicates
      *  the object is a URL.
      */
-    public boolean getURLFlag ()
-    {
+    public boolean getURLFlag() {
         return _urlFlag;
     }
 
     /**
      *  Returns the value of the consistency flag.
      */
-    public boolean isConsistent ()
-    {
+    public boolean isConsistent() {
         return _consistent;
     }
 
@@ -323,8 +306,7 @@ public class RepInfo implements Cloneable
      *  Returns the value of the well-formed flag.
      *  Can return TRUE, FALSE, or UNDETERMINED.
      */
-    public int getWellFormed ()
-    {
+    public int getWellFormed() {
         return _wellFormed;
     }
 
@@ -332,24 +314,21 @@ public class RepInfo implements Cloneable
      *  Returns the value of the validity flag.
      *  Can return TRUE, FALSE, or UNDETERMINED.
      */
-    public int getValid ()
-    {
+    public int getValid() {
         return _valid;
     }
 
     /**
      *  Returns the version property stored in this object
      */
-    public String getVersion ()
-    {
+    public String getVersion() {
 	return _version;
     }
 
     /**
      *  Returns the note property stored in this object
      */
-    public String getNote ()
-    {
+    public String getNote() {
 	return _note;
     }
     
@@ -360,19 +339,18 @@ public class RepInfo implements Cloneable
      *  returned will reflect all modules that have looked
      *  at the document so far.
      */
-    public List<String> getSigMatch ()
-    {
+    public List<String> getSigMatch() {
         return _sigMatch;
     }
 
     /**
      * Return property by name, regardless of its position in the
      * property hierarchy.
+     * 
      * @param name Property name
      * @return Named property (or null)
      */
-    public Property getByName (String name)
-    {
+    public Property getByName(String name) {
         Property prop = null;
 
         Collection<Property> coll = _property.values ();
@@ -394,72 +372,63 @@ public class RepInfo implements Cloneable
     /**
      *  Append a Checksum object to the checksum list.
      */
-    public void setChecksum (Checksum checksum)
-    {
+    public void setChecksum(Checksum checksum) {
         _checksum.add (checksum);
     }
 
     /**
      *  Set the value of the consistency flag
      */
-    public void setConsistent (boolean consistent)
-    {
+    public void setConsistent(boolean consistent) {
 	_consistent = consistent;
     }
 
     /**
      *  Set the creation date
      */
-    public void setCreated (Date created)
-    {
+    public void setCreated(Date created) {
 	_created = created;
     }
 
     /**
      *  Set the format identifier
      */
-    public void setFormat (String format)
-    {
+    public void setFormat(String format) {
 	_format = format;
     }
 
     /**
      *  Set the last modified date
      */
-    public void setLastModified (Date lastModified)
-    {
+    public void setLastModified(Date lastModified) {
         _lastModified = lastModified;
     }
 
     /**
      *  Append a Message object to the message list
      */
-    public void setMessage (Message message)
-    {
+    public void setMessage(Message message) {
         _message.add (message);
     }
 
     /**
      *  Set the MIME type string
      */
-    public void setMimeType (String mimeType)
-    {
+    public void setMimeType(String mimeType) {
         _mimeType = mimeType;
     }
 
     /**
      * Add the module.
      */
-    public void setModule (Module module)
-    {
+    public void setModule(Module module) {
         _module = module;
     }
 
     /**
      *  Append a profile String to the profile list
      */
-    public void setProfile (String profile)
-    {
+    public void setProfile(String profile) {
         _profile.add (profile);
     }
 
@@ -467,16 +436,14 @@ public class RepInfo implements Cloneable
      *   Add a Property to the property map.  The name of the Property
      *   becomes its key in the map.
      */
-    public void setProperty (Property property)
-    {
+    public void setProperty(Property property) {
         _property.put (property.getName (), property);
     }
 
     /**
      *  Set the size property
      */
-    public void setSize (long size)
-    {
+    public void setSize(long size) {
         _size = size;
     }
     
@@ -484,8 +451,7 @@ public class RepInfo implements Cloneable
      *  Set the flag to indicate whether this is a URL (true)
      *  or a file (false)
      */
-    public void setURLFlag (boolean flag)
-    {
+    public void setURLFlag(boolean flag) {
         _urlFlag = flag;
     }
 
@@ -496,8 +462,7 @@ public class RepInfo implements Cloneable
      *                  an integer value:
      *                  true maps to TRUE, and false to FALSE.
      */
-    public void setWellFormed (boolean wellFormed) 
-    {
+    public void setWellFormed(boolean wellFormed) {
         _wellFormed = wellFormed ? TRUE : FALSE;
         if (!wellFormed) {
             _consistent = false;
@@ -510,8 +475,7 @@ public class RepInfo implements Cloneable
      *  Setting wellFormed to false forces the consistent and
      *  valid flags to be false as well.
      */
-    public void setWellFormed (int wellFormed)
-    {
+    public void setWellFormed(int wellFormed) {
         _wellFormed = wellFormed;
 	if (wellFormed == FALSE) {
 	    _consistent = false;
@@ -529,8 +493,7 @@ public class RepInfo implements Cloneable
      *                  an integer value:
      *                  true maps to TRUE, and false to FALSE.
      */
-    public void setValid (boolean valid) 
-    {
+    public void setValid(boolean valid) {
         _valid = valid ? TRUE : FALSE;
     }
 
@@ -541,45 +504,42 @@ public class RepInfo implements Cloneable
      *                  UNDETERMINED.  The effect of using 
      *                  other values is undefined.
      */
-    public void setValid (int valid) 
-    {
+    public void setValid(int valid) {
         _valid = valid;
     }
 
     /**
      *  Set the version string
      */
-    public void setVersion (String version) 
-    {
+    public void setVersion(String version) {
         _version = version;
     }
 
     /**
      *  Set the note string
      */
-    public void setNote (String note)
-    {
+    public void setNote(String note) {
 	_note = note;
     }
     
-    /** Adds the name of a module, signifying that the document
+    /**
+     * Adds the name of a module, signifying that the document
      *  signature matched the module's requirements.
      *  JhoveBase will make this value persistent across
      *  module invocations for a given document.
      */
-    public void setSigMatch (String modname)
-    {
+    public void setSigMatch(String modname) {
         _sigMatch.add (modname);
     }
     
-    /** Adds a list of module names, signifying that the document
+    /**
+     * Adds a list of module names, signifying that the document
      *  signature matched the module's requirements.
      *  Any previous list is lost.
      *  JhoveBase will make this value persistent across
      *  module invocations for a given document.
      */
-    public void setSigMatch (List<String> modnames)
-    {
+    public void setSigMatch(List<String> modnames) {
         _sigMatch = modnames;
     }
 
@@ -592,8 +552,7 @@ public class RepInfo implements Cloneable
      *  destination of the output are determined by the
      *  OutputHandler.
      */
-    public void show (OutputHandler handler)
-    {
+    public void show(OutputHandler handler) {
 	handler.analyze (this);
 	handler.show    (this);
     }

--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/MessageTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/MessageTest.java
@@ -1,0 +1,23 @@
+package edu.harvard.hul.ois.jhove;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class MessageTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.simple().forClass(Message.class).verify();
+        assertEquals(new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+        assertEquals(new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+        assertNotEquals(new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+    }
+}

--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/messages/JhoveMessagesTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/messages/JhoveMessagesTest.java
@@ -2,6 +2,7 @@ package edu.harvard.hul.ois.jhove.messages;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -122,6 +123,9 @@ public class JhoveMessagesTest {
     @Test
     public void testEqualsContract() {
         EqualsVerifier.forClass(JhoveMessageImpl.class).verify();
+        assertNotEquals(JhoveMessages.DEFAULT_MESSAGE, JhoveMessages.getMessageInstance("ID", "MSG"));
+        assertEquals(JhoveMessages.DEFAULT_MESSAGE,
+                JhoveMessages.getMessageInstance(JhoveMessages.NO_ID, JhoveMessages.EMPTY_MESSAGE));
     }
 
     @Test
@@ -173,6 +177,8 @@ public class JhoveMessagesTest {
             System.setProperty("module.language", "");
             JhoveMessageFactory messageFactory = JhoveMessages
                     .getInstance("edu.harvard.hul.ois.jhove.messages.ErrorMessages");
+            JhoveMessage msg = messageFactory.getMessage("MSG");
+            assertEquals("English", msg.getMessage());
         }
     }
 }

--- a/jhove-ext-modules/src/test/java/edu/harvard/hul/ois/jhove/module/WarcModuleTest.java
+++ b/jhove-ext-modules/src/test/java/edu/harvard/hul/ois/jhove/module/WarcModuleTest.java
@@ -99,10 +99,10 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
         
-        assertEquals(7, info.getMessage().size());
+        assertEquals(1, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(1, messages.size());
-        assertEquals(7, messages.get(DiagnosisType.RECOMMENDED_MISSING.name()).intValue());
+        assertEquals(1, messages.get(DiagnosisType.RECOMMENDED_MISSING.name()).intValue());
 	}
 
 	@Test
@@ -216,10 +216,10 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(16, info.getMessage().size());
+        assertEquals(4, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(1, messages.size());
-        assertEquals(16, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
+        assertEquals(4, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
 	}
 
 	@Test
@@ -240,10 +240,10 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(6, info.getMessage().size());
+        assertEquals(3, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(1, messages.size());
-        assertEquals(6, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
+        assertEquals(3, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
 	}
 
 	@Test
@@ -264,10 +264,10 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(3, info.getMessage().size());
+        assertEquals(2, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(1, messages.size());
-        assertEquals(3, messages.get(DiagnosisType.INVALID_EXPECTED.name()).intValue());
+        assertEquals(2, messages.get(DiagnosisType.INVALID_EXPECTED.name()).intValue());
 	}
 
 	@Test
@@ -797,12 +797,12 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(7, info.getMessage().size());
+        assertEquals(6, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(5, messages.size());
         assertEquals(2, messages.get(DiagnosisType.INVALID.name()).intValue());
         assertEquals(1, messages.get(DiagnosisType.INVALID_EXPECTED.name()).intValue());
-        assertEquals(2, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
+        assertEquals(1, messages.get(DiagnosisType.REQUIRED_INVALID.name()).intValue());
         assertEquals(1, messages.get(DiagnosisType.RECOMMENDED_MISSING.name()).intValue());
         assertEquals(1, messages.get(DiagnosisType.RECOMMENDED.name()).intValue());
 	}
@@ -813,10 +813,10 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(2, info.getMessage().size());
+        assertEquals(1, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(1, messages.size());
-        assertEquals(2, messages.get(DiagnosisType.ERROR.name()).intValue());
+        assertEquals(1, messages.get(DiagnosisType.ERROR.name()).intValue());
 	}
 	
 	@Test
@@ -825,11 +825,11 @@ public class WarcModuleTest {
 
 		RepInfo info = generalInvalidChecks(warcFile);
 
-        assertEquals(8, info.getMessage().size());
+        assertEquals(4, info.getMessage().size());
         Map<String, Integer> messages = extractMessages(info.getMessage());
         assertEquals(3, messages.size());
-        assertEquals(4, messages.get(DiagnosisType.INVALID.name()).intValue());
-        assertEquals(3, messages.get(DiagnosisType.INVALID_EXPECTED.name()).intValue());
+        assertEquals(2, messages.get(DiagnosisType.INVALID.name()).intValue());
+        assertEquals(1, messages.get(DiagnosisType.INVALID_EXPECTED.name()).intValue());
         assertEquals(1, messages.get(DiagnosisType.INVALID_DATA.name()).intValue());
 	}
 


### PR DESCRIPTION
- Message classes made hash/equals safe, for use in HashSet;
- RepInfo now uses a HashSet to store messages and returns a derived list;
- removed line left in target script by mistake; and
- added comments to target script.