### PR TITLE
Change in GUI MIX field name from mimetype to format name

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -889,7 +889,7 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 				"NisoImageMetadata", true);
 		String s = niso.getMimeType();
 		if (s != null) {
-			val.add(new DefaultMutableTreeNode("MIMEType: " + s, false));
+			val.add(new DefaultMutableTreeNode("FormatName: " + s, false));
 		}
 		s = niso.getByteOrder();
 		if (s != null) {


### PR DESCRIPTION
Hi @carlwilson 

The GUI shows Mimetype for MIX image data, according to the specifications this should be Format Name. The export in txt and XML show the correct field, but the GUI of jHove showed the wrong field name. Fixes #896 

Sam