### PR TITLE
Checks the range of the orientation tag to be 1-9, and forces value 9…

### DIFF
--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/NisoImageMetadata.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/NisoImageMetadata.java
@@ -185,8 +185,8 @@ public class NisoImageMetadata
     /** 6.2.4 orientation value labels. */
     public static final String [] ORIENTATION = {
 	"", "normal", "reflected horiz", "rotated 180 deg", "reflected vert",
-	"left top", "rotated cw 90 deg", "Right bottom", "Rotated ccw 90 deg",
-	"Unknown"
+	"left top", "rotated cw 90 deg", "right bottom", "rotated ccw 90 deg",
+	"unknown"
     };
 
     /** 6.1.6 planar configuration value labels. */

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/JsonHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/JsonHandler.java
@@ -1648,19 +1648,19 @@ public class JsonHandler extends HandlerBase {
 
 		n = niso.getOrientation();
 		if (n != NisoImageMetadata.NULL) {
+			if (n > 9 || n < 1) {
+				n = 9; // force "unknown" for reserved value
+			}
 			if (bMix10) {
 				mixBuilder.add("mix:orientation", n);
 			} else {
-				final String[] orient = { "unknown", "normal*",
+				final String[] orient = { "", "normal*",
 						"normal, image flipped", "normal, rotated 180\u00B0",
 						"normal, image flipped, rotated 180\u00B0",
 						"normal, image flipped, rotated cw 90\u00B0",
 						"normal, rotated ccw 90\u00B0",
 						"normal, image flipped, rotated ccw 90\u00B0",
-						"normal, rotated cw 90\u00B0" };
-				if (n > 8 || n < 0) {
-					n = 0; // force "unknown" for bad value
-				}
+						"normal, rotated cw 90\u00B0", "unknown" };
 				mixBuilder.add("mix:orientation", orient[n]);
 			}
 			hasBuilder = true;

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -1311,6 +1311,9 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
         }
         n = niso.getOrientation();
         if (n != NisoImageMetadata.NULL) {
+            if (n > 9 || n < 1) {
+                n = 9; // force "unknown" for reserved value
+            }
             fileBuf.append(margn4
                     + element("mix:Orientation", Integer.toString(n)) + EOL);
             useFileBuf = true;
@@ -2717,6 +2720,9 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
 
         n = niso.getOrientation();
         if (n != NisoImageMetadata.NULL) {
+            if (n > 9 || n < 1) {
+                n = 9; // force "unknown" for reserved value
+            }
             captureBuffer.append(margn3
                     + element("mix:orientation", Integer.toString(n)) + EOL);
             useCaptureBuffer = true;
@@ -3780,15 +3786,16 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
 
         n = niso.getOrientation();
         if (n != NisoImageMetadata.NULL) {
-            final String[] orient = { "unknown", "normal*",
+        	// Values defined in the MIX 2.0 schema
+            final String[] orient = { "", "normal*",
                     "normal, image flipped", "normal, rotated 180\u00B0",
                     "normal, image flipped, rotated 180\u00B0",
                     "normal, image flipped, rotated cw 90\u00B0",
                     "normal, rotated ccw 90\u00B0",
                     "normal, image flipped, rotated ccw 90\u00B0",
-                    "normal, rotated cw 90\u00B0" };
-            if (n > 8 || n < 0) {
-                n = 0; // force "unknown" for bad value
+                    "normal, rotated cw 90\u00B0", "unknown" };
+            if (n > 9 || n < 1) {
+                n = 9; // force "unknown" for reserved value
             }
             captureBuffer.append(margn3 + element("mix:orientation", orient[n])
                     + EOL);


### PR DESCRIPTION
… (unknown) in XML and JSON output to remind valid.

Fixes #913