### PR TITLE
add BitPerSampleUnit to the GUI

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -1274,6 +1274,10 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 			for (int i = 0; i < iarray.length; i++) {
 				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
 						false));
+				//BitsPerSampleUnit Integer is assumed, because of BitsPerSample
+				// According to the specification, it can also be float.
+				// This is currently not supported by jHove
+				nod.add(new DefaultMutableTreeNode("Integer"));
 			}
 		}
 		if ((n = niso.getSamplesPerPixel()) != NisoImageMetadata.NULL) {


### PR DESCRIPTION
Hi @carlwilson 
The BitsPerSampleUnit is missing in the GUI. It is hard-coded as Integer, because this is how it is also done in the other handlers. According to the specification of MIX, it can also be float. but this is not supported by jhove.

fixes #898 

Sam