### PR TITLE
Error when Image Height and Width is null

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -2367,13 +2367,20 @@ public class PdfModule extends ModuleBase {
 											.get(DICT_KEY_WIDTH);
 									PdfSimpleObject widObj = (PdfSimpleObject) resolveIndirectObject(
 											widthBase);
-									niso.setImageWidth(widObj.getIntValue());
 									PdfObject heightBase = xobdict
 											.get(DICT_KEY_HEIGHT);
 									PdfSimpleObject htObj = (PdfSimpleObject) resolveIndirectObject(
 											heightBase);
-									niso.setImageLength(htObj.getIntValue());
-
+									if(widObj != null || htObj != null ) {		
+											niso.setImageWidth(widObj.getIntValue());
+											niso.setImageLength(htObj.getIntValue());
+									} else {
+										info.setWellFormed(false);
+										JhoveMessage message = JhoveMessages.getMessageInstance(
+												MessageConstants.PDF_HUL_159.getId(), 
+												MessageConstants.PDF_HUL_159.getMessage());
+										info.setMessage(new ErrorMessage(message)); // PDF-HUL-159
+									}
 									// Check for filters to add to the filter
 									// list
 									Filter[] filters = ((PdfStream) xob)

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -197,6 +197,7 @@ public enum MessageConstants {
 	public static final JhoveMessage PDF_HUL_156 = messageFactory.getMessage("PDF-HUL-156");
     public static final JhoveMessage PDF_HUL_157 = messageFactory.getMessage("PDF-HUL-157");
     public static final JhoveMessage PDF_HUL_158 = messageFactory.getMessage("PDF-HUL-158");
+	public static final JhoveMessage PDF_HUL_159 = messageFactory.getMessage("PDF-HUL-159");
 
 	/**
 	 * Logger Messages

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -160,3 +160,4 @@ PDF-HUL-155 = Error parsing mandatory version number from PDF header.
 PDF-HUL-156 = Extension can't be defined as an indirect reference
 PDF-HUL-157 = Unexpected exception {0}
 PDF-HUL-158 = Unexpected exception {0}
+PDF-HUL-159 = Image height and width are manditory properties


### PR DESCRIPTION
Hi @carlwilson ,

I created a small pull request to make parsing of Image Height and Width more robust. In the arlington model they are required attributes of XObject Image, so that's why it is an error (and not a warning)

Sam