### PR TITLE
REL: JHOVE 1.28.0-RC2

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,7 +8,22 @@ see the file LICENSE for details).
 Versions 1.7 to 1.11 of JHOVE released independently.
 Versions 1.12 onwards released by the Open Preservation Foundation.
 
-## JHOVE 1.28.0
+## JHOVE 1.28.0-RC2
+
+2023-04-20
+
+## General
+
+- Fixed small issue in generated reports where schema version wasn't incremented to 1.9. [[#849][]]
+
+### XML Module 1.5.3
+
+- Reverted reporting of XmlParseExceptions so that exception detail is part of message body. [[#850][]]
+
+[#849]: https://github.com/openpreserve/jhove/pull/849
+[#850]: https://github.com/openpreserve/jhove/pull/850
+
+## JHOVE 1.28.0-RC1
 
 2023-03-16
 

--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
 
   <artifactId>jhove-apps</artifactId>

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
 
   <artifactId>jhove-core</artifactId>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
 
   <artifactId>jhove-ext-modules</artifactId>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
 
   <artifactId>jhove-installer</artifactId>
@@ -218,7 +218,7 @@
     <dependency>
       <groupId>org.openpreservation.jhove.modules</groupId>
       <artifactId>xml-hul</artifactId>
-      <version>1.5.3-RC1</version>
+      <version>1.5.3-RC2</version>
     </dependency>
   </dependencies>
 

--- a/jhove-installer/src/main/izpack/install.xml
+++ b/jhove-installer/src/main/izpack/install.xml
@@ -79,8 +79,8 @@
       <executable targetfile="$INSTALL_PATH/bin/utf8-hul-1.7.3-RC1.jar"/>
       <file targetdir="$INSTALL_PATH/bin" src="bin/wave-hul-1.8.2.jar"/>
       <executable targetfile="$INSTALL_PATH/bin/wave-hul-1.8.2.jar"/>
-      <file targetdir="$INSTALL_PATH/bin" src="bin/xml-hul-1.5.3-RC1.jar"/>
-      <executable targetfile="$INSTALL_PATH/bin/xml-hul-1.5.3-RC1.jar"/>
+      <file targetdir="$INSTALL_PATH/bin" src="bin/xml-hul-1.5.3-RC2.jar"/>
+      <executable targetfile="$INSTALL_PATH/bin/xml-hul-1.5.3-RC2.jar"/>
       <file targetdir="$INSTALL_PATH/conf"  override="true" src="config/jhove.conf"/>
       <parsable targetfile="$INSTALL_PATH/conf/jhove.conf" type="xml"/>
       <updatecheck>

--- a/jhove-modules/aiff-hul/pom.xml
+++ b/jhove-modules/aiff-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>aiff-hul</artifactId>
   <version>1.6.2</version>

--- a/jhove-modules/ascii-hul/pom.xml
+++ b/jhove-modules/ascii-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>ascii-hul</artifactId>
   <version>1.4.2</version>

--- a/jhove-modules/gif-hul/pom.xml
+++ b/jhove-modules/gif-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>gif-hul</artifactId>
   <version>1.4.3</version>

--- a/jhove-modules/html-hul/pom.xml
+++ b/jhove-modules/html-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>html-hul</artifactId>
   <version>1.4.3-RC1</version>
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>xml-hul</artifactId>
-        <version>1.5.3-RC1</version>
+        <version>1.5.3-RC2</version>
       </dependency>
   </dependencies>
 

--- a/jhove-modules/jpeg-hul/pom.xml
+++ b/jhove-modules/jpeg-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>jpeg-hul</artifactId>
   <version>1.5.4-RC1</version>

--- a/jhove-modules/jpeg2000-hul/pom.xml
+++ b/jhove-modules/jpeg2000-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>jpeg2000-hul</artifactId>
   <version>1.4.4-RC1</version>

--- a/jhove-modules/pdf-hul/pom.xml
+++ b/jhove-modules/pdf-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>pdf-hul</artifactId>
   <version>1.12.4-RC1</version>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.jhove</groupId>
     <artifactId>jhove</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
 
   <groupId>org.openpreservation.jhove.modules</groupId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.openpreservation.jhove</groupId>
       <artifactId>jhove-core</artifactId>
-      <version>1.28.0-RC1</version>
+      <version>1.28.0-RC2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jhove-modules/tiff-hul/pom.xml
+++ b/jhove-modules/tiff-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>tiff-hul</artifactId>
   <version>1.9.4-RC1</version>

--- a/jhove-modules/utf8-hul/pom.xml
+++ b/jhove-modules/utf8-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>utf8-hul</artifactId>
   <version>1.7.3-RC1</version>

--- a/jhove-modules/wave-hul/pom.xml
+++ b/jhove-modules/wave-hul/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>wave-hul</artifactId>
   <version>1.8.2</version>

--- a/jhove-modules/xml-hul/pom.xml
+++ b/jhove-modules/xml-hul/pom.xml
@@ -3,10 +3,10 @@
   <parent>
     <groupId>org.openpreservation.jhove.modules</groupId>
     <artifactId>jhove-modules</artifactId>
-    <version>1.28.0-RC1</version>
+    <version>1.28.0-RC2</version>
   </parent>
   <artifactId>xml-hul</artifactId>
-  <version>1.5.3-RC1</version>
+  <version>1.5.3-RC2</version>
   <name>JHOVE XML Module HUL</name>
   <description>XML module developed by Harvard University Library</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.jhove</groupId>
   <artifactId>jhove</artifactId>
-  <version>1.28.0-RC1</version>
+  <version>1.28.0-RC2</version>
   <packaging>pom</packaging>
 
   <name>JHOVE - JSTOR/Harvard Object Validation Environment</name>


### PR DESCRIPTION
- bumped application version to 1.28.0-RC2;
- bumped xml-HUL version to 1.5.3-RC2;
- update installer packaging versions; and
- updated `RELEASENOTES.md` with change details.