### PR TITLE
FIX: Installer language pack warning

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 JHOVE - JSTOR/Harvard Object Validation Environment
-Copyright 2003-2008 by JSTOR and the President and Fellows of Harvard College
+Copyright 2003-2015 by JSTOR and the President and Fellows of Harvard College
+Copyright 2015-2023 by Open Preservation Foundation
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lessor General Public License as

--- a/jhove-installer/src/main/izpack/i18n/packsLang.xml
+++ b/jhove-installer/src/main/izpack/i18n/packsLang.xml
@@ -1,0 +1,3 @@
+<izpack:langpack version="5.0" xmlns:izpack="http://izpack.org/schema/langpack" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
+  <str id="HTMLHelloPanel.headline" txt="Begin installing JHOVE"/>
+</izpack:langpack>

--- a/jhove-installer/src/main/izpack/i18n/packsLang.xml_eng
+++ b/jhove-installer/src/main/izpack/i18n/packsLang.xml_eng
@@ -1,0 +1,3 @@
+<izpack:langpack version="5.0" xmlns:izpack="http://izpack.org/schema/langpack" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://izpack.org/schema/langpack http://izpack.org/schema/5.0/izpack-langpack-5.0.xsd">
+  <str id="HTMLHelloPanel.headline" txt="Begin installing JHOVE"/>
+</izpack:langpack>

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -12,7 +12,7 @@
     </authors>
   </info>
 
-  <guiprefs height="400" resizable="no" width="640">
+  <guiprefs height="450" resizable="no" width="640">
     <modifier key="useButtonIcons" value="yes"/>
     <modifier key="useLabelIcons" value="no"/>
     <modifier key="labelGap" value="2"/>
@@ -31,8 +31,10 @@
   </locale>
 
   <resources>
+    <res id="packsLang.xml_eng" src="i18n/packsLang.xml_eng"/>
+    <res id="packsLang.xml" src="i18n/packsLang.xml"/>
     <res id="customicons.xml" src="customicons.xml" />
-    <res id="HTMLInfoPanel.welcome" src="welcome.html"/>
+    <res id="HTMLHelloPanel.welcome" src="welcome.html"/>
     <res id="JFrameIcon" src="icon.png"/>
     <res id="OPFLogo" src="jhovelogo.png"/>
   </resources>
@@ -46,7 +48,7 @@
 
   <panels>
     <!-- FIXME why doesn't HTMLHelloPanel work any more?  it is nice not to have the "Please read the following information" text ... -->
-    <panel classname="HTMLInfoPanel" id="welcome"/>
+    <panel classname="HTMLHelloPanel" id="welcome"/>
     <panel classname="TargetPanel" id="install_dir"/>
     <panel classname="PacksPanel" id="sdk_pack_select"/>
     <panel classname="InstallPanel" id="install"/>


### PR DESCRIPTION
- changed Welcome panel to be a Hello panel and resized;
- added default language pack files to mute installer warning; and
- added OPF copyright to `LICENCE`.

Closes #845 