### PR TITLE
FIX: Duplicate error removal issues

### DIFF
--- a/jhove-bbt/scripts/create-1.27-target.sh
+++ b/jhove-bbt/scripts/create-1.27-target.sh
@@ -149,6 +149,47 @@ find "${targetRoot}" -type f -name "*.jp2.jhove.xml" -exec sed -i 's/severity="e
 
 # Copy the XML result of regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml follwing https://github.com/openpreserve/jhove/pull/784
 if [[ -f "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" ]]; then
-echo " - PR:748 JPEG result patch 1."
+echo " - PR:784 JPEG result patch 1."
 	cp "${candidateRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml" "${targetRoot}/regression/modules/JPEG-hul/19_e190014.jpg.jhove.xml"
+fi
+
+# Finally copy the files affected by the duplicate error removal
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-86-govdocs-445892.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-35-govdocs-156429.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml" "${targetRoot}/errors/modules/PDF-hul/pdf-hul-5-govdocs-659152.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-truncated-inner-chunk-by-2-bytes.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-fmt-chunk-missing.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml" ]]; then
+	cp "${candidateRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml" "${targetRoot}/errors/modules/WAVE-hul/wf-pcm-44khz-8bit-mono-chunk-size-larger-than-bytes-remaining.wav.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/class-cast.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml" ]]; then
+	cp "${candidateRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml" "${targetRoot}/regression/modules/PDF-hul/issue_306.pdf.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/quad-tile.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/peppers.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/cramps-tile.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/smallliz.tif.jhove.xml"
+fi
+if [[ -f "${candidateRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml" ]]; then
+	cp "${candidateRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml" "${targetRoot}/examples/modules/TIFF-hul/zackthecat.tif.jhove.xml"
 fi

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/ErrorMessage.java
@@ -24,7 +24,7 @@ public final class ErrorMessage extends Message {
 	 *            The message text and its identifier.
 	 */
 	public ErrorMessage(JhoveMessage message) {
-		super(message);
+        this(message, NULL);
 	}
 
 	/**
@@ -37,7 +37,7 @@ public final class ErrorMessage extends Message {
 	 *            was detected.
 	 */
 	public ErrorMessage(JhoveMessage message, long offset) {
-		super(message, offset);
+        this(message, message.getSubMessage(), offset);
 	}
 
 	/**
@@ -49,7 +49,7 @@ public final class ErrorMessage extends Message {
 	 *            Human-readable additional information.
 	 */
 	public ErrorMessage(JhoveMessage message, String subMessage) {
-		super(message, subMessage);
+        this(message, subMessage, NULL);
 	}
 
 	/**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/InfoMessage.java
@@ -20,7 +20,7 @@ public final class InfoMessage extends Message {
 	 *            The message text and its identifier.
 	 */
 	public InfoMessage(JhoveMessage message) {
-		super(message);
+        this(message, NULL);
 	}
 
 	/**
@@ -33,7 +33,7 @@ public final class InfoMessage extends Message {
 	 *            situation being described.
 	 */
 	public InfoMessage(JhoveMessage message, long offset) {
-		super(message, offset);
+        this(message, message.getSubMessage(), offset);
 	}
 
 	/**
@@ -45,7 +45,7 @@ public final class InfoMessage extends Message {
 	 *            Human-readable additional information.
 	 */
 	public InfoMessage(JhoveMessage message, String subMessage) {
-		super(message, subMessage);
+        this(message, subMessage, NULL);
 	}
 
 	/**

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/Message.java
@@ -39,51 +39,6 @@ public abstract class Message {
 
 	/**
 	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly, since Message is abstract.
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 */
-	protected Message(final JhoveMessage message) {
-        this(message, message.getSubMessage());
-	}
-
-	/**
-	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly,
-	 * since Message is abstract. The second argument
-	 * adds secondary details to the primary message;
-	 * the message will typically be displayed in the
-	 * form "message: subMessage".
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 * @param subMessage
-	 *            Human-readable additional information.
-	 */
-	protected Message(final JhoveMessage message, final String subMessage) {
-        this(message, subMessage, NULL, "");
-	}
-
-	/**
-	 * Creates a Message with an identifier.
-	 * This constructor cannot be invoked directly,
-	 * since Message is abstract. The second argument
-	 * adds secondary details to the primary message;
-	 * the message will typically be displayed in the
-	 * form "message: subMessage".
-	 * 
-	 * @param message
-	 *            The message text and its identifier.
-	 * @param offset
-	 *            Byte offset associated with the message.
-	 */
-	protected Message(final JhoveMessage message, final long offset) {
-        this(message, message.getSubMessage(), offset, "");
-	}
-
-	/**
-	 * Creates a Message with an identifier.
 	 * This constructor cannot be invoked directly,
 	 * since Message is abstract. The second argument
 	 * adds secondary details to the primary message;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/RepInfo.java
@@ -226,7 +226,13 @@ public class RepInfo implements Cloneable {
      *  Returns the message list stored in this object
      */
     public List<Message> getMessage() {
-        return Collections.unmodifiableList(new ArrayList<Message>(_message));
+        List<Message> messages = new ArrayList<Message>(_message);
+        Collections.sort(messages, new Comparator<Message>() {
+            public int compare(Message m1, Message m2) {
+                return (int) m1.getOffset() - (int) m2.getOffset();
+            }
+        });
+        return messages;
     }
 
     /**

--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/MessageTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/MessageTest.java
@@ -1,0 +1,23 @@
+package edu.harvard.hul.ois.jhove;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public class MessageTest {
+    @Test
+    public void testEqualsContract() {
+        EqualsVerifier.simple().forClass(Message.class).verify();
+        assertEquals(new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+        assertEquals(new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+        assertNotEquals(new ErrorMessage(JhoveMessages.DEFAULT_MESSAGE, 0),
+                new InfoMessage(JhoveMessages.DEFAULT_MESSAGE, 0));
+    }
+}


### PR DESCRIPTION
- error messages have no duplicates and are sorted by offset;
- fixed a couple of issues with constructor calling to make message hash safe and ensure that severities are reported;
- removed `Message` class constructors for consistent instantiation;
- hash/equals safety tests for `Message` class; and
- copied test files for issues where the number/sorting of issues has changed.