### PR TITLE
MAINT: Upgrade Maven build

### DIFF
--- a/jhove-apps/pom.xml
+++ b/jhove-apps/pom.xml
@@ -60,11 +60,6 @@
       <artifactId>jhove-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/jhove-bbt/scripts/bbt-jhove.sh
+++ b/jhove-bbt/scripts/bbt-jhove.sh
@@ -127,7 +127,7 @@ showHelp() {
 checkParams "$@"
 candidate="${paramOutputLoc:?}/${MAJOR_MINOR_VER}"
 tempInstallLoc="/tmp/to-test"
-sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.8.10\/org\.jacoco.agent-0\.8\.10-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -Xss2048k  -classpath "$CP" edu.harvard.hul.ois.jhove.Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
+sed -i 's/^java.*/java -javaagent:${HOME}\/\.m2\/repository\/org\/jacoco\/org\.jacoco\.agent\/0.8.11\/org\.jacoco.agent-0\.8\.11-runtime\.jar=destfile=jhove-apps\/target\/jacoco\.exec -Xss2048k  -classpath "$CP" edu.harvard.hul.ois.jhove.Jhove -c "${CONFIG}" "${@}"/g' "${tempInstallLoc}/jhove"
 bash "$SCRIPT_DIR/baseline-jhove.sh" -j "${tempInstallLoc}" -c "${paramCorpusLoc}" -o "${candidate}"
 
 if [[ -f "${SCRIPT_DIR}/create-${MAJOR_MINOR_VER}-target.sh" ]]

--- a/jhove-core/pom.xml
+++ b/jhove-core/pom.xml
@@ -35,13 +35,17 @@
         <version>1.1.3</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.14</version>
+      <version>3.15.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jhove-ext-modules/pom.xml
+++ b/jhove-ext-modules/pom.xml
@@ -58,8 +58,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
     <!-- JWAT for WARC, ARC and GZIP -->
     <dependency>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <installer.output.filename>jhove-xplt-installer-${project.version}.jar</installer.output.filename>
-    <izpack.version>5.1.3</izpack.version>
+    <izpack.version>5.2.0</izpack.version>
     <izpack.staging>${project.build.directory}/staging</izpack.staging>
     <izpack.target>${project.build.directory}</izpack.target>
     <izpack.scripts>${project.build.scriptSourceDirectory}</izpack.scripts>

--- a/jhove-modules/pom.xml
+++ b/jhove-modules/pom.xml
@@ -21,8 +21,8 @@
       <version>1.29.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,28 +68,27 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <mvn.antrun.version>3.1.0</mvn.antrun.version>
     <mvn.assembly.version>3.6.0</mvn.assembly.version>
-    <mvn.clean.version>3.2.0</mvn.clean.version>
-    <mvn.compiler.version>3.11.0</mvn.compiler.version>
-    <mvn.dependency.version>3.6.0</mvn.dependency.version>
+    <mvn.clean.version>3.3.2</mvn.clean.version>
+    <mvn.compiler.version>3.12.1</mvn.compiler.version>
+    <mvn.dependency.version>3.6.1</mvn.dependency.version>
     <mvn.deploy.version>3.1.1</mvn.deploy.version>
     <mvn.install.version>3.1.1</mvn.install.version>
     <mvn.resources.version>3.3.1</mvn.resources.version>
-    <mvn.site.version>4.0.0-M8</mvn.site.version>
+    <mvn.site.version>4.0.0-M13</mvn.site.version>
     <mvn.gpg.version>3.1.0</mvn.gpg.version>
     <mvn.jar.version>3.3.0</mvn.jar.version>
-    <mvn.javadoc.version>3.5.0</mvn.javadoc.version>
+    <mvn.javadoc.version>3.6.3</mvn.javadoc.version>
     <mvn.source.version>3.3.0</mvn.source.version>
-    <mvn.surefire.version>3.1.2</mvn.surefire.version>
+    <mvn.surefire.version>3.2.5</mvn.surefire.version>
     <mvn.release.version>3.0.1</mvn.release.version>
-    <jacoco.version>0.8.10</jacoco.version>
+    <jacoco.version>0.8.11</jacoco.version>
     <java.source.version>1.8</java.source.version>
     <java.target.version>1.8</java.target.version>
     <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
-    <jaxb.impl.version>4.0.3</jaxb.impl.version>
-    <jaxb.core.version>4.0.3</jaxb.core.version>
-    <junit.version>4.13.2</junit.version>
+    <jaxb.impl.version>4.0.4</jaxb.impl.version>
+    <jaxb.core.version>4.0.4</jaxb.core.version>
+    <junit.version>5.10.2</junit.version>
     <mvn.target.release>8</mvn.target.release>
     <jhove.timestamp>${maven.build.timestamp}</jhove.timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -98,11 +97,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>${mvn.antrun.version}</version>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
@@ -224,9 +218,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
@@ -302,12 +303,13 @@
       </build>
       <dependencies>
 
-        <dependency>
-          <groupId>org.codehaus.sonar-plugins.java</groupId>
-          <artifactId>sonar-jacoco-listeners</artifactId>
-          <version>1.2</version>
-          <scope>test</scope>
-        </dependency>
+      <!-- https://mvnrepository.com/artifact/org.sonarsource.java/sonar-jacoco-listeners -->
+      <dependency>
+        <groupId>org.sonarsource.java</groupId>
+        <artifactId>sonar-jacoco-listeners</artifactId>
+        <version>5.14.0.18788</version>
+        <scope>test</scope>
+      </dependency>
 
       </dependencies>
     </profile>


### PR DESCRIPTION
- removed some redundant plugin declarations; and
- bumped versions of various dependencies:
  - Izpack -> 5.2;
  - maven-clean-plugin -> 3.3.2;
  - maven-compiler-plugin -> 3.12.1;
  - maven-dependency-plugin -> 3.6.1;
  - maven-site-plugin -> 4.0.0-M13;
  - maven-javadoc-plugin -> 3.6.3;
  - maven-surefire-plugin -> 3.2.5;
  - maven-jacoco-plugin -> 0.8.11;
  - jaxb -> 1.4;
  - junit -> 5.10.2 via vintage engine.