### PR TITLE
FEAT: Updated audio outputs to conform to the AES57-2011 spec

### DIFF
--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -37,48 +37,48 @@ import edu.harvard.hul.ois.jhove.TextMDMetadata;
  */
 public class RepTreeRoot extends DefaultMutableTreeNode {
 
-	/**
-	 * Serialisation identifier
-	 */
-	private static final long serialVersionUID = -4409152022584715925L;
-	private RepInfo _info;
-	private JhoveBase _base;
-	private boolean _rawOutput;
-	private DateFormat _dateFmt;
+    /**
+     * Serialisation identifier
+     */
+    private static final long serialVersionUID = -4409152022584715925L;
+    private RepInfo _info;
+    private JhoveBase _base;
+    private boolean _rawOutput;
+    private DateFormat _dateFmt;
 
-	/* Sample rate. */
-	private double _sampleRate;
+    /* Sample rate. */
+    private double _sampleRate;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param info
-	 *            The RepInfo object whose contents are to be displayed.
-	 * @param base
-	 *            The JHOVE base on which we're operating.
-	 */
-	public RepTreeRoot(RepInfo info, JhoveBase base) {
-		super(info.getUri());
-		_info = info;
-		_base = base;
-		_rawOutput = _base.getShowRawFlag();
+    /**
+     * Constructor.
+     *
+     * @param info
+     *             The RepInfo object whose contents are to be displayed.
+     * @param base
+     *             The JHOVE base on which we're operating.
+     */
+    public RepTreeRoot(RepInfo info, JhoveBase base) {
+        super(info.getUri());
+        _info = info;
+        _base = base;
+        _rawOutput = _base.getShowRawFlag();
 
-		// Set the DateFormat for displaying the module date.
-		_dateFmt = DateFormat.getDateInstance();
+        // Set the DateFormat for displaying the module date.
+        _dateFmt = DateFormat.getDateInstance();
 
-		// Snarf everything up into the tree.
+        // Snarf everything up into the tree.
 
-		snarfRepInfo();
-	}
+        snarfRepInfo();
+    }
 
-	private static final String TEXT_MD_METADTA = "TextMDMetadata";
-	private static final String FORMAT = "Format: ";
-	private static final String VERSION = "Version: ";
-	private static final String BYTE_ORDER = "ByteOrder: ";
-	private static final String FRAME_COUNT_30 = "FrameCount: 30";
-	private static final String TIME_BASE_1000 = "TimeBase: 1000";
-	private static final String VIDEO_FIELD_FIELD_1 = "VideoField: FIELD_1";
-	private static final String COUNTING_MODE_NTSC_NON_DROP_FRAME= "CountingMode: NTSC_NON_DROP_FRAME";
+    private static final String TEXT_MD_METADTA = "TextMDMetadata";
+    private static final String FORMAT = "Format: ";
+    private static final String VERSION = "Version: ";
+    private static final String BYTE_ORDER = "ByteOrder: ";
+    private static final String FRAME_COUNT_30 = "FrameCount: 30";
+    private static final String TIME_BASE_1000 = "TimeBase: 1000";
+    private static final String VIDEO_FIELD_FIELD_1 = "VideoField: FIELD_1";
+    private static final String COUNTING_MODE_NTSC_NON_DROP_FRAME = "CountingMode: NTSC_NON_DROP_FRAME";
     private static final String HOURS = "Hours: ";
     private static final String MINUTES = "Minutes: ";
     private static final String SECONDS = "Seconds: ";
@@ -88,1442 +88,1398 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
     private static final String FILM_FRAMING = "FilmFraming";
     private static final String FRAMING_NOT_APPLICABLE = "Framing: NOT_APPLICABLE";
     private static final String NTSC_FILM_FRAMING_TYPE = "Type: ntscFilmFramingType";
-    
 
+    /**
+     * Constructs a DefaultMutableTreeNode representing a property
+     */
+    private DefaultMutableTreeNode propToNode(Property pProp) {
+        PropertyArity arity = pProp.getArity();
+        PropertyType typ = pProp.getType();
+        Object pValue = pProp.getValue();
+        if (arity == PropertyArity.SCALAR) {
+            if (null == typ) {
+                // Simple types: just use name plus string value.
+                DefaultMutableTreeNode val = new DefaultMutableTreeNode(
+                        pProp.getName() + ": " + pValue.toString());
+                return val;
+            } else {
+                TextMDMetadata tData;
+                DefaultMutableTreeNode val;
+                switch (typ) {
+                    case NISOIMAGEMETADATA:
+                        // NISO Image metadata is a world of its own.
+                        NisoImageMetadata nData = (NisoImageMetadata) pValue;
+                        return nisoToNode(nData);
+                    case AESAUDIOMETADATA:
+                        // AES audio metadata is another world.
+                        AESAudioMetadata aData = (AESAudioMetadata) pValue;
+                        return aesToNode(aData);
+                    case TEXTMDMETADATA:
+                        // textMD metadata is another world.
+                        tData = (TextMDMetadata) pValue;
+                        return textMDToNode(tData);
+                    case PROPERTY:
 
-	/**
-	 * Constructs a DefaultMutableTreeNode representing a property
-	 */
-	private DefaultMutableTreeNode propToNode(Property pProp) {
-		PropertyArity arity = pProp.getArity();
-		PropertyType typ = pProp.getType();
-		Object pValue = pProp.getValue();
-		if (arity == PropertyArity.SCALAR) {
-			if (null == typ) {
-				// Simple types: just use name plus string value.
-				DefaultMutableTreeNode val = new DefaultMutableTreeNode(
-						pProp.getName() + ": " + pValue.toString());
-				return val;
-			} else {
-				TextMDMetadata tData;
-				DefaultMutableTreeNode val;
-				switch (typ) {
-				case NISOIMAGEMETADATA:
-					// NISO Image metadata is a world of its own.
-					NisoImageMetadata nData = (NisoImageMetadata) pValue;
-					return nisoToNode(nData);
-				case AESAUDIOMETADATA:
-					// AES audio metadata is another world.
-					AESAudioMetadata aData = (AESAudioMetadata) pValue;
-					return aesToNode(aData);
-				case TEXTMDMETADATA:
-					// textMD metadata is another world.
-					tData = (TextMDMetadata) pValue;
-					return textMDToNode(tData);
-				case PROPERTY:
+                        if (TEXT_MD_METADTA.equals(pProp.getName())) {
+                            tData = (TextMDMetadata) pValue;
+                            return textMDToNode(tData);
+                        }
+                        // A scalar property of type Property -- seems
+                        // pointless, but we handle it.
+                        val = new DefaultMutableTreeNode(pProp.getName());
+                        val.add(propToNode((Property) pValue));
+                        return val;
 
-					if (TEXT_MD_METADTA.equals(pProp.getName())) {
-						tData = (TextMDMetadata) pValue;
-						return textMDToNode(tData);
-					}
-					// A scalar property of type Property -- seems
-					// pointless, but we handle it.
-					val = new DefaultMutableTreeNode(pProp.getName());
-					val.add(propToNode((Property) pValue));
-					return val;
+                    default:
 
-				default:
+                        // Simple types: just use name plus string value.
+                        val = new DefaultMutableTreeNode(pProp.getName() + ": "
+                                + pValue.toString());
+                        return val;
 
-					// Simple types: just use name plus string value.
-					val = new DefaultMutableTreeNode(pProp.getName() + ": "
-							+ pValue.toString());
-					return val;
+                }
+            }
+        }
+        // Compound properties. The text of the node is the
+        // property name.
+        DefaultMutableTreeNode val = new DefaultMutableTreeNode(pProp.getName());
+        if (null != arity)
+            switch (arity) {
+                case ARRAY:
+                    addArrayMembers(val, pProp);
+                    break;
+                case LIST:
+                    addListMembers(val, pProp);
+                    break;
+                case MAP:
+                    addMapMembers(val, pProp);
+                    break;
+                case SET:
+                    addSetMembers(val, pProp);
+                    break;
+                default:
+                    break;
+            }
+        return val;
+    }
 
-				}
-			}
-		}
-		// Compound properties. The text of the node is the
-		// property name.
-		DefaultMutableTreeNode val = new DefaultMutableTreeNode(pProp.getName());
-		if (null != arity)
-			switch (arity) {
-			case ARRAY:
-				addArrayMembers(val, pProp);
-				break;
-			case LIST:
-				addListMembers(val, pProp);
-				break;
-			case MAP:
-				addMapMembers(val, pProp);
-				break;
-			case SET:
-				addSetMembers(val, pProp);
-				break;
-			default:
-				break;
-			}
-		return val;
-	}
+    /**
+     * Find the index of an object in its parent. Understands the Jhove property
+     * structure.
+     */
+    public int getIndexOfChild(Object parent, Object child) {
+        Property pProp = (Property) parent;
+        PropertyArity arity = pProp.getArity();
+        // For Lists, Maps, and Sets we construct an Iterator.
+        Iterator<?> iter = null;
+        if (arity == PropertyArity.SET || arity == PropertyArity.LIST
+                || arity == PropertyArity.MAP) {
+            if (null == arity) {
+                List<?> list = (List<?>) pProp.getValue();
+                iter = list.iterator();
+            } else
+                switch (arity) {
+                    case SET:
+                        Set<?> set = (Set<?>) pProp.getValue();
+                        iter = set.iterator();
+                        break;
+                    case MAP:
+                        Map<?, ?> map = (Map<?, ?>) pProp.getValue();
+                        iter = map.values().iterator();
+                        break;
+                    default:
+                        List<?> list = (List<?>) pProp.getValue();
+                        iter = list.iterator();
+                        break;
+                }
+            for (int i = 0;; i++) {
+                if (!iter.hasNext()) {
+                    return 0; // Should never happen
+                } else if (iter.next() == child) {
+                    return i;
+                }
+            }
+        }
+        // OK, that was the easy one. Now for that damn array arity.
+        // In the case of non-object types, we can't actually tell which
+        // position matches the object, so we return 0 and hope it doesn't
+        // mess things up too much.
+        PropertyType propType = pProp.getType();
+        java.util.Date[] dateArray = null;
+        Property[] propArray = null;
+        Rational[] rationalArray = null;
+        Object[] objArray = null;
+        int n = 0;
 
-	/**
-	 * Find the index of an object in its parent. Understands the Jhove property
-	 * structure.
-	 */
-	public int getIndexOfChild(Object parent, Object child) {
-		Property pProp = (Property) parent;
-		PropertyArity arity = pProp.getArity();
-		// For Lists, Maps, and Sets we construct an Iterator.
-		Iterator<?> iter = null;
-		if (arity == PropertyArity.SET || arity == PropertyArity.LIST
-				|| arity == PropertyArity.MAP) {
-			if (null == arity) {
-				List<?> list = (List<?>) pProp.getValue();
-				iter = list.iterator();
-			} else
-				switch (arity) {
-				case SET:
-					Set<?> set = (Set<?>) pProp.getValue();
-					iter = set.iterator();
-					break;
-				case MAP:
-					Map<?, ?> map = (Map<?, ?>) pProp.getValue();
-					iter = map.values().iterator();
-					break;
-				default:
-					List<?> list = (List<?>) pProp.getValue();
-					iter = list.iterator();
-					break;
-				}
-			for (int i = 0;; i++) {
-				if (!iter.hasNext()) {
-					return 0; // Should never happen
-				} else if (iter.next() == child) {
-					return i;
-				}
-			}
-		}
-		// OK, that was the easy one. Now for that damn array arity.
-		// In the case of non-object types, we can't actually tell which
-		// position matches the object, so we return 0 and hope it doesn't
-		// mess things up too much.
-		PropertyType propType = pProp.getType();
-		java.util.Date[] dateArray = null;
-		Property[] propArray = null;
-		Rational[] rationalArray = null;
-		Object[] objArray = null;
-		int n = 0;
+        if (null == propType) {
+            return 0; // non-object array type
+        } else
+            // if (child instanceof LeafHolder) {
+            // return ((LeafHolder) child).getPosition ();
+            // }
+            // else
+            switch (propType) {
+                case DATE:
+                    dateArray = (java.util.Date[]) pProp.getValue();
+                    n = dateArray.length;
+                    break;
+                case OBJECT:
+                    objArray = (Object[]) pProp.getValue();
+                    n = objArray.length;
+                    break;
+                case RATIONAL:
+                    rationalArray = (Rational[]) pProp.getValue();
+                    n = rationalArray.length;
+                    break;
+                case PROPERTY:
+                    propArray = (Property[]) pProp.getValue();
+                    n = propArray.length;
+                    break;
+                default:
+                    return 0; // non-object array type
+            }
 
-		if (null == propType) {
-			return 0; // non-object array type
-		} else
-			// if (child instanceof LeafHolder) {
-			// return ((LeafHolder) child).getPosition ();
-			// }
-			// else
-			switch (propType) {
-			case DATE:
-				dateArray = (java.util.Date[]) pProp.getValue();
-				n = dateArray.length;
-				break;
-			case OBJECT:
-				objArray = (Object[]) pProp.getValue();
-				n = objArray.length;
-				break;
-			case RATIONAL:
-				rationalArray = (Rational[]) pProp.getValue();
-				n = rationalArray.length;
-				break;
-			case PROPERTY:
-				propArray = (Property[]) pProp.getValue();
-				n = propArray.length;
-				break;
-			default:
-				return 0; // non-object array type
-			}
+        for (int i = 0; i < n; i++) {
+            Object elem = null;
+            switch (propType) {
+                case DATE:
+                    elem = dateArray[i];
+                    break;
+                case OBJECT:
+                    elem = objArray[i];
+                    break;
+                case RATIONAL:
+                    elem = rationalArray[i];
+                    break;
+                case PROPERTY:
+                    elem = propArray[i];
+                    break;
+                default:
+                    break;
+            }
+            if (elem == child) {
+                return i;
+            }
+        }
+        return 0; // somehow fell through
+    }
 
-		for (int i = 0; i < n; i++) {
-			Object elem = null;
-			switch (propType) {
-			case DATE:
-				elem = dateArray[i];
-				break;
-			case OBJECT:
-				elem = objArray[i];
-				break;
-			case RATIONAL:
-				elem = rationalArray[i];
-				break;
-			case PROPERTY:
-				elem = propArray[i];
-				break;
-			default:
-				break;
-			}
-			if (elem == child) {
-				return i;
-			}
-		}
-		return 0; // somehow fell through
-	}
+    private void snarfRepInfo() {
+        // This node has two children, for the module and the RepInfo
 
-	private void snarfRepInfo() {
-		// This node has two children, for the module and the RepInfo
+        Module module = _info.getModule();
+        if (module != null) {
+            // Create a subnode for the module, which has three
+            // leaf children.
+            DefaultMutableTreeNode moduleNode = new DefaultMutableTreeNode(
+                    "Module");
+            moduleNode.add(new DefaultMutableTreeNode(module.getName(), false));
+            moduleNode.add(new DefaultMutableTreeNode("Release: "
+                    + module.getRelease(), false));
+            moduleNode.add(new DefaultMutableTreeNode("Date: "
+                    + _dateFmt.format(module.getDate()), false));
+            add(moduleNode);
+        }
 
-		Module module = _info.getModule();
-		if (module != null) {
-			// Create a subnode for the module, which has three
-			// leaf children.
-			DefaultMutableTreeNode moduleNode = new DefaultMutableTreeNode(
-					"Module");
-			moduleNode.add(new DefaultMutableTreeNode(module.getName(), false));
-			moduleNode.add(new DefaultMutableTreeNode("Release: "
-					+ module.getRelease(), false));
-			moduleNode.add(new DefaultMutableTreeNode("Date: "
-					+ _dateFmt.format(module.getDate()), false));
-			add(moduleNode);
-		}
+        DefaultMutableTreeNode infoNode = new DefaultMutableTreeNode("RepInfo");
+        infoNode.add(new DefaultMutableTreeNode("URI: " + _info.getUri(), false));
+        Date dt = _info.getCreated();
+        if (dt != null) {
+            infoNode.add(new DefaultMutableTreeNode(
+                    "Created: " + dt.toString(), false));
+        }
+        dt = _info.getLastModified();
+        if (dt != null) {
+            infoNode.add(new DefaultMutableTreeNode("LastModified: "
+                    + dt.toString(), false));
+        }
+        long sz = _info.getSize();
+        if (sz != -1) {
+            infoNode.add(new DefaultMutableTreeNode("Size: "
+                    + Long.toString(sz), false));
+        }
+        String s = _info.getFormat();
+        if (s != null) {
+            infoNode.add(new DefaultMutableTreeNode(FORMAT + s, false));
+        }
+        s = _info.getVersion();
+        if (s != null) {
+            infoNode.add(new DefaultMutableTreeNode(VERSION + s, false));
+        }
+        String wfStr;
+        switch (_info.getWellFormed()) {
+            case RepInfo.TRUE:
+                wfStr = "Well-Formed";
+                break;
+            case RepInfo.FALSE:
+                wfStr = "Not well-formed";
+                break;
+            default:
+                wfStr = "Unknown";
+                break;
+        }
+        if (_info.getWellFormed() == RepInfo.TRUE) {
+            switch (_info.getValid()) {
+                case RepInfo.TRUE:
+                    wfStr += " and valid";
+                    break;
 
-		DefaultMutableTreeNode infoNode = new DefaultMutableTreeNode("RepInfo");
-		infoNode.add(new DefaultMutableTreeNode("URI: " + _info.getUri(), false));
-		Date dt = _info.getCreated();
-		if (dt != null) {
-			infoNode.add(new DefaultMutableTreeNode(
-					"Created: " + dt.toString(), false));
-		}
-		dt = _info.getLastModified();
-		if (dt != null) {
-			infoNode.add(new DefaultMutableTreeNode("LastModified: "
-					+ dt.toString(), false));
-		}
-		long sz = _info.getSize();
-		if (sz != -1) {
-			infoNode.add(new DefaultMutableTreeNode("Size: "
-					+ Long.toString(sz), false));
-		}
-		String s = _info.getFormat();
-		if (s != null) {
-			infoNode.add(new DefaultMutableTreeNode(FORMAT + s, false));
-		}
-		s = _info.getVersion();
-		if (s != null) {
-			infoNode.add(new DefaultMutableTreeNode(VERSION + s, false));
-		}
-		String wfStr;
-		switch (_info.getWellFormed()) {
-		case RepInfo.TRUE:
-			wfStr = "Well-Formed";
-			break;
-		case RepInfo.FALSE:
-			wfStr = "Not well-formed";
-			break;
-		default:
-			wfStr = "Unknown";
-			break;
-		}
-		if (_info.getWellFormed() == RepInfo.TRUE) {
-			switch (_info.getValid()) {
-			case RepInfo.TRUE:
-				wfStr += " and valid";
-				break;
+                case RepInfo.FALSE:
+                    wfStr += ", but not valid";
+                    break;
 
-			case RepInfo.FALSE:
-				wfStr += ", but not valid";
-				break;
+                // case UNDETERMINED: add nothing
+            }
+        }
+        infoNode.add(new DefaultMutableTreeNode("Status: " + wfStr, false));
 
-			// case UNDETERMINED: add nothing
-			}
-		}
-		infoNode.add(new DefaultMutableTreeNode("Status: " + wfStr, false));
+        // Report modules that said their signatures match
+        List<String> sigList = _info.getSigMatch();
+        if (sigList != null && sigList.size() > 0) {
+            DefaultMutableTreeNode sigNode = new DefaultMutableTreeNode(
+                    "SignatureMatches");
+            infoNode.add(sigNode);
+            for (int i = 0; i < sigList.size(); i++) {
+                DefaultMutableTreeNode sNode = new DefaultMutableTreeNode(
+                        sigList.get(i));
+                sigNode.add(sNode);
+            }
+        }
+        // Compile a list of messages and offsets into a subtree
+        List<Message> messageList = _info.getMessage();
+        if (messageList != null && messageList.size() > 0) {
+            DefaultMutableTreeNode msgNode = new DefaultMutableTreeNode(
+                    "Messages");
+            infoNode.add(msgNode);
+            int i;
+            for (i = 0; i < messageList.size(); i++) {
+                Message msg = messageList.get(i);
+                String prefix;
+                if (msg instanceof InfoMessage) {
+                    prefix = "InfoMessage: ";
+                } else if (msg instanceof ErrorMessage) {
+                    prefix = "ErrorMessage: ";
+                } else {
+                    prefix = "Message: ";
+                }
+                DefaultMutableTreeNode mNode = new DefaultMutableTreeNode(
+                        prefix + msg.getMessage());
 
-		// Report modules that said their signatures match
-		List<String> sigList = _info.getSigMatch();
-		if (sigList != null && sigList.size() > 0) {
-			DefaultMutableTreeNode sigNode = new DefaultMutableTreeNode(
-					"SignatureMatches");
-			infoNode.add(sigNode);
-			for (int i = 0; i < sigList.size(); i++) {
-				DefaultMutableTreeNode sNode = new DefaultMutableTreeNode(
-						sigList.get(i));
-				sigNode.add(sNode);
-			}
-		}
-		// Compile a list of messages and offsets into a subtree
-		List<Message> messageList = _info.getMessage();
-		if (messageList != null && messageList.size() > 0) {
-			DefaultMutableTreeNode msgNode = new DefaultMutableTreeNode(
-					"Messages");
-			infoNode.add(msgNode);
-			int i;
-			for (i = 0; i < messageList.size(); i++) {
-				Message msg = messageList.get(i);
-				String prefix;
-				if (msg instanceof InfoMessage) {
-					prefix = "InfoMessage: ";
-				} else if (msg instanceof ErrorMessage) {
-					prefix = "ErrorMessage: ";
-				} else {
-					prefix = "Message: ";
-				}
-				DefaultMutableTreeNode mNode = new DefaultMutableTreeNode(
-						prefix + msg.getMessage());
+                if (msg.getId() != null && !msg.getId().isEmpty()) {
+                    mNode.add(new DefaultMutableTreeNode("ID: "
+                            + msg.getId()));
+                }
 
-				if (msg.getId() != null && !msg.getId().isEmpty()) {
-					mNode.add(new DefaultMutableTreeNode("ID: "
-							+ msg.getId()));
-				}
+                String subMessage = msg.getSubMessage();
+                if (subMessage != null) {
+                    mNode.add(new DefaultMutableTreeNode("SubMessage: "
+                            + subMessage));
+                }
+                long offset = -1;
+                if (msg instanceof ErrorMessage) {
+                    offset = ((ErrorMessage) msg).getOffset();
+                }
+                //
+                // If the offset is positive, we give the message node
+                // a child with the offset value.
+                if (offset >= 0) {
+                    mNode.add(new DefaultMutableTreeNode("Offset: "
+                            + Long.toString(offset)));
+                }
+                msgNode.add(mNode);
+            }
+        }
 
-				String subMessage = msg.getSubMessage();
-				if (subMessage != null) {
-					mNode.add(new DefaultMutableTreeNode("SubMessage: "
-							+ subMessage));
-				}
-				long offset = -1;
-				if (msg instanceof ErrorMessage) {
-					offset = ((ErrorMessage) msg).getOffset();
-				}
-				//
-				// If the offset is positive, we give the message node
-				// a child with the offset value.
-				if (offset >= 0) {
-					mNode.add(new DefaultMutableTreeNode("Offset: "
-							+ Long.toString(offset)));
-				}
-				msgNode.add(mNode);
-			}
-		}
+        s = _info.getMimeType();
+        if (s != null) {
+            infoNode.add(new DefaultMutableTreeNode("MimeType: " + s, false));
+        }
 
-		s = _info.getMimeType();
-		if (s != null) {
-			infoNode.add(new DefaultMutableTreeNode("MimeType: " + s, false));
-		}
+        // Compile a list of profile strings into a string list
+        List<String> profileList = _info.getProfile();
+        if (profileList != null && profileList.size() > 0) {
+            DefaultMutableTreeNode profNode = new DefaultMutableTreeNode(
+                    "Profiles");
+            infoNode.add(profNode);
+            int i;
+            for (i = 0; i < profileList.size(); i++) {
+                profNode.add(new DefaultMutableTreeNode(profileList.get(i),
+                        false));
+            }
+        }
 
-		// Compile a list of profile strings into a string list
-		List<String> profileList = _info.getProfile();
-		if (profileList != null && profileList.size() > 0) {
-			DefaultMutableTreeNode profNode = new DefaultMutableTreeNode(
-					"Profiles");
-			infoNode.add(profNode);
-			int i;
-			for (i = 0; i < profileList.size(); i++) {
-				profNode.add(new DefaultMutableTreeNode(profileList.get(i),
-						false));
-			}
-		}
+        // Here we come to the property map. We have to walk
+        // through all the properties recursively, turning
+        // each into a leaf or subtree.
+        Map<String, Property> map = _info.getProperty();
+        if (map != null) {
+            Iterator<String> iter = map.keySet().iterator();
+            while (iter.hasNext()) {
+                String key = iter.next();
+                Property property = _info.getProperty(key);
+                infoNode.add(propToNode(property));
+            }
+        }
 
-		// Here we come to the property map. We have to walk
-		// through all the properties recursively, turning
-		// each into a leaf or subtree.
-		Map<String, Property> map = _info.getProperty();
-		if (map != null) {
-			Iterator<String> iter = map.keySet().iterator();
-			while (iter.hasNext()) {
-				String key = iter.next();
-				Property property = _info.getProperty(key);
-				infoNode.add(propToNode(property));
-			}
-		}
+        List<Checksum> cksumList = _info.getChecksum();
+        if (cksumList != null && !cksumList.isEmpty()) {
+            DefaultMutableTreeNode ckNode = new DefaultMutableTreeNode(
+                    "Checksums");
+            infoNode.add(ckNode);
+            // List cPropList = new LinkedList ();
+            for (Checksum cksum : cksumList) {
+                DefaultMutableTreeNode csNode = new DefaultMutableTreeNode(
+                        "Checksum");
+                ckNode.add(csNode);
+                csNode.add(new DefaultMutableTreeNode("Type:"
+                        + cksum.getType().toString(), false));
+                csNode.add(new DefaultMutableTreeNode("Checksum: "
+                        + cksum.getValue(), false));
+            }
+        }
 
-		List<Checksum> cksumList = _info.getChecksum();
-		if (cksumList != null && !cksumList.isEmpty()) {
-			DefaultMutableTreeNode ckNode = new DefaultMutableTreeNode(
-					"Checksums");
-			infoNode.add(ckNode);
-			// List cPropList = new LinkedList ();
-			for (Checksum cksum : cksumList) {
-				DefaultMutableTreeNode csNode = new DefaultMutableTreeNode(
-						"Checksum");
-				ckNode.add(csNode);
-				csNode.add(new DefaultMutableTreeNode("Type:"
-						+ cksum.getType().toString(), false));
-				csNode.add(new DefaultMutableTreeNode("Checksum: "
-						+ cksum.getValue(), false));
-			}
-		}
+        s = _info.getNote();
+        if (s != null) {
+            infoNode.add(new DefaultMutableTreeNode("Note: " + s, false));
+        }
+        add(infoNode);
+    }
 
-		s = _info.getNote();
-		if (s != null) {
-			infoNode.add(new DefaultMutableTreeNode("Note: " + s, false));
-		}
-		add(infoNode);
-	}
+    /*
+     * Add the members of an array property to a node. The property must be of
+     * arity ARRAY.
+     */
+    private void addArrayMembers(DefaultMutableTreeNode node, Property p) {
+        Object pVal = p.getValue();
+        PropertyType typ = p.getType();
+        if (null != typ)
+            switch (typ) {
+                case INTEGER: {
+                    if (pVal instanceof int[]) {
+                        Integer[] vals = Arrays.stream((int[]) pVal) // IntStream
+                                .boxed() // Stream<Integer>
+                                .toArray(Integer[]::new);
+                        addToNode(node, vals);
+                    } else {
+                        addToNode(node, (Integer[]) pVal);
+                    }
+                    break;
+                }
+                case LONG: {
+                    if (pVal instanceof long[]) {
+                        Long[] vals = Arrays.stream((long[]) pVal) // IntStream
+                                .boxed() // Stream<Integer>
+                                .toArray(Long[]::new);
+                        addToNode(node, vals);
+                    } else {
+                        addToNode(node, (Long[]) pVal);
+                    }
+                    break;
+                }
+                case BOOLEAN: {
+                    addToNode(node, (Boolean[]) pVal);
+                    break;
+                }
+                case CHARACTER: {
+                    addToNode(node, (Character[]) pVal);
+                    break;
+                }
+                case DOUBLE: {
+                    if (pVal instanceof double[]) {
+                        Double[] vals = Arrays.stream((double[]) pVal) // IntStream
+                                .boxed() // Stream<Double>
+                                .toArray(Double[]::new);
+                        addToNode(node, vals);
+                    } else {
+                        addToNode(node, (Double[]) pVal);
+                    }
+                    break;
+                }
+                case FLOAT: {
+                    addToNode(node, (Float[]) pVal);
+                    break;
+                }
+                case SHORT: {
+                    addToNode(node, (Short[]) pVal);
+                    break;
+                }
+                case BYTE: {
+                    addToNode(node, (Byte[]) pVal);
+                    break;
+                }
+                case STRING: {
+                    addToNode(node, (String[]) pVal);
+                    break;
+                }
+                case RATIONAL: {
+                    addToNode(node, (Rational[]) pVal);
+                    break;
+                }
+                case PROPERTY: {
+                    addToNode(node, (Property[]) pVal);
+                    break;
+                }
+                case NISOIMAGEMETADATA: {
+                    addToNode(node, (NisoImageMetadata[]) pVal);
+                    break;
+                }
+                case OBJECT: {
+                    addToNode(node, (Object[]) pVal);
+                    break;
+                }
+                default:
+                    break;
+            }
+    }
 
-	/*
-	 * Add the members of an array property to a node. The property must be of
-	 * arity ARRAY.
-	 */
-	private void addArrayMembers(DefaultMutableTreeNode node, Property p) {
-		Object pVal = p.getValue();
-		PropertyType typ = p.getType();
-		if (null != typ)
-			switch (typ) {
-			case INTEGER: {
-				if (pVal instanceof int[]) {
-					Integer[] vals = Arrays.stream((int[])pVal) // IntStream
-							.boxed()				// Stream<Integer>
-							.toArray(Integer[]::new);
-					addToNode(node, vals);
-				} else {
-					addToNode(node, (Integer[]) pVal);
-				}
-				break;
-			}
-			case LONG: {
-				if (pVal instanceof long[]) {
-					Long[] vals = Arrays.stream((long[])pVal) // IntStream
-							.boxed()				// Stream<Integer>
-							.toArray(Long[]::new);
-					addToNode(node, vals);
-				} else {
-					addToNode(node, (Long[]) pVal);
-				}
-				break;
-			}
-			case BOOLEAN: {
-				addToNode(node, (Boolean[]) pVal);
-				break;
-			}
-			case CHARACTER: {
-				addToNode(node, (Character[]) pVal);
-				break;
-			}
-			case DOUBLE: {
-				if (pVal instanceof double[]) {
-					Double[] vals = Arrays.stream((double[])pVal) // IntStream
-					                    .boxed()				// Stream<Double>
-					                    .toArray(Double[]::new);
-					addToNode(node, vals);
-				} else {
-					addToNode(node, (Double[]) pVal);
-				}
-				break;
-			}
-			case FLOAT: {
-				addToNode(node, (Float[]) pVal);
-				break;
-			}
-			case SHORT: {
-				addToNode(node, (Short[]) pVal);
-				break;
-			}
-			case BYTE: {
-				addToNode(node, (Byte[]) pVal);
-				break;
-			}
-			case STRING: {
-				addToNode(node, (String[]) pVal);
-				break;
-			}
-			case RATIONAL: {
-				addToNode(node, (Rational[]) pVal);
-				break;
-			}
-			case PROPERTY: {
-				addToNode(node, (Property[]) pVal);
-				break;
-			}
-			case NISOIMAGEMETADATA: {
-				addToNode(node, (NisoImageMetadata[]) pVal);
-				break;
-			}
-			case OBJECT: {
-				addToNode(node, (Object[]) pVal);
-				break;
-			}
-			default:
-				break;
-			}
-	}
+    /*
+     * Add the members of a list property to a node. The property must be of
+     * arity LIST.
+     */
+    private void addListMembers(DefaultMutableTreeNode node, Property p) {
+        List<?> l = (List<?>) p.getValue();
+        PropertyType ptyp = p.getType();
+        boolean canHaveChildren = Boolean.FALSE;
+        l.forEach(item -> node.add(getDefaultMutableTreeNode(ptyp, item,
+                canHaveChildren)));
+    }
 
-	/*
-	 * Add the members of a list property to a node. The property must be of
-	 * arity LIST.
-	 */
-	private void addListMembers(DefaultMutableTreeNode node, Property p) {
-		List<?> l = (List<?>) p.getValue();
-		PropertyType ptyp = p.getType();
-		boolean canHaveChildren = Boolean.FALSE;
-		l.forEach(item -> node.add(getDefaultMutableTreeNode(ptyp, item,
-				canHaveChildren)));
-	}
+    /*
+     * Add the members of a set property to a node. The property must be of
+     * arity SET.
+     */
+    private void addSetMembers(DefaultMutableTreeNode node, Property p) {
+        Set<?> s = (Set<?>) p.getValue();
+        PropertyType ptyp = p.getType();
+        boolean canHaveChildren = Boolean.FALSE;
+        Iterator<?> iter = s.iterator();
+        while (iter.hasNext()) {
+            Object item = iter.next();
+            node.add(getDefaultMutableTreeNode(ptyp, item, canHaveChildren));
+        }
+    }
 
-	/*
-	 * Add the members of a set property to a node. The property must be of
-	 * arity SET.
-	 */
-	private void addSetMembers(DefaultMutableTreeNode node, Property p) {
-		Set<?> s = (Set<?>) p.getValue();
-		PropertyType ptyp = p.getType();
-		boolean canHaveChildren = Boolean.FALSE;
-		Iterator<?> iter = s.iterator();
-		while (iter.hasNext()) {
-			Object item = iter.next();
-			node.add(getDefaultMutableTreeNode(ptyp, item, canHaveChildren));
-		}
-	}
+    /*
+     * Add the members of a map property to a node. The property must be of
+     * arity MAP.
+     */
+    private void addMapMembers(DefaultMutableTreeNode node, Property p) {
+        Map<?, ?> m = (Map<?, ?>) p.getValue();
+        PropertyType ptyp = p.getType();
+        Boolean canHaveChildren = Boolean.TRUE;
+        // Iterator iter = m.values ().iterator ();
+        Iterator<?> iter = m.keySet().iterator();
+        while (iter.hasNext()) {
+            DefaultMutableTreeNode itemNode;
+            String key = (String) iter.next();
+            Object item = m.get(key);
+            itemNode = getDefaultMutableTreeNode(ptyp, item, canHaveChildren);
+            node.add(itemNode);
 
-	/*
-	 * Add the members of a map property to a node. The property must be of
-	 * arity MAP.
-	 */
-	private void addMapMembers(DefaultMutableTreeNode node, Property p) {
-		Map<?, ?> m = (Map<?, ?>) p.getValue();
-		PropertyType ptyp = p.getType();
-		Boolean canHaveChildren = Boolean.TRUE;
-		// Iterator iter = m.values ().iterator ();
-		Iterator<?> iter = m.keySet().iterator();
-		while (iter.hasNext()) {
-			DefaultMutableTreeNode itemNode;
-			String key = (String) iter.next();
-			Object item = m.get(key);
-			itemNode = getDefaultMutableTreeNode(ptyp, item, canHaveChildren);
-			node.add(itemNode);
+            // Add a subnode for the key
+            itemNode.setAllowsChildren(true);
+            itemNode.add(new DefaultMutableTreeNode("Key: " + key, false));
+        }
+    }
 
-			// Add a subnode for the key
-			itemNode.setAllowsChildren(true);
-			itemNode.add(new DefaultMutableTreeNode("Key: " + key, false));
-		}
-	}
+    /* Function for turning the AES metadata into a subtree. */
+    private DefaultMutableTreeNode aesToNode(AESAudioMetadata aes) {
+        _sampleRate = aes.getSampleRate();
 
-	/* Function for turning the AES metadata into a subtree. */
-	private DefaultMutableTreeNode aesToNode(AESAudioMetadata aes) {
-		_sampleRate = aes.getSampleRate();
+        DefaultMutableTreeNode val = new DefaultMutableTreeNode(
+                "AESAudioMetadata", true);
+        String s = aes.getAnalogDigitalFlag();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("AnalogDigitalFlag: " + s, false));
+            // The "false" argument signifies this will have no subnodes
+        }
+        s = aes.getSchemaVersion();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("SchemaVersion: " + s, false));
+        }
+        s = aes.getFormat();
+        if (s != null) {
+            DefaultMutableTreeNode fmt = new DefaultMutableTreeNode(FORMAT
+                    + s, true);
+            val.add(fmt);
+            String v = aes.getSpecificationVersion();
+            if (v != null) {
+                fmt.add(new DefaultMutableTreeNode(
+                        "SpecificationVersion: " + v, false));
+            }
+        }
+        s = aes.getAppSpecificData();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("AppSpecificData: " + s, false));
+        }
+        s = aes.getAudioDataEncoding();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("AudioDataEncoding: " + s, false));
+        }
+        int in = aes.getByteOrder();
+        if (in != AESAudioMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode(BYTE_ORDER
+                    + (in == AESAudioMetadata.BIG_ENDIAN ? "BIG_ENDIAN"
+                            : "LITTLE_ENDIAN")));
+        }
+        long lin = aes.getFirstSampleOffset();
+        if (lin != AESAudioMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("FirstSampleOffset: "
+                    + Long.toString(lin)));
+        }
+        String[] use = aes.getUse();
+        if (use != null) {
+            DefaultMutableTreeNode u = new DefaultMutableTreeNode("Use", true);
+            val.add(u);
+            u.add(new DefaultMutableTreeNode("UseType: " + use[0], false));
+            u.add(new DefaultMutableTreeNode("OtherType: " + use[1], false));
+        }
+        s = aes.getPrimaryIdentifier();
+        if (s != null) {
+            String t = aes.getPrimaryIdentifierType();
+            DefaultMutableTreeNode pi = new DefaultMutableTreeNode(
+                    "PrimaryIdentifier: " + s, true);
+            val.add(pi);
+            if (t != null) {
+                pi.add(new DefaultMutableTreeNode("IdentifierType: " + t));
+            }
+        }
+        // Add the face information, which is mostly filler.
+        // In the general case, it can contain multiple Faces;
+        // this isn't supported yet.
+        List<AESAudioMetadata.Face> facelist = aes.getFaceList();
+        if (!facelist.isEmpty()) {
+            AESAudioMetadata.Face f = facelist.get(0);
 
-		DefaultMutableTreeNode val = new DefaultMutableTreeNode(
-				"AESAudioMetadata", true);
-		String s = aes.getAnalogDigitalFlag();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("AnalogDigitalFlag: " + s, false));
-			// The "false" argument signifies this will have no subnodes
-		}
-		s = aes.getSchemaVersion();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("SchemaVersion: " + s, false));
-		}
-		s = aes.getFormat();
-		if (s != null) {
-			DefaultMutableTreeNode fmt = new DefaultMutableTreeNode(FORMAT
-					+ s, true);
-			val.add(fmt);
-			String v = aes.getSpecificationVersion();
-			if (v != null) {
-				fmt.add(new DefaultMutableTreeNode(
-						"SpecificationVersion: " + v, false));
-			}
-		}
-		s = aes.getAppSpecificData();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("AppSpecificData: " + s, false));
-		}
-		s = aes.getAudioDataEncoding();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("AudioDataEncoding: " + s, false));
-		}
-		int in = aes.getByteOrder();
-		if (in != AESAudioMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode(BYTE_ORDER
-					+ (in == AESAudioMetadata.BIG_ENDIAN ? "BIG_ENDIAN"
-							: "LITTLE_ENDIAN")));
-		}
-		long lin = aes.getFirstSampleOffset();
-		if (lin != AESAudioMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("FirstSampleOffset: "
-					+ Long.toString(lin)));
-		}
-		String[] use = aes.getUse();
-		if (use != null) {
-			DefaultMutableTreeNode u = new DefaultMutableTreeNode("Use", true);
-			val.add(u);
-			u.add(new DefaultMutableTreeNode("UseType: " + use[0], false));
-			u.add(new DefaultMutableTreeNode("OtherType: " + use[1], false));
-		}
-		s = aes.getPrimaryIdentifier();
-		if (s != null) {
-			String t = aes.getPrimaryIdentifierType();
-			DefaultMutableTreeNode pi = new DefaultMutableTreeNode(
-					"PrimaryIdentifier: " + s, true);
-			val.add(pi);
-			if (t != null) {
-				pi.add(new DefaultMutableTreeNode("IdentifierType: " + t));
-			}
-		}
-		// Add the face information, which is mostly filler.
-		// In the general case, it can contain multiple Faces;
-		// this isn't supported yet.
-		List<AESAudioMetadata.Face> facelist = aes.getFaceList();
-		if (!facelist.isEmpty()) {
-			AESAudioMetadata.Face f = facelist.get(0);
+            DefaultMutableTreeNode face = new DefaultMutableTreeNode("Face",
+                    true);
+            DefaultMutableTreeNode timeline = new DefaultMutableTreeNode(
+                    "TimeLine", true);
+            AESAudioMetadata.TimeDesc startTime = f.getStartTime();
+            if (startTime != null) {
+                addAESTimeRange(timeline, startTime, f.getDuration());
+            }
+            face.add(timeline);
 
-			DefaultMutableTreeNode face = new DefaultMutableTreeNode("Face",
-					true);
-			DefaultMutableTreeNode timeline = new DefaultMutableTreeNode(
-					"TimeLine", true);
-			AESAudioMetadata.TimeDesc startTime = f.getStartTime();
-			if (startTime != null) {
-				addAESTimeRange(timeline, startTime, f.getDuration());
-			}
-			face.add(timeline);
+            // For the present, assume just one face region
+            AESAudioMetadata.FaceRegion facergn = f.getFaceRegion(0);
+            DefaultMutableTreeNode region = new DefaultMutableTreeNode(
+                    "Region", true);
+            timeline = new DefaultMutableTreeNode("TimeRange", true);
+            addAESTimeRange(timeline, facergn.getStartTime(),
+                    facergn.getDuration());
+            region.add(timeline);
+            int nchan = aes.getNumChannels();
+            if (nchan != AESAudioMetadata.NULL) {
+                region.add(new DefaultMutableTreeNode("NumChannels: "
+                        + Integer.toString(nchan), false));
+                for (int ch = 0; ch < nchan; ch++) {
+                    // write a stream element for each channel
+                    DefaultMutableTreeNode stream = new DefaultMutableTreeNode(
+                            "Stream", true);
+                    region.add(stream);
+                    stream.add(new DefaultMutableTreeNode("ChannelNum: " + Integer.toString(ch), false));
+                }
+            }
+            face.add(region);
+            val.add(face);
+        }
+        // In the general case, a FormatList can contain multiple
+        // FormatRegions. This doesn't happen with any of the current
+        // modules; if it's needed in the future, simply set up an
+        // iteration loop on formatList.
+        List<AESAudioMetadata.FormatRegion> flist = aes.getFormatList();
+        if (!flist.isEmpty()) {
+            AESAudioMetadata.FormatRegion rgn = flist.get(0);
+            int bitDepth = rgn.getBitDepth();
+            double sampleRate = rgn.getSampleRate();
+            int wordSize = rgn.getWordSize();
+            String[] bitRed = rgn.getBitrateReduction();
+            // Build a FormatRegion subtree if at least one piece of data
+            // that goes into it is present.
+            if (bitDepth != AESAudioMetadata.NULL
+                    || sampleRate != AESAudioMetadata.NILL
+                    || wordSize != AESAudioMetadata.NULL) {
+                DefaultMutableTreeNode formatList = new DefaultMutableTreeNode(
+                        "FormatList", true);
+                DefaultMutableTreeNode formatRegion = new DefaultMutableTreeNode(
+                        "FormatRegion", true);
+                if (bitDepth != AESAudioMetadata.NULL) {
+                    formatRegion.add(new DefaultMutableTreeNode("BitDepth: "
+                            + Integer.toString(bitDepth), false));
+                }
+                if (sampleRate != AESAudioMetadata.NILL) {
+                    formatRegion.add(new DefaultMutableTreeNode("SampleRate: "
+                            + Double.toString(sampleRate), false));
+                }
+                if (wordSize != AESAudioMetadata.NULL) {
+                    formatRegion.add(new DefaultMutableTreeNode("WordSize: "
+                            + Integer.toString(bitDepth), false));
+                }
+                if (bitRed != null) {
+                    DefaultMutableTreeNode br = new DefaultMutableTreeNode(
+                            "BitrateReduction", true);
+                    br.add(new DefaultMutableTreeNode(
+                            "codecName: " + bitRed[0], false));
+                    br.add(new DefaultMutableTreeNode("codecNameVersion: "
+                            + bitRed[1], false));
+                    br.add(new DefaultMutableTreeNode(
+                            "codecCreatorApplication: " + bitRed[2], false));
+                    br.add(new DefaultMutableTreeNode(
+                            "codecCreatorApplicationVersion: " + bitRed[3],
+                            false));
+                    br.add(new DefaultMutableTreeNode("codecQuality: "
+                            + bitRed[4], false));
+                    br.add(new DefaultMutableTreeNode("dataRate: " + bitRed[5],
+                            false));
+                    br.add(new DefaultMutableTreeNode("dataRateMode: "
+                            + bitRed[6], false));
+                    formatRegion.add(br);
+                }
+                formatList.add(formatRegion);
+                val.add(formatList);
+            }
+        }
 
-			// For the present, assume just one face region
-			AESAudioMetadata.FaceRegion facergn = f.getFaceRegion(0);
-			DefaultMutableTreeNode region = new DefaultMutableTreeNode(
-					"Region", true);
-			timeline = new DefaultMutableTreeNode("TimeRange", true);
-			addAESTimeRange(timeline, facergn.getStartTime(),
-					facergn.getDuration());
-			region.add(timeline);
-			int nchan = aes.getNumChannels();
-			if (nchan != AESAudioMetadata.NULL) {
-				String[] locs = aes.getMapLocations();
-				region.add(new DefaultMutableTreeNode("NumChannels: "
-						+ Integer.toString(nchan), false));
-				for (String loc : locs) {
-					// write a stream element for each channel
-					DefaultMutableTreeNode stream = new DefaultMutableTreeNode(
-							"Stream", true);
-					region.add(stream);
-					stream.add(new DefaultMutableTreeNode("ChannelAssignment: "
-							+ loc, false));
-				}
-			}
-			face.add(region);
-			val.add(face);
-		}
-		// In the general case, a FormatList can contain multiple
-		// FormatRegions. This doesn't happen with any of the current
-		// modules; if it's needed in the future, simply set up an
-		// iteration loop on formatList.
-		List<AESAudioMetadata.FormatRegion> flist = aes.getFormatList();
-		if (!flist.isEmpty()) {
-			AESAudioMetadata.FormatRegion rgn = flist.get(0);
-			int bitDepth = rgn.getBitDepth();
-			double sampleRate = rgn.getSampleRate();
-			int wordSize = rgn.getWordSize();
-			String[] bitRed = rgn.getBitrateReduction();
-			// Build a FormatRegion subtree if at least one piece of data
-			// that goes into it is present.
-			if (bitDepth != AESAudioMetadata.NULL
-					|| sampleRate != AESAudioMetadata.NILL
-					|| wordSize != AESAudioMetadata.NULL) {
-				DefaultMutableTreeNode formatList = new DefaultMutableTreeNode(
-						"FormatList", true);
-				DefaultMutableTreeNode formatRegion = new DefaultMutableTreeNode(
-						"FormatRegion", true);
-				if (bitDepth != AESAudioMetadata.NULL) {
-					formatRegion.add(new DefaultMutableTreeNode("BitDepth: "
-							+ Integer.toString(bitDepth), false));
-				}
-				if (sampleRate != AESAudioMetadata.NILL) {
-					formatRegion.add(new DefaultMutableTreeNode("SampleRate: "
-							+ Double.toString(sampleRate), false));
-				}
-				if (wordSize != AESAudioMetadata.NULL) {
-					formatRegion.add(new DefaultMutableTreeNode("WordSize: "
-							+ Integer.toString(bitDepth), false));
-				}
-				if (bitRed != null) {
-					DefaultMutableTreeNode br = new DefaultMutableTreeNode(
-							"BitrateReduction", true);
-					br.add(new DefaultMutableTreeNode(
-							"codecName: " + bitRed[0], false));
-					br.add(new DefaultMutableTreeNode("codecNameVersion: "
-							+ bitRed[1], false));
-					br.add(new DefaultMutableTreeNode(
-							"codecCreatorApplication: " + bitRed[2], false));
-					br.add(new DefaultMutableTreeNode(
-							"codecCreatorApplicationVersion: " + bitRed[3],
-							false));
-					br.add(new DefaultMutableTreeNode("codecQuality: "
-							+ bitRed[4], false));
-					br.add(new DefaultMutableTreeNode("dataRate: " + bitRed[5],
-							false));
-					br.add(new DefaultMutableTreeNode("dataRateMode: "
-							+ bitRed[6], false));
-					formatRegion.add(br);
-				}
-				formatList.add(formatRegion);
-				val.add(formatList);
-			}
-		}
+        return val;
+    }
 
-		return val;
-	}
+    private void addAESTimeRange(DefaultMutableTreeNode parent,
+            AESAudioMetadata.TimeDesc start, AESAudioMetadata.TimeDesc duration) {
+        writeAESTimeRangePart(parent, "StartTime", start);
+        // Duration is optional.
+        if (duration != null) {
+            writeAESTimeRangePart(parent, "Duration", duration);
+        }
+    }
 
-	private void addAESTimeRange(DefaultMutableTreeNode parent,
-			AESAudioMetadata.TimeDesc start, AESAudioMetadata.TimeDesc duration) {
-		// Put the start time in
-		DefaultMutableTreeNode node = new DefaultMutableTreeNode("Start", true);
-		// Put in boilerplate to match the AES schema
-		node.add(new DefaultMutableTreeNode(FRAME_COUNT_30, false));
-		node.add(new DefaultMutableTreeNode(TIME_BASE_1000));
-		node.add(new DefaultMutableTreeNode(VIDEO_FIELD_FIELD_1));
-		node.add(new DefaultMutableTreeNode(
-				COUNTING_MODE_NTSC_NON_DROP_FRAME, false));
-		node.add(new DefaultMutableTreeNode(HOURS + start.getHours(), false));
-		node.add(new DefaultMutableTreeNode(MINUTES + start.getMinutes(),
-				false));
-		node.add(new DefaultMutableTreeNode(SECONDS + start.getSeconds(),
-				false));
-		node.add(new DefaultMutableTreeNode(FRAMES + start.getFrames(),
-				false));
+    private void writeAESTimeRangePart(DefaultMutableTreeNode parent,
+            String name, AESAudioMetadata.TimeDesc timeDesc) {
+        double sampleRate = timeDesc.getSampleRate();
+        if (sampleRate == 1.0) {
+            sampleRate = _sampleRate;
+        }
 
-		// Do samples a bit more elaborately than is really necessary,
-		// to maintain parallelism with the xml schema.
-		DefaultMutableTreeNode snode = new DefaultMutableTreeNode(SAMPLES,
-				true);
-		double sr = start.getSampleRate();
-		if (sr == 1.0) {
-			sr = _sampleRate;
-		}
-		snode.add(new DefaultMutableTreeNode("SampleRate: S"
-				+ Integer.toString((int) sr), false));
-		snode.add(new DefaultMutableTreeNode(NUMBER_OF_SAMPLES
-				+ start.getSamples(), false));
-		node.add(snode);
+        DefaultMutableTreeNode node = new DefaultMutableTreeNode(name, true);
+        node.add(new DefaultMutableTreeNode(
+                "Value: " + String.valueOf(timeDesc.getSamples()), false));
+        node.add(new DefaultMutableTreeNode(
+                "EditRate: " + sampleRate, false));
+        node.add(new DefaultMutableTreeNode(
+                "FactorNumerator: 1", false));
+        node.add(new DefaultMutableTreeNode(
+                "FactorDenominator: 1", false));
 
-		snode = new DefaultMutableTreeNode(FILM_FRAMING, true);
-		snode.add(new DefaultMutableTreeNode(FRAMING_NOT_APPLICABLE, false));
-		snode.add(new DefaultMutableTreeNode(NTSC_FILM_FRAMING_TYPE, false));
-		node.add(snode);
-		parent.add(node);
+        parent.add(node);
+    }
 
-		// Duration is optional.
-		if (duration != null) {
-			node = new DefaultMutableTreeNode("Duration", true);
-			// Put in boilerplate to match the AES schema
-			node.add(new DefaultMutableTreeNode(FRAME_COUNT_30, false));
-			node.add(new DefaultMutableTreeNode(TIME_BASE_1000));
-			node.add(new DefaultMutableTreeNode(VIDEO_FIELD_FIELD_1));
-			node.add(new DefaultMutableTreeNode(
-					COUNTING_MODE_NTSC_NON_DROP_FRAME, false));
-			node.add(new DefaultMutableTreeNode(
-					HOURS + duration.getHours(), false));
-			node.add(new DefaultMutableTreeNode(MINUTES
-					+ duration.getMinutes(), false));
-			node.add(new DefaultMutableTreeNode(SECONDS
-					+ duration.getSeconds(), false));
-			node.add(new DefaultMutableTreeNode(FRAMES
-					+ duration.getFrames(), false));
+    /* Function for turning the textMD metadata into a subtree. */
+    private DefaultMutableTreeNode textMDToNode(TextMDMetadata textMD) {
+        DefaultMutableTreeNode val = new DefaultMutableTreeNode(
+                TEXT_MD_METADTA, true);
 
-			// Do samples a bit more elaborately than is really necessary,
-			// to maintain parallelism with the xml schema.
-			snode = new DefaultMutableTreeNode(SAMPLES, true);
-			sr = duration.getSampleRate();
-			if (sr == 1.0) {
-				sr = _sampleRate;
-			}
-			snode.add(new DefaultMutableTreeNode("SamplesRate S"
-					+ Integer.toString((int) sr), false));
-			snode.add(new DefaultMutableTreeNode(NUMBER_OF_SAMPLES
-					+ duration.getSamples(), false));
-			node.add(snode);
+        DefaultMutableTreeNode u = new DefaultMutableTreeNode("Character_info",
+                true);
+        val.add(u);
 
-			snode = new DefaultMutableTreeNode(FILM_FRAMING, true);
-			snode.add(new DefaultMutableTreeNode(FRAMING_NOT_APPLICABLE,
-					false));
-			snode.add(new DefaultMutableTreeNode(NTSC_FILM_FRAMING_TYPE,
-					false));
-			node.add(snode);
-			parent.add(node);
-		}
-	}
+        String s = textMD.getCharset();
+        if (s != null) {
+            u.add(new DefaultMutableTreeNode("Charset: " + s, false));
+        }
+        s = textMD.getByte_orderString();
+        if (s != null) {
+            u.add(new DefaultMutableTreeNode("Byte_order: " + s, false));
+        }
+        s = textMD.getByte_size();
+        if (s != null) {
+            u.add(new DefaultMutableTreeNode("Byte_size: " + s, false));
+        }
+        s = textMD.getCharacter_size();
+        if (s != null) {
+            u.add(new DefaultMutableTreeNode("Character_size: " + s, false));
+        }
+        s = textMD.getLinebreakString();
+        if (s != null) {
+            u.add(new DefaultMutableTreeNode("Linebreak: " + s, false));
+        }
+        s = textMD.getLanguage();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("Language: " + s, false));
+        }
+        s = textMD.getMarkup_basis();
+        if (s != null) {
+            DefaultMutableTreeNode basis = new DefaultMutableTreeNode(
+                    "Markup_basis: " + s, true);
+            val.add(basis);
+            s = textMD.getMarkup_basis_version();
+            if (s != null) {
+                basis.add(new DefaultMutableTreeNode(VERSION + s, false));
+            }
+        }
+        s = textMD.getMarkup_language();
+        if (s != null) {
+            DefaultMutableTreeNode language = new DefaultMutableTreeNode(
+                    "Markup_language: " + s, true);
+            val.add(language);
+            s = textMD.getMarkup_language_version();
+            if (s != null) {
+                language.add(new DefaultMutableTreeNode(VERSION + s, false));
+            }
+        }
+        return val;
+    }
 
-	/* Function for turning the textMD metadata into a subtree. */
-	private DefaultMutableTreeNode textMDToNode(TextMDMetadata textMD) {
-		DefaultMutableTreeNode val = new DefaultMutableTreeNode(
-				TEXT_MD_METADTA, true);
+    /* Function for turning the Niso metadata into a subtree. */
+    private DefaultMutableTreeNode nisoToNode(NisoImageMetadata niso) {
+        DefaultMutableTreeNode val = new DefaultMutableTreeNode(
+                "NisoImageMetadata", true);
+        String s = niso.getMimeType();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode("FormatName: " + s, false));
+        }
+        s = niso.getByteOrder();
+        if (s != null) {
+            val.add(new DefaultMutableTreeNode(BYTE_ORDER + s, false));
+        }
 
-		DefaultMutableTreeNode u = new DefaultMutableTreeNode("Character_info",
-				true);
-		val.add(u);
+        int n = niso.getCompressionScheme();
+        if (n != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("CompressionScheme: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.COMPRESSION_SCHEME,
+                            NisoImageMetadata.COMPRESSION_SCHEME_INDEX),
+                    false));
+        }
+        if ((n = niso.getCompressionLevel()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("CompressionLevel: "
+                    + Integer.toString(n), false));
+        }
+        if ((n = niso.getColorSpace()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("ColorSpace: "
+                    + integerRepresentation(n, NisoImageMetadata.COLORSPACE,
+                            NisoImageMetadata.COLORSPACE_INDEX),
+                    false));
+        }
+        if ((s = niso.getProfileName()) != null) {
+            val.add(new DefaultMutableTreeNode("ProfileName: " + s, false));
+        }
+        if ((s = niso.getProfileURL()) != null) {
+            val.add(new DefaultMutableTreeNode("ProfileURL: " + s, false));
+        }
+        int[] iarray = niso.getYCbCrSubSampling();
+        if (iarray != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "YCbCrSubSampling"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((n = niso.getYCbCrPositioning()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("YCbCrPositioning: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.YCBCR_POSITIONING),
+                    false));
+        }
+        Rational[] rarray = niso.getYCbCrCoefficients();
+        if (rarray != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "YCbCrCoefficients", true));
+            val.add(nod);
+            for (int i = 0; i < rarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(rarray[i].toString(), false));
+            }
+        }
+        rarray = niso.getReferenceBlackWhite();
+        if (rarray != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ReferenceBlackWhite", true));
+            val.add(nod);
+            for (int i = 0; i < rarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(rarray[i].toString(), false));
+            }
+        }
+        if ((n = niso.getSegmentType()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("YSegmentType: "
+                    + integerRepresentation(n, NisoImageMetadata.SEGMENT_TYPE),
+                    false));
+        }
+        long[] larray = niso.getStripOffsets();
+        if (larray != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "StripOffsets", true));
+            val.add(nod);
+            for (int i = 0; i < larray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
+                        false));
+            }
+        }
+        long ln = niso.getRowsPerStrip();
+        if (ln != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("RowsPerStrip: "
+                    + Long.toString(ln), false));
+        }
+        if ((larray = niso.getStripByteCounts()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "StripByteCounts", true));
+            val.add(nod);
+            for (int i = 0; i < larray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
+                        false));
+            }
+        }
+        if ((ln = niso.getTileWidth()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("TileWidth: "
+                    + Long.toString(ln)));
+        }
+        if ((ln = niso.getTileLength()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("TileLength: "
+                    + Long.toString(ln)));
+        }
+        if ((larray = niso.getTileOffsets()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "TileOffsets", true));
+            val.add(nod);
+            for (int i = 0; i < larray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
+                        false));
+            }
+        }
+        if ((larray = niso.getTileByteCounts()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "TileByteCounts", true));
+            val.add(nod);
+            for (int i = 0; i < larray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
+                        false));
+            }
+        }
+        if ((n = niso.getPlanarConfiguration()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("PlanarConfiguration: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.PLANAR_CONFIGURATION),
+                    false));
+        }
+        if ((s = niso.getImageIdentifier()) != null) {
+            val.add(new DefaultMutableTreeNode("ImageIdentifier: " + s, false));
+        }
+        if ((s = niso.getImageIdentifierLocation()) != null) {
+            val.add(new DefaultMutableTreeNode("ImageIdentifierLocation: " + s,
+                    false));
+        }
+        if ((ln = niso.getFileSize()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode(
+                    "FileSize: " + Long.toString(ln), false));
+        }
+        if ((n = niso.getChecksumMethod()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("ChecksumMethod: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.CHECKSUM_METHOD),
+                    false));
+        }
+        if ((s = niso.getChecksumValue()) != null) {
+            val.add(new DefaultMutableTreeNode("ChecksumValue: " + s, false));
+        }
+        if ((n = niso.getOrientation()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("Orientation: "
+                    + integerRepresentation(n, NisoImageMetadata.ORIENTATION),
+                    false));
+        }
+        if ((n = niso.getDisplayOrientation()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("DisplayOrientation: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.DISPLAY_ORIENTATION),
+                    false));
+        }
+        if ((ln = niso.getXTargetedDisplayAR()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("XTargetedDisplayAR: "
+                    + Long.toString(ln), false));
+        }
+        if ((ln = niso.getYTargetedDisplayAR()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("YTargetedDisplayAR: "
+                    + Long.toString(ln), false));
+        }
+        if ((s = niso.getPreferredPresentation()) != null) {
+            val.add(new DefaultMutableTreeNode("PreferredPresentation: " + s,
+                    false));
+        }
+        if ((s = niso.getSourceType()) != null) {
+            val.add(new DefaultMutableTreeNode("SourceType: " + s, false));
+        }
+        if ((s = niso.getImageProducer()) != null) {
+            val.add(new DefaultMutableTreeNode("ImageProducer: " + s, false));
+        }
+        if ((s = niso.getHostComputer()) != null) {
+            val.add(new DefaultMutableTreeNode("HostComputer: " + s, false));
+        }
+        if ((s = niso.getOS()) != null) {
+            val.add(new DefaultMutableTreeNode("OperatingSystem: " + s, false));
+        }
+        if ((s = niso.getOSVersion()) != null) {
+            val.add(new DefaultMutableTreeNode("OSVersion: " + s, false));
+        }
+        if ((s = niso.getDeviceSource()) != null) {
+            val.add(new DefaultMutableTreeNode("DeviceSource: " + s, false));
+        }
+        if ((s = niso.getScannerManufacturer()) != null) {
+            val.add(new DefaultMutableTreeNode("ScannerManufacturer: " + s,
+                    false));
+        }
+        if ((s = niso.getScannerModelName()) != null) {
+            val.add(new DefaultMutableTreeNode("ScannerModelName: " + s, false));
+        }
+        if ((s = niso.getScannerModelNumber()) != null) {
+            val.add(new DefaultMutableTreeNode("ScannerModelNumber: " + s,
+                    false));
+        }
+        if ((s = niso.getScannerModelSerialNo()) != null) {
+            val.add(new DefaultMutableTreeNode("ScannerModelSerialNo: " + s,
+                    false));
+        }
+        if ((s = niso.getScanningSoftware()) != null) {
+            val.add(new DefaultMutableTreeNode("ScanningSoftware: " + s, false));
+        }
+        if ((s = niso.getScanningSoftwareVersionNo()) != null) {
+            val.add(new DefaultMutableTreeNode("ScanningSoftwareVersionNo: "
+                    + s, false));
+        }
+        double d = niso.getPixelSize();
+        if (d != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("PixelSize: "
+                    + Double.toString(d), false));
+        }
+        if ((d = niso.getXPhysScanResolution()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("XPhysScanResolution: "
+                    + Double.toString(d), false));
+        }
+        if ((d = niso.getYPhysScanResolution()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("YPhysScanResolution: "
+                    + Double.toString(d), false));
+        }
 
-		String s = textMD.getCharset();
-		if (s != null) {
-			u.add(new DefaultMutableTreeNode("Charset: " + s, false));
-		}
-		s = textMD.getByte_orderString();
-		if (s != null) {
-			u.add(new DefaultMutableTreeNode("Byte_order: " + s, false));
-		}
-		s = textMD.getByte_size();
-		if (s != null) {
-			u.add(new DefaultMutableTreeNode("Byte_size: " + s, false));
-		}
-		s = textMD.getCharacter_size();
-		if (s != null) {
-			u.add(new DefaultMutableTreeNode("Character_size: " + s, false));
-		}
-		s = textMD.getLinebreakString();
-		if (s != null) {
-			u.add(new DefaultMutableTreeNode("Linebreak: " + s, false));
-		}
-		s = textMD.getLanguage();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("Language: " + s, false));
-		}
-		s = textMD.getMarkup_basis();
-		if (s != null) {
-			DefaultMutableTreeNode basis = new DefaultMutableTreeNode(
-					"Markup_basis: " + s, true);
-			val.add(basis);
-			s = textMD.getMarkup_basis_version();
-			if (s != null) {
-				basis.add(new DefaultMutableTreeNode(VERSION + s, false));
-			}
-		}
-		s = textMD.getMarkup_language();
-		if (s != null) {
-			DefaultMutableTreeNode language = new DefaultMutableTreeNode(
-					"Markup_language: " + s, true);
-			val.add(language);
-			s = textMD.getMarkup_language_version();
-			if (s != null) {
-				language.add(new DefaultMutableTreeNode(VERSION + s, false));
-			}
-		}
-		return val;
-	}
+        if ((s = niso.getDigitalCameraManufacturer()) != null) {
+            val.add(new DefaultMutableTreeNode("DigitalCameraManufacturer: "
+                    + s, false));
+        }
+        if ((s = niso.getDigitalCameraModelName()) != null) {
+            val.add(new DefaultMutableTreeNode("DigitalCameraModelName: " + s,
+                    false));
+        }
+        if ((s = niso.getDigitalCameraModelNumber()) != null) {
+            val.add(new DefaultMutableTreeNode(
+                    "DigitalCameraModelNumber: " + s, false));
+        }
+        if ((s = niso.getDigitalCameraModelSerialNo()) != null) {
+            val.add(new DefaultMutableTreeNode("DigitalCameraModelSerialNo: "
+                    + s, false));
+        }
+        if ((d = niso.getFNumber()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode(
+                    "FNumber: " + Double.toString(d), false));
+        }
+        if ((d = niso.getExposureTime()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("ExposureTime: "
+                    + Double.toString(d), false));
+        }
+        if ((n = niso.getExposureProgram()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("ExposureProgram: "
+                    + Integer.toString(n), false));
+        }
+        if ((s = niso.getExifVersion()) != null) {
+            val.add(new DefaultMutableTreeNode("ExifVersion: " + s, false));
+        }
+        Rational r;
+        if ((r = niso.getBrightness()) != null) {
+            val.add(new DefaultMutableTreeNode("Brightness: " + r.toString(),
+                    false));
+        }
+        if ((r = niso.getExposureBias()) != null) {
+            val.add(new DefaultMutableTreeNode("ExposureBias: " + r.toString(),
+                    false));
+        }
 
-	/* Function for turning the Niso metadata into a subtree. */
-	private DefaultMutableTreeNode nisoToNode(NisoImageMetadata niso) {
-		DefaultMutableTreeNode val = new DefaultMutableTreeNode(
-				"NisoImageMetadata", true);
-		String s = niso.getMimeType();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode("FormatName: " + s, false));
-		}
-		s = niso.getByteOrder();
-		if (s != null) {
-			val.add(new DefaultMutableTreeNode(BYTE_ORDER + s, false));
-		}
+        double[] darray = niso.getSubjectDistance();
+        if (darray != null) {
+            DefaultMutableTreeNode nod = new DefaultMutableTreeNode(
+                    "SubjectDistance", true);
+            val.add(nod);
+            for (int i = 0; i < darray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Double.toString(darray[i]),
+                        false));
+            }
+        }
+        if ((n = niso.getMeteringMode()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("MeteringMode: "
+                    + Integer.toString(n), false));
+        }
+        if ((n = niso.getSceneIlluminant()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SceneIlluminant: "
+                    + Integer.toString(n), false));
+        }
+        if ((d = niso.getColorTemp()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("ColorTemp: "
+                    + Double.toString(d), false));
+        }
+        if ((d = niso.getFocalLength()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("FocalLength: "
+                    + Double.toString(d), false));
+        }
+        if ((n = niso.getFlash()) != NisoImageMetadata.NULL) {
+            // First bit (0 = Flash did not fire, 1 = Flash fired)
+            val.add(new DefaultMutableTreeNode("Flash: "
+                    + integerRepresentation(n & 1, NisoImageMetadata.FLASH_20),
+                    false));
+        }
+        if ((r = niso.getFlashEnergy()) != null) {
+            val.add(new DefaultMutableTreeNode("FlashEnergy: " + r.toString(),
+                    false));
+        }
+        if ((n = niso.getFlashReturn()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("FlashReturn: "
+                    + integerRepresentation(n, NisoImageMetadata.FLASH_RETURN),
+                    false));
+        }
+        if ((n = niso.getBackLight()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("BackLight: "
+                    + integerRepresentation(n, NisoImageMetadata.BACKLIGHT),
+                    false));
+        }
+        if ((d = niso.getExposureIndex()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("ExposureIndex: "
+                    + Double.toString(d), false));
+        }
+        if ((n = niso.getAutoFocus()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("AutoFocus: "
+                    + Integer.toString(n), false));
+            // NisoImageMetadata.AUTOFOCUS
+        }
+        if ((d = niso.getXPrintAspectRatio()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("XPrintAspectRatio: "
+                    + Double.toString(d), false));
+        }
+        if ((d = niso.getYPrintAspectRatio()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("YPrintAspectRatio: "
+                    + Double.toString(d), false));
+        }
 
-		int n = niso.getCompressionScheme();
-		if (n != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("CompressionScheme: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.COMPRESSION_SCHEME,
-							NisoImageMetadata.COMPRESSION_SCHEME_INDEX), false));
-		}
-		if ((n = niso.getCompressionLevel()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("CompressionLevel: "
-					+ Integer.toString(n), false));
-		}
-		if ((n = niso.getColorSpace()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("ColorSpace: "
-					+ integerRepresentation(n, NisoImageMetadata.COLORSPACE,
-							NisoImageMetadata.COLORSPACE_INDEX), false));
-		}
-		if ((s = niso.getProfileName()) != null) {
-			val.add(new DefaultMutableTreeNode("ProfileName: " + s, false));
-		}
-		if ((s = niso.getProfileURL()) != null) {
-			val.add(new DefaultMutableTreeNode("ProfileURL: " + s, false));
-		}
-		int[] iarray = niso.getYCbCrSubSampling();
-		if (iarray != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"YCbCrSubSampling"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((n = niso.getYCbCrPositioning()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("YCbCrPositioning: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.YCBCR_POSITIONING), false));
-		}
-		Rational[] rarray = niso.getYCbCrCoefficients();
-		if (rarray != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"YCbCrCoefficients", true));
-			val.add(nod);
-			for (int i = 0; i < rarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(rarray[i].toString(), false));
-			}
-		}
-		rarray = niso.getReferenceBlackWhite();
-		if (rarray != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ReferenceBlackWhite", true));
-			val.add(nod);
-			for (int i = 0; i < rarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(rarray[i].toString(), false));
-			}
-		}
-		if ((n = niso.getSegmentType()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("YSegmentType: "
-					+ integerRepresentation(n, NisoImageMetadata.SEGMENT_TYPE),
-					false));
-		}
-		long[] larray = niso.getStripOffsets();
-		if (larray != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"StripOffsets", true));
-			val.add(nod);
-			for (int i = 0; i < larray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
-						false));
-			}
-		}
-		long ln = niso.getRowsPerStrip();
-		if (ln != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("RowsPerStrip: "
-					+ Long.toString(ln), false));
-		}
-		if ((larray = niso.getStripByteCounts()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"StripByteCounts", true));
-			val.add(nod);
-			for (int i = 0; i < larray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
-						false));
-			}
-		}
-		if ((ln = niso.getTileWidth()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("TileWidth: "
-					+ Long.toString(ln)));
-		}
-		if ((ln = niso.getTileLength()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("TileLength: "
-					+ Long.toString(ln)));
-		}
-		if ((larray = niso.getTileOffsets()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"TileOffsets", true));
-			val.add(nod);
-			for (int i = 0; i < larray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
-						false));
-			}
-		}
-		if ((larray = niso.getTileByteCounts()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"TileByteCounts", true));
-			val.add(nod);
-			for (int i = 0; i < larray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Long.toString(larray[i]),
-						false));
-			}
-		}
-		if ((n = niso.getPlanarConfiguration()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("PlanarConfiguration: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.PLANAR_CONFIGURATION), false));
-		}
-		if ((s = niso.getImageIdentifier()) != null) {
-			val.add(new DefaultMutableTreeNode("ImageIdentifier: " + s, false));
-		}
-		if ((s = niso.getImageIdentifierLocation()) != null) {
-			val.add(new DefaultMutableTreeNode("ImageIdentifierLocation: " + s,
-					false));
-		}
-		if ((ln = niso.getFileSize()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode(
-					"FileSize: " + Long.toString(ln), false));
-		}
-		if ((n = niso.getChecksumMethod()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("ChecksumMethod: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.CHECKSUM_METHOD), false));
-		}
-		if ((s = niso.getChecksumValue()) != null) {
-			val.add(new DefaultMutableTreeNode("ChecksumValue: " + s, false));
-		}
-		if ((n = niso.getOrientation()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("Orientation: "
-					+ integerRepresentation(n, NisoImageMetadata.ORIENTATION),
-					false));
-		}
-		if ((n = niso.getDisplayOrientation()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("DisplayOrientation: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.DISPLAY_ORIENTATION), false));
-		}
-		if ((ln = niso.getXTargetedDisplayAR()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("XTargetedDisplayAR: "
-					+ Long.toString(ln), false));
-		}
-		if ((ln = niso.getYTargetedDisplayAR()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("YTargetedDisplayAR: "
-					+ Long.toString(ln), false));
-		}
-		if ((s = niso.getPreferredPresentation()) != null) {
-			val.add(new DefaultMutableTreeNode("PreferredPresentation: " + s,
-					false));
-		}
-		if ((s = niso.getSourceType()) != null) {
-			val.add(new DefaultMutableTreeNode("SourceType: " + s, false));
-		}
-		if ((s = niso.getImageProducer()) != null) {
-			val.add(new DefaultMutableTreeNode("ImageProducer: " + s, false));
-		}
-		if ((s = niso.getHostComputer()) != null) {
-			val.add(new DefaultMutableTreeNode("HostComputer: " + s, false));
-		}
-		if ((s = niso.getOS()) != null) {
-			val.add(new DefaultMutableTreeNode("OperatingSystem: " + s, false));
-		}
-		if ((s = niso.getOSVersion()) != null) {
-			val.add(new DefaultMutableTreeNode("OSVersion: " + s, false));
-		}
-		if ((s = niso.getDeviceSource()) != null) {
-			val.add(new DefaultMutableTreeNode("DeviceSource: " + s, false));
-		}
-		if ((s = niso.getScannerManufacturer()) != null) {
-			val.add(new DefaultMutableTreeNode("ScannerManufacturer: " + s,
-					false));
-		}
-		if ((s = niso.getScannerModelName()) != null) {
-			val.add(new DefaultMutableTreeNode("ScannerModelName: " + s, false));
-		}
-		if ((s = niso.getScannerModelNumber()) != null) {
-			val.add(new DefaultMutableTreeNode("ScannerModelNumber: " + s,
-					false));
-		}
-		if ((s = niso.getScannerModelSerialNo()) != null) {
-			val.add(new DefaultMutableTreeNode("ScannerModelSerialNo: " + s,
-					false));
-		}
-		if ((s = niso.getScanningSoftware()) != null) {
-			val.add(new DefaultMutableTreeNode("ScanningSoftware: " + s, false));
-		}
-		if ((s = niso.getScanningSoftwareVersionNo()) != null) {
-			val.add(new DefaultMutableTreeNode("ScanningSoftwareVersionNo: "
-					+ s, false));
-		}
-		double d = niso.getPixelSize();
-		if (d != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("PixelSize: "
-					+ Double.toString(d), false));
-		}
-		if ((d = niso.getXPhysScanResolution()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("XPhysScanResolution: "
-					+ Double.toString(d), false));
-		}
-		if ((d = niso.getYPhysScanResolution()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("YPhysScanResolution: "
-					+ Double.toString(d), false));
-		}
+        if ((n = niso.getSensor()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("Sensor: "
+                    + integerRepresentation(n, NisoImageMetadata.SENSOR), false));
+        }
+        if ((s = niso.getDateTimeCreated()) != null) {
+            val.add(new DefaultMutableTreeNode("DateTimeCreated: " + s, false));
+        }
+        if ((s = niso.getMethodology()) != null) {
+            val.add(new DefaultMutableTreeNode("Methodology: " + s, false));
+        }
+        if ((n = niso.getSamplingFrequencyPlane()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SamplingFrequencyPlane: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.SAMPLING_FREQUENCY_PLANE),
+                    false));
+        }
+        if ((n = niso.getSamplingFrequencyUnit()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SamplingFrequencyUnit: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.SAMPLING_FREQUENCY_UNIT),
+                    false));
+        }
+        Rational rat = niso.getXSamplingFrequency();
+        if (rat != null) {
+            val.add(new DefaultMutableTreeNode("XSamplingFrequency: "
+                    + rat.toString(), false));
+        }
+        rat = niso.getYSamplingFrequency();
+        if (rat != null) {
+            val.add(new DefaultMutableTreeNode("YSamplingFrequency: "
+                    + rat.toString(), false));
+        }
+        if ((ln = niso.getImageWidth()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("ImageWidth: "
+                    + Long.toString(ln), false));
+        }
+        if ((ln = niso.getImageLength()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("ImageLength: "
+                    + Long.toString(ln), false));
+        }
+        if ((d = niso.getSourceXDimension()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("SourceXDimension: "
+                    + Double.toString(d), false));
+        }
+        if ((n = niso.getSourceXDimensionUnit()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SourceXDimensionUnit: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.SOURCE_DIMENSION_UNIT),
+                    false));
+        }
+        if ((d = niso.getSourceYDimension()) != NisoImageMetadata.NILL) {
+            val.add(new DefaultMutableTreeNode("SourceYDimension: "
+                    + Double.toString(d), false));
+        }
+        if ((n = niso.getSourceYDimensionUnit()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SourceYDimensionUnit: "
+                    + integerRepresentation(n,
+                            NisoImageMetadata.SOURCE_DIMENSION_UNIT),
+                    false));
+        }
+        if ((iarray = niso.getBitsPerSample()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "BitsPerSample"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+                // BitsPerSampleUnit Integer is assumed, because of BitsPerSample
+                // According to the specification, it can also be float.
+                // This is currently not supported by jHove
+                nod.add(new DefaultMutableTreeNode("Integer"));
+            }
+        }
+        if ((n = niso.getSamplesPerPixel()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("SamplesPerPixel: "
+                    + Integer.toString(n), false));
+        }
+        if ((iarray = niso.getExtraSamples()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ExtraSamples"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(integerRepresentation(
+                        iarray[i], NisoImageMetadata.EXTRA_SAMPLES), false));
+            }
+        }
+        if ((s = niso.getColormapReference()) != null) {
+            val.add(new DefaultMutableTreeNode("ColormapReference: " + s));
+        }
+        if ((iarray = niso.getColormapBitCodeValue()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ColormapBitCodeValue"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((iarray = niso.getColormapRedValue()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ColormapRedValue"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((iarray = niso.getColormapGreenValue()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ColormapGreenValue"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((iarray = niso.getColormapBlueValue()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "ColormapBlueValue"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((iarray = niso.getGrayResponseCurve()) != null) {
+            DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
+                    "GrayResponseCurve"));
+            val.add(nod);
+            for (int i = 0; i < iarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
+                        false));
+            }
+        }
+        if ((n = niso.getGrayResponseUnit()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("GrayResponseUnit: "
+                    + Integer.toString(n), false));
+        }
+        r = niso.getWhitePointXValue();
+        if (r != null) {
+            val.add(new DefaultMutableTreeNode("WhitePointXValue: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getWhitePointYValue()) != null) {
+            val.add(new DefaultMutableTreeNode("WhitePointYValue: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getPrimaryChromaticitiesRedX()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesRedX: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getPrimaryChromaticitiesRedY()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesRedY: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getPrimaryChromaticitiesGreenX()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesGreenX: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getPrimaryChromaticitiesGreenY()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesGreenY: "
+                    + r.toString(), false));
+        }
+        if ((r = niso.getPrimaryChromaticitiesBlueX()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesBlueX: "
+                    + r.toString()));
+        }
+        if ((r = niso.getPrimaryChromaticitiesBlueY()) != null) {
+            val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesBlueY: "
+                    + r.toString()));
+        }
+        if ((n = niso.getTargetType()) != NisoImageMetadata.NULL) {
+            val.add(new DefaultMutableTreeNode("TargetType: "
+                    + integerRepresentation(n, NisoImageMetadata.TARGET_TYPE),
+                    false));
+        }
+        if ((s = niso.getTargetIDManufacturer()) != null) {
+            val.add(new DefaultMutableTreeNode("TargetIDManufacturer: " + s,
+                    false));
+        }
+        if ((s = niso.getTargetIDName()) != null) {
+            val.add(new DefaultMutableTreeNode("TargetIDName: " + s, false));
+        }
+        if ((s = niso.getTargetIDNo()) != null) {
+            val.add(new DefaultMutableTreeNode("TargetIDNo: " + s, false));
+        }
+        if ((s = niso.getTargetIDMedia()) != null) {
+            val.add(new DefaultMutableTreeNode("TargetIDMedia: " + s, false));
+        }
+        if ((s = niso.getImageData()) != null) {
+            val.add(new DefaultMutableTreeNode("ImageData: " + s, false));
+        }
+        if ((s = niso.getPerformanceData()) != null) {
+            val.add(new DefaultMutableTreeNode("PerformanceData: " + s, false));
+        }
+        if ((s = niso.getProfiles()) != null) {
+            val.add(new DefaultMutableTreeNode("Profiles: " + s, false));
+        }
+        if ((s = niso.getDateTimeProcessed()) != null) {
+            val.add(new DefaultMutableTreeNode("DateTimeProcessed: " + s, false));
+        }
+        if ((s = niso.getSourceData()) != null) {
+            val.add(new DefaultMutableTreeNode("SourceData: " + s, false));
+        }
+        if ((s = niso.getProcessingAgency()) != null) {
+            val.add(new DefaultMutableTreeNode("ProcessingAgency: " + s, false));
+        }
+        if ((s = niso.getProcessingSoftwareName()) != null) {
+            val.add(new DefaultMutableTreeNode("ProcessingSoftwareName: " + s,
+                    false));
+        }
+        if ((s = niso.getProcessingSoftwareVersion()) != null) {
+            val.add(new DefaultMutableTreeNode("ProcessingSoftwareVersion: "
+                    + s, false));
+        }
+        String[] sarray = niso.getProcessingActions();
+        if (sarray != null) {
+            DefaultMutableTreeNode nod = new DefaultMutableTreeNode(
+                    "ProcessingActions", true);
+            val.add(nod);
+            for (int i = 1; i < sarray.length; i++) {
+                nod.add(new DefaultMutableTreeNode(sarray[i], false));
+            }
+        }
+        return val;
+    }
 
-		if ((s = niso.getDigitalCameraManufacturer()) != null) {
-			val.add(new DefaultMutableTreeNode("DigitalCameraManufacturer: "
-					+ s, false));
-		}
-		if ((s = niso.getDigitalCameraModelName()) != null) {
-			val.add(new DefaultMutableTreeNode("DigitalCameraModelName: " + s,
-					false));
-		}
-		if ((s = niso.getDigitalCameraModelNumber()) != null) {
-			val.add(new DefaultMutableTreeNode(
-					"DigitalCameraModelNumber: " + s, false));
-		}
-		if ((s = niso.getDigitalCameraModelSerialNo()) != null) {
-			val.add(new DefaultMutableTreeNode("DigitalCameraModelSerialNo: "
-					+ s, false));
-		}
-		if ((d = niso.getFNumber()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode(
-					"FNumber: " + Double.toString(d), false));
-		}
-		if ((d = niso.getExposureTime()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("ExposureTime: "
-					+ Double.toString(d), false));
-		}
-		if ((n = niso.getExposureProgram()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("ExposureProgram: "
-					+ Integer.toString(n), false));
-		}
-		if ((s = niso.getExifVersion()) != null) {
-			val.add(new DefaultMutableTreeNode("ExifVersion: " + s, false));
-		}
-		Rational r;
-		if ((r = niso.getBrightness()) != null) {
-			val.add(new DefaultMutableTreeNode("Brightness: " + r.toString(),
-					false));
-		}
-		if ((r = niso.getExposureBias()) != null) {
-			val.add(new DefaultMutableTreeNode("ExposureBias: " + r.toString(),
-					false));
-		}
+    /*
+     * Return the string equivalent of an integer if raw output isn't selected,
+     * or its literal representation if it is.
+     */
+    private String integerRepresentation(int n, String[] labels) {
+        if (_rawOutput) {
+            return Integer.toString(n);
+        }
+        try {
+            return labels[n];
+        } catch (Exception e) {
+            return Integer.toString(n);
+        }
+    }
 
-		double[] darray = niso.getSubjectDistance();
-		if (darray != null) {
-			DefaultMutableTreeNode nod = new DefaultMutableTreeNode(
-					"SubjectDistance", true);
-			val.add(nod);
-			for (int i = 0; i < darray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Double.toString(darray[i]),
-						false));
-			}
-		}
-		if ((n = niso.getMeteringMode()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("MeteringMode: "
-					+ Integer.toString(n), false));
-		}
-		if ((n = niso.getSceneIlluminant()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SceneIlluminant: "
-					+ Integer.toString(n), false));
-		}
-		if ((d = niso.getColorTemp()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("ColorTemp: "
-					+ Double.toString(d), false));
-		}
-		if ((d = niso.getFocalLength()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("FocalLength: "
-					+ Double.toString(d), false));
-		}
-		if ((n = niso.getFlash()) != NisoImageMetadata.NULL) {
-			// First bit (0 = Flash did not fire, 1 = Flash fired)
-			val.add(new DefaultMutableTreeNode("Flash: "
-					+ integerRepresentation(n & 1, NisoImageMetadata.FLASH_20),
-					false));
-		}
-		if ((r = niso.getFlashEnergy()) != null) {
-			val.add(new DefaultMutableTreeNode("FlashEnergy: " + r.toString(),
-					false));
-		}
-		if ((n = niso.getFlashReturn()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("FlashReturn: "
-					+ integerRepresentation(n, NisoImageMetadata.FLASH_RETURN),
-					false));
-		}
-		if ((n = niso.getBackLight()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("BackLight: "
-					+ integerRepresentation(n, NisoImageMetadata.BACKLIGHT),
-					false));
-		}
-		if ((d = niso.getExposureIndex()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("ExposureIndex: "
-					+ Double.toString(d), false));
-		}
-		if ((n = niso.getAutoFocus()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("AutoFocus: "
-					+ Integer.toString(n), false));
-			// NisoImageMetadata.AUTOFOCUS
-		}
-		if ((d = niso.getXPrintAspectRatio()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("XPrintAspectRatio: "
-					+ Double.toString(d), false));
-		}
-		if ((d = niso.getYPrintAspectRatio()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("YPrintAspectRatio: "
-					+ Double.toString(d), false));
-		}
+    private String integerRepresentation(int n, String[] labels, int[] index) {
+        if (_rawOutput) {
+            return Integer.toString(n);
+        }
+        try {
+            int idx = -1;
+            for (int i = 0; i < index.length; i++) {
+                if (n == index[i]) {
+                    idx = i;
+                    break;
+                }
+            }
+            if (idx > -1) {
+                return labels[idx];
+            }
+        } catch (Exception e) {
+        }
+        // If we don't get a match, or do get an exception
+        return Integer.toString(n);
+    }
 
-		if ((n = niso.getSensor()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("Sensor: "
-					+ integerRepresentation(n, NisoImageMetadata.SENSOR), false));
-		}
-		if ((s = niso.getDateTimeCreated()) != null) {
-			val.add(new DefaultMutableTreeNode("DateTimeCreated: " + s, false));
-		}
-		if ((s = niso.getMethodology()) != null) {
-			val.add(new DefaultMutableTreeNode("Methodology: " + s, false));
-		}
-		if ((n = niso.getSamplingFrequencyPlane()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SamplingFrequencyPlane: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.SAMPLING_FREQUENCY_PLANE), false));
-		}
-		if ((n = niso.getSamplingFrequencyUnit()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SamplingFrequencyUnit: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.SAMPLING_FREQUENCY_UNIT), false));
-		}
-		Rational rat = niso.getXSamplingFrequency();
-		if (rat != null) {
-			val.add(new DefaultMutableTreeNode("XSamplingFrequency: "
-					+ rat.toString(), false));
-		}
-		rat = niso.getYSamplingFrequency();
-		if (rat != null) {
-			val.add(new DefaultMutableTreeNode("YSamplingFrequency: "
-					+ rat.toString(), false));
-		}
-		if ((ln = niso.getImageWidth()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("ImageWidth: "
-					+ Long.toString(ln), false));
-		}
-		if ((ln = niso.getImageLength()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("ImageLength: "
-					+ Long.toString(ln), false));
-		}
-		if ((d = niso.getSourceXDimension()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("SourceXDimension: "
-					+ Double.toString(d), false));
-		}
-		if ((n = niso.getSourceXDimensionUnit()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SourceXDimensionUnit: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.SOURCE_DIMENSION_UNIT), false));
-		}
-		if ((d = niso.getSourceYDimension()) != NisoImageMetadata.NILL) {
-			val.add(new DefaultMutableTreeNode("SourceYDimension: "
-					+ Double.toString(d), false));
-		}
-		if ((n = niso.getSourceYDimensionUnit()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SourceYDimensionUnit: "
-					+ integerRepresentation(n,
-							NisoImageMetadata.SOURCE_DIMENSION_UNIT), false));
-		}
-		if ((iarray = niso.getBitsPerSample()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"BitsPerSample"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-				//BitsPerSampleUnit Integer is assumed, because of BitsPerSample
-				// According to the specification, it can also be float.
-				// This is currently not supported by jHove
-				nod.add(new DefaultMutableTreeNode("Integer"));
-			}
-		}
-		if ((n = niso.getSamplesPerPixel()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("SamplesPerPixel: "
-					+ Integer.toString(n), false));
-		}
-		if ((iarray = niso.getExtraSamples()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ExtraSamples"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(integerRepresentation(
-						iarray[i], NisoImageMetadata.EXTRA_SAMPLES), false));
-			}
-		}
-		if ((s = niso.getColormapReference()) != null) {
-			val.add(new DefaultMutableTreeNode("ColormapReference: " + s));
-		}
-		if ((iarray = niso.getColormapBitCodeValue()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ColormapBitCodeValue"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((iarray = niso.getColormapRedValue()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ColormapRedValue"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((iarray = niso.getColormapGreenValue()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ColormapGreenValue"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((iarray = niso.getColormapBlueValue()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"ColormapBlueValue"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((iarray = niso.getGrayResponseCurve()) != null) {
-			DefaultMutableTreeNode nod = (new DefaultMutableTreeNode(
-					"GrayResponseCurve"));
-			val.add(nod);
-			for (int i = 0; i < iarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(Integer.toString(iarray[i]),
-						false));
-			}
-		}
-		if ((n = niso.getGrayResponseUnit()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("GrayResponseUnit: "
-					+ Integer.toString(n), false));
-		}
-		r = niso.getWhitePointXValue();
-		if (r != null) {
-			val.add(new DefaultMutableTreeNode("WhitePointXValue: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getWhitePointYValue()) != null) {
-			val.add(new DefaultMutableTreeNode("WhitePointYValue: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getPrimaryChromaticitiesRedX()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesRedX: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getPrimaryChromaticitiesRedY()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesRedY: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getPrimaryChromaticitiesGreenX()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesGreenX: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getPrimaryChromaticitiesGreenY()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesGreenY: "
-					+ r.toString(), false));
-		}
-		if ((r = niso.getPrimaryChromaticitiesBlueX()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesBlueX: "
-					+ r.toString()));
-		}
-		if ((r = niso.getPrimaryChromaticitiesBlueY()) != null) {
-			val.add(new DefaultMutableTreeNode("PrimaryChromaticitiesBlueY: "
-					+ r.toString()));
-		}
-		if ((n = niso.getTargetType()) != NisoImageMetadata.NULL) {
-			val.add(new DefaultMutableTreeNode("TargetType: "
-					+ integerRepresentation(n, NisoImageMetadata.TARGET_TYPE),
-					false));
-		}
-		if ((s = niso.getTargetIDManufacturer()) != null) {
-			val.add(new DefaultMutableTreeNode("TargetIDManufacturer: " + s,
-					false));
-		}
-		if ((s = niso.getTargetIDName()) != null) {
-			val.add(new DefaultMutableTreeNode("TargetIDName: " + s, false));
-		}
-		if ((s = niso.getTargetIDNo()) != null) {
-			val.add(new DefaultMutableTreeNode("TargetIDNo: " + s, false));
-		}
-		if ((s = niso.getTargetIDMedia()) != null) {
-			val.add(new DefaultMutableTreeNode("TargetIDMedia: " + s, false));
-		}
-		if ((s = niso.getImageData()) != null) {
-			val.add(new DefaultMutableTreeNode("ImageData: " + s, false));
-		}
-		if ((s = niso.getPerformanceData()) != null) {
-			val.add(new DefaultMutableTreeNode("PerformanceData: " + s, false));
-		}
-		if ((s = niso.getProfiles()) != null) {
-			val.add(new DefaultMutableTreeNode("Profiles: " + s, false));
-		}
-		if ((s = niso.getDateTimeProcessed()) != null) {
-			val.add(new DefaultMutableTreeNode("DateTimeProcessed: " + s, false));
-		}
-		if ((s = niso.getSourceData()) != null) {
-			val.add(new DefaultMutableTreeNode("SourceData: " + s, false));
-		}
-		if ((s = niso.getProcessingAgency()) != null) {
-			val.add(new DefaultMutableTreeNode("ProcessingAgency: " + s, false));
-		}
-		if ((s = niso.getProcessingSoftwareName()) != null) {
-			val.add(new DefaultMutableTreeNode("ProcessingSoftwareName: " + s,
-					false));
-		}
-		if ((s = niso.getProcessingSoftwareVersion()) != null) {
-			val.add(new DefaultMutableTreeNode("ProcessingSoftwareVersion: "
-					+ s, false));
-		}
-		String[] sarray = niso.getProcessingActions();
-		if (sarray != null) {
-			DefaultMutableTreeNode nod = new DefaultMutableTreeNode(
-					"ProcessingActions", true);
-			val.add(nod);
-			for (int i = 1; i < sarray.length; i++) {
-				nod.add(new DefaultMutableTreeNode(sarray[i], false));
-			}
-		}
-		return val;
-	}
+    /**
+     * This method returns a member of a property list based on it's
+     * PropertyType
+     *
+     * @param ptyp
+     *                       the propertytype
+     * @param item
+     *                       the item of the list
+     * @param allowsChildren
+     * @return
+     */
+    private DefaultMutableTreeNode getDefaultMutableTreeNode(PropertyType ptyp,
+            Object item, boolean allowsChildren) {
 
-	/*
-	 * Return the string equivalent of an integer if raw output isn't selected,
-	 * or its literal representation if it is.
-	 */
-	private String integerRepresentation(int n, String[] labels) {
-		if (_rawOutput) {
-			return Integer.toString(n);
-		}
-		try {
-			return labels[n];
-		} catch (Exception e) {
-			return Integer.toString(n);
-		}
-	}
+        DefaultMutableTreeNode itemNode;
 
-	private String integerRepresentation(int n, String[] labels, int[] index) {
-		if (_rawOutput) {
-			return Integer.toString(n);
-		}
-		try {
-			int idx = -1;
-			for (int i = 0; i < index.length; i++) {
-				if (n == index[i]) {
-					idx = i;
-					break;
-				}
-			}
-			if (idx > -1) {
-				return labels[idx];
-			}
-		} catch (Exception e) {
-		}
-		// If we don't get a match, or do get an exception
-		return Integer.toString(n);
-	}
+        if (null == ptyp) {
+            // Simple objects just need a leaf.
+            itemNode = (new DefaultMutableTreeNode(item, allowsChildren));
+        } else
+            // Object item = iter.next ();
+            switch (ptyp) {
+                case PROPERTY:
+                    itemNode = (propToNode((Property) item));
+                    break;
+                case NISOIMAGEMETADATA:
+                    itemNode = (nisoToNode((NisoImageMetadata) item));
+                    break;
+                default:
+                    // Simple objects just need a leaf.
+                    itemNode = (new DefaultMutableTreeNode(item, allowsChildren));
+                    break;
+            }
 
-	/**
-	 * This method returns a member of a property list based on it's
-	 * PropertyType
-	 *
-	 * @param ptyp
-	 *            the propertytype
-	 * @param item
-	 *            the item of the list
-	 * @param allowsChildren
-	 * @return
-	 */
-	private DefaultMutableTreeNode getDefaultMutableTreeNode(PropertyType ptyp,
-			Object item, boolean allowsChildren) {
+        return itemNode;
+    }
 
-		DefaultMutableTreeNode itemNode;
-
-		if (null == ptyp) {
-			// Simple objects just need a leaf.
-			itemNode = (new DefaultMutableTreeNode(item, allowsChildren));
-		} else
-			// Object item = iter.next ();
-			switch (ptyp) {
-			case PROPERTY:
-				itemNode = (propToNode((Property) item));
-				break;
-			case NISOIMAGEMETADATA:
-				itemNode = (nisoToNode((NisoImageMetadata) item));
-				break;
-			default:
-				// Simple objects just need a leaf.
-				itemNode = (new DefaultMutableTreeNode(item, allowsChildren));
-				break;
-			}
-
-		return itemNode;
-	}
-
-	/**
-	 * Method to add an array to a node
-	 *
-	 * @param <E>
-	 *            generic method, can be used for arrays of different types
-	 * @param node
-	 *            the node to add the elements of the array
-	 * @param array
-	 *            the array to be added to the node
-	 */
-	private <E> void addToNode(DefaultMutableTreeNode node, E[] array) {
-		for (E element : array) {
-			if (element instanceof Property) {
-				node.add(propToNode((Property) element));
-			} else {
-				node.add(new DefaultMutableTreeNode(element));
-			}
-		}
-	}
+    /**
+     * Method to add an array to a node
+     *
+     * @param <E>
+     *              generic method, can be used for arrays of different types
+     * @param node
+     *              the node to add the elements of the array
+     * @param array
+     *              the array to be added to the node
+     */
+    private <E> void addToNode(DefaultMutableTreeNode node, E[] array) {
+        for (E element : array) {
+            if (element instanceof Property) {
+                node.add(propToNode((Property) element));
+            } else {
+                node.add(new DefaultMutableTreeNode(element));
+            }
+        }
+    }
 }

--- a/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
+++ b/jhove-apps/src/main/java/edu/harvard/hul/ois/jhove/viewer/RepTreeRoot.java
@@ -75,19 +75,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
     private static final String FORMAT = "Format: ";
     private static final String VERSION = "Version: ";
     private static final String BYTE_ORDER = "ByteOrder: ";
-    private static final String FRAME_COUNT_30 = "FrameCount: 30";
-    private static final String TIME_BASE_1000 = "TimeBase: 1000";
-    private static final String VIDEO_FIELD_FIELD_1 = "VideoField: FIELD_1";
-    private static final String COUNTING_MODE_NTSC_NON_DROP_FRAME = "CountingMode: NTSC_NON_DROP_FRAME";
-    private static final String HOURS = "Hours: ";
-    private static final String MINUTES = "Minutes: ";
-    private static final String SECONDS = "Seconds: ";
-    private static final String FRAMES = "Frames: ";
-    private static final String SAMPLES = "Samples";
-    private static final String NUMBER_OF_SAMPLES = "NumberOfSamples: ";
-    private static final String FILM_FRAMING = "FilmFraming";
-    private static final String FRAMING_NOT_APPLICABLE = "Framing: NOT_APPLICABLE";
-    private static final String NTSC_FILM_FRAMING_TYPE = "Type: ntscFilmFramingType";
 
     /**
      * Constructs a DefaultMutableTreeNode representing a property
@@ -99,9 +86,8 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
         if (arity == PropertyArity.SCALAR) {
             if (null == typ) {
                 // Simple types: just use name plus string value.
-                DefaultMutableTreeNode val = new DefaultMutableTreeNode(
+                return new DefaultMutableTreeNode(
                         pProp.getName() + ": " + pValue.toString());
-                return val;
             } else {
                 TextMDMetadata tData;
                 DefaultMutableTreeNode val;
@@ -214,10 +200,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
         if (null == propType) {
             return 0; // non-object array type
         } else
-            // if (child instanceof LeafHolder) {
-            // return ((LeafHolder) child).getPosition ();
-            // }
-            // else
             switch (propType) {
                 case DATE:
                     dateArray = (java.util.Date[]) pProp.getValue();
@@ -335,7 +317,7 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 
         // Report modules that said their signatures match
         List<String> sigList = _info.getSigMatch();
-        if (sigList != null && sigList.size() > 0) {
+        if (sigList != null && !sigList.isEmpty()) {
             DefaultMutableTreeNode sigNode = new DefaultMutableTreeNode(
                     "SignatureMatches");
             infoNode.add(sigNode);
@@ -347,7 +329,7 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
         }
         // Compile a list of messages and offsets into a subtree
         List<Message> messageList = _info.getMessage();
-        if (messageList != null && messageList.size() > 0) {
+        if (messageList != null && !messageList.isEmpty()) {
             DefaultMutableTreeNode msgNode = new DefaultMutableTreeNode(
                     "Messages");
             infoNode.add(msgNode);
@@ -397,7 +379,7 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
 
         // Compile a list of profile strings into a string list
         List<String> profileList = _info.getProfile();
-        if (profileList != null && profileList.size() > 0) {
+        if (profileList != null && !profileList.isEmpty()) {
             DefaultMutableTreeNode profNode = new DefaultMutableTreeNode(
                     "Profiles");
             infoNode.add(profNode);
@@ -426,7 +408,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
             DefaultMutableTreeNode ckNode = new DefaultMutableTreeNode(
                     "Checksums");
             infoNode.add(ckNode);
-            // List cPropList = new LinkedList ();
             for (Checksum cksum : cksumList) {
                 DefaultMutableTreeNode csNode = new DefaultMutableTreeNode(
                         "Checksum");
@@ -567,7 +548,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
         Map<?, ?> m = (Map<?, ?>) p.getValue();
         PropertyType ptyp = p.getType();
         Boolean canHaveChildren = Boolean.TRUE;
-        // Iterator iter = m.values ().iterator ();
         Iterator<?> iter = m.keySet().iterator();
         while (iter.hasNext()) {
             DefaultMutableTreeNode itemNode;
@@ -1446,7 +1426,6 @@ public class RepTreeRoot extends DefaultMutableTreeNode {
             // Simple objects just need a leaf.
             itemNode = (new DefaultMutableTreeNode(item, allowsChildren));
         } else
-            // Object item = iter.next ();
             switch (ptyp) {
                 case PROPERTY:
                     itemNode = (propToNode((Property) item));

--- a/jhove-bbt/scripts/create-1.31-target.sh
+++ b/jhove-bbt/scripts/create-1.31-target.sh
@@ -161,3 +161,8 @@ do
 		cp "${candidateRoot}/${filename}" "${targetRoot}/${filename}"
 	fi
 done
+
+# Copy all of the AIF and WAV results as these are changed by the AES schema changes
+cp -rf "${candidateRoot}/examples/modules/AIFF-hul" "${targetRoot}/examples/modules/"
+cp -rf "${candidateRoot}/examples/modules/WAVE-hul" "${targetRoot}/examples/modules/"
+cp -rf "${candidateRoot}/errors/modules/WAVE-hul" "${targetRoot}/errors/modules/"

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
@@ -14,8 +14,7 @@ import java.util.*;
  * @author Gary McGath
  *
  */
-public class AESAudioMetadata 
-{
+public class AESAudioMetadata {
     /******************************************************************
      * PUBLIC CLASS FIELDS.
      ******************************************************************/
@@ -27,14 +26,13 @@ public class AESAudioMetadata
     public static final int LITTLE_ENDIAN = 1;
 
     /** Analog / digital labels. */
-    public static final String [] A_D = {
-    "ANALOG", "PHYS_DIGITAL", "FILE_DIGITAL"
+    public static final String[] A_D = {
+            "ANALOG", "PHYS_DIGITAL", "FILE_DIGITAL"
     };
-    
+
     /** Values for primary identifier type */
-    public static final String
-        FILE_NAME = "FILE_NAME",
-        OTHER = "OTHER";
+    public static final String FILE_NAME = "FILE_NAME",
+            OTHER = "OTHER";
 
     /** Constant for an undefined integer value. */
     public static final int NULL = -1;
@@ -47,8 +45,8 @@ public class AESAudioMetadata
      ******************************************************************/
 
     /** Constant value for the SchemaVersion field */
-    public static final String SCHEMA_VERSION = "1.02b";
-    
+    public static final String SCHEMA_VERSION = "1.0.0";
+
     /** Constant value for the disposition field */
     private static final String DEFAULT_DISPOSITION = "validation";
 
@@ -78,10 +76,10 @@ public class AESAudioMetadata
      * CLASS CONSTRUCTOR.
      ******************************************************************/
 
-    /** Instantiate a <code>NisoImageMetadata</code> object.
+    /**
+     * Instantiate a <code>NisoImageMetadata</code> object.
      */
-    public AESAudioMetadata ()
-    {
+    public AESAudioMetadata() {
         _schemaVersion = SCHEMA_VERSION;
         _disposition = DEFAULT_DISPOSITION;
         _analogDigitalFlag = null;
@@ -92,151 +90,170 @@ public class AESAudioMetadata
         _primaryIdentifierType = null;
         _use = null;
 
-        // We add one format region to get started.  In practice,
+        // We add one format region to get started. In practice,
         // that one is all we're likely to need. but more can be
         // added if necessary.
-        _formatList = new LinkedList<> ();
-        _faceList = new LinkedList<> ();
-        addFormatRegion ();
-        addFace ();
+        _formatList = new LinkedList<>();
+        _faceList = new LinkedList<>();
+        addFormatRegion();
+        addFace();
         _numChannels = NULL;
         _byteOrder = NULL;
         _firstSampleOffset = NULL;
     }
-    
+
     /******************************************************************
      * PUBLIC STATIC INTERFACES.
      * 
      ******************************************************************/
     /**
-     *  Public interface to the nested FormatRegion object.  Instances
-     *  of this should be created only by addFormatRegion, but can be
-     *  accessed through the public methods of this interface.
+     * Public interface to the nested FormatRegion object. Instances
+     * of this should be created only by addFormatRegion, but can be
+     * accessed through the public methods of this interface.
      */
     public static interface FormatRegion {
         /** Returns the bit depth. */
-        public int getBitDepth ();
-        /** Returns the bitrate reduction (compression information).
-         *  This will be an array of seven strings (which may be
-         *  empty, but should never be null) interpreted as follows:
-         *  <ul>
-         *  <li>0: codecName
-         *  <li>1: codecNameVersion
-         *  <li>2: codecCreatorApplication
-         *  <li>3: codecCreatorApplicationVersion
-         *  <li>4: codecQuality
-         *  <li>5: dataRate
-         *  <li>6: dataRateMode
-         *  </ul> 
+        public int getBitDepth();
+
+        /**
+         * Returns the bitrate reduction (compression information).
+         * This will be an array of seven strings (which may be
+         * empty, but should never be null) interpreted as follows:
+         * <ul>
+         * <li>0: codecName
+         * <li>1: codecNameVersion
+         * <li>2: codecCreatorApplication
+         * <li>3: codecCreatorApplicationVersion
+         * <li>4: codecQuality
+         * <li>5: dataRate
+         * <li>6: dataRateMode
+         * </ul>
          */
-        public String[] getBitrateReduction ();
+        public String[] getBitrateReduction();
+
         /** Returns the sample rate. */
-        public double getSampleRate ();
+        public double getSampleRate();
+
         /** Returns the word size. */
-        int getWordSize ();
+        int getWordSize();
+
         /** Returns <code>true</code> if the region is empty. */
-        public boolean isEmpty ();
+        public boolean isEmpty();
+
         /** Sets the bit depth value. */
-        public void setBitDepth (int bitDepth);
+        public void setBitDepth(int bitDepth);
+
         /** Sets the bitrate reduction information to null (no compression). */
-        public void clearBitrateReduction ();
+        public void clearBitrateReduction();
+
         /** Sets the bitrate reduction (aka compression type). */
-        public void setBitrateReduction (String codecName,
+        public void setBitrateReduction(String codecName,
                 String codecNameVersion,
                 String codecCreatorApplication,
                 String codecCreatorApplicationVersion,
                 String codecQuality,
                 String dataRate,
                 String dataRateMode);
+
         /** Sets the sample rate. */
-        public void setSampleRate (double sampleRate);
+        public void setSampleRate(double sampleRate);
+
         /** Sets the word size. */
-        public void setWordSize (int wordSize);
+        public void setWordSize(int wordSize);
     }
 
     /**
-     *  Public interface to the nested TimeDesc object.  Instances
-     *  of this should be created only by appropriate methods, but can be
-     *  accessed through the public methods of this interface.
+     * Public interface to the nested TimeDesc object. Instances
+     * of this should be created only by appropriate methods, but can be
+     * accessed through the public methods of this interface.
      */
     public static interface TimeDesc {
-        /** Returns the hours component. */
-        public long getHours ();
-        /** Returns the minutes component. */
-        public long getMinutes ();
-        /** Returns the seconds component. */
-        public long getSeconds ();
-        /** Returns the frames component of the fraction of a second.
-         *  We always consider frames to be thirtieths of a second. */
-        public long getFrames ();
-        /** Returns the samples remaining after the frames part of
-         *  the fractional second. */
-        public long getSamples ();
-        /** Returns the sample rate on which the samples remainder
-         *  is based. */
-        public double getSampleRate ();
+        /**
+         * Returns the number of samples.
+         */
+        public long getSamples();
+
+        /**
+         * Returns the sample rate.
+         */
+        public double getSampleRate();
     }
-    
-    /** Public interface to the nested Face object. Instances
-     *  of this should be created only by appropriate methods, but can be
-     *  accessed through the public methods of this interface. */
+
+    /**
+     * Public interface to the nested Face object. Instances
+     * of this should be created only by appropriate methods, but can be
+     * accessed through the public methods of this interface.
+     */
     public static interface Face {
         /** Returns an indexed FaceRegion. */
-        public FaceRegion getFaceRegion (int i);
-        
-        /** Adds a FaceRegion. This may be called repeatedly to
-         *  add multiple FaceRegions. */
-        public void addFaceRegion ();
-        
-        /** Returns the starting time. */
-        public TimeDesc getStartTime ();
-        
-        /** Returns the duration. */
-        public TimeDesc getDuration ();
-        
-        /** Returns the direction. */
-        public String getDirection ();
-        
-        /** Sets the starting time.  This will be converted
-         *  into a TimeDesc. */
-        public void setStartTime (long samples);
-        
-        /** Sets the duration. This will be converted
-         *  into a TimeDesc. */
-        public void setDuration (long samples);
-        
-        /** Sets the direction.  This must be one of the
-         *  directionTypes.  FORWARD is recommended for most
-         *  or all cases. 
+        public FaceRegion getFaceRegion(int i);
+
+        /**
+         * Adds a FaceRegion. This may be called repeatedly to
+         * add multiple FaceRegions.
          */
-        public void setDirection (String direction);
+        public void addFaceRegion();
+
+        /** Returns the starting time. */
+        public TimeDesc getStartTime();
+
+        /** Returns the duration. */
+        public TimeDesc getDuration();
+
+        /** Returns the direction. */
+        public String getDirection();
+
+        /**
+         * Sets the starting time. This will be converted
+         * into a TimeDesc.
+         */
+        public void setStartTime(long samples);
+
+        /**
+         * Sets the duration. This will be converted
+         * into a TimeDesc.
+         */
+        public void setDuration(long samples);
+
+        /**
+         * Sets the direction. This must be one of the
+         * directionTypes. FORWARD is recommended for most
+         * or all cases.
+         */
+        public void setDirection(String direction);
 
         /* End of interface Face */
     }
-    
-    /** Public interface to the nested FaceRegion object. Instances
-     *  of this should be created only by appropriate methods, but can be
-     *  accessed through the public methods of this interface. */
+
+    /**
+     * Public interface to the nested FaceRegion object. Instances
+     * of this should be created only by appropriate methods, but can be
+     * accessed through the public methods of this interface.
+     */
     public static interface FaceRegion {
         /** Returns the starting time. */
-        public TimeDesc getStartTime ();
-        
-        /** Returns the duration. */
-        public TimeDesc getDuration ();
+        public TimeDesc getStartTime();
 
-        /** Returns the channel map locations.  The array length must
-         *  equal the number of channels. */
-        public String[] getMapLocations ();
+        /** Returns the duration. */
+        public TimeDesc getDuration();
+
+        /**
+         * Returns the channel map locations. The array length must
+         * equal the number of channels.
+         */
+        public String[] getMapLocations();
 
         /** Sets the starting time. */
-        public void setStartTime (long samples);
-        
+        public void setStartTime(long samples);
+
         /** Sets the duration. */
-        public void setDuration (long samples);
-        
-        /** Sets the channel map locations.  The array length must
-         *  equal the number of channels. */
-        public void setMapLocations (String[] locations);
+        public void setDuration(long samples);
+
+        /**
+         * Sets the channel map locations. The array length must
+         * equal the number of channels.
+         */
+        public void setMapLocations(String[] locations);
 
         /* End of interface FaceRegion */
     }
@@ -245,101 +262,97 @@ public class AESAudioMetadata
      * STATIC MEMBER CLASSES.
      * 
      ******************************************************************/
-    /** The implementation of the FormatRegion interface.  The combination
-     *  of a public interface and a private implementation is suggested
-     *  in _Java in a Nutshell_.
+    /**
+     * The implementation of the FormatRegion interface. The combination
+     * of a public interface and a private implementation is suggested
+     * in _Java in a Nutshell_.
      */
     class FormatRegionImpl implements FormatRegion {
-        
+
         private int _bitDepth;
         private double _sampleRate;
         private int _wordSize;
         private String[] _bitrateReduction;
 
-        public FormatRegionImpl () {
+        public FormatRegionImpl() {
             _bitDepth = NULL;
             _sampleRate = NILL;
             _wordSize = NULL;
             _bitrateReduction = null;
         }
-        
+
         /** Returns bit depth. */
         @Override
-        public int getBitDepth ()
-        {
+        public int getBitDepth() {
             return _bitDepth;
         }
-        
-        /** Returns the bitrate reduction (compression information).
-         *  This will be an array of seven strings (which may be
-         *  empty but not null) interpreted respectively as follows:
-         *  <ul>
-         *  <li>0: codecName
-         *  <li>1: codecNameVersion
-         *  <li>2: codecCreatorApplication
-         *  <li>3: codecCreatorApplicationVersion
-         *  <li>4: codecQuality
-         *  <li>5: dataRate
-         *  <li>6: dataRateMode
-         *  </ul> 
+
+        /**
+         * Returns the bitrate reduction (compression information).
+         * This will be an array of seven strings (which may be
+         * empty but not null) interpreted respectively as follows:
+         * <ul>
+         * <li>0: codecName
+         * <li>1: codecNameVersion
+         * <li>2: codecCreatorApplication
+         * <li>3: codecCreatorApplicationVersion
+         * <li>4: codecQuality
+         * <li>5: dataRate
+         * <li>6: dataRateMode
+         * </ul>
          */
         @Override
-        public String[] getBitrateReduction ()
-        {
+        public String[] getBitrateReduction() {
             return _bitrateReduction;
         }
-        
+
         /** Returns sample rate. */
         @Override
-        public double getSampleRate ()
-        {
+        public double getSampleRate() {
             return _sampleRate;
         }
-        
+
         /** Returns word size. */
         @Override
-        public int getWordSize ()
-        {
+        public int getWordSize() {
             return _wordSize;
         }
-        
-        /** Returns true if the FormatRegion contains only
-         *  default values. */
+
+        /**
+         * Returns true if the FormatRegion contains only
+         * default values.
+         */
         @Override
-        public boolean isEmpty ()
-        {
+        public boolean isEmpty() {
             return _bitDepth == NULL &&
-                   _sampleRate == NILL &&
-                   _wordSize == NULL;
+                    _sampleRate == NILL &&
+                    _wordSize == NULL;
         }
 
         /** Sets bit depth. */
         @Override
-        public void setBitDepth (int bitDepth)
-        {
+        public void setBitDepth(int bitDepth) {
             _bitDepth = bitDepth;
         }
 
         /** Sets the bitrate reduction information to null (no compression). */
         @Override
-        public void clearBitrateReduction ()
-        {
+        public void clearBitrateReduction() {
             _bitrateReduction = null;
         }
 
         /** Sets the bitrate reduction (compression type). */
         @Override
-        public void setBitrateReduction (String codecName,
+        public void setBitrateReduction(String codecName,
                 String codecNameVersion,
                 String codecCreatorApplication,
                 String codecCreatorApplicationVersion,
                 String codecQuality,
                 String dataRate,
-                String dataRateMode)
-        {
+                String dataRateMode) {
             _bitrateReduction = new String[7];
             _bitrateReduction[0] = codecName;
-            _bitrateReduction[1] = codecNameVersion;  
+            _bitrateReduction[1] = codecNameVersion;
             _bitrateReduction[2] = codecCreatorApplication;
             _bitrateReduction[3] = codecCreatorApplicationVersion;
             _bitrateReduction[4] = codecQuality;
@@ -349,275 +362,225 @@ public class AESAudioMetadata
 
         /** Sets sample rate. */
         @Override
-        public void setSampleRate (double sampleRate)
-        {
+        public void setSampleRate(double sampleRate) {
             _sampleRate = sampleRate;
         }
-        
-        
+
         /** Sets word size. */
         @Override
-        public void setWordSize (int wordSize)
-        {
+        public void setWordSize(int wordSize) {
             _wordSize = wordSize;
         }
-        
+
         /* End of FormatRegionImpl */
     }
 
-    /** The implementation of the TimeDesc interface.  The combination
-     *  of a public interface and a private implementation is suggested
-     *  in _Java in a Nutshell_.
+    /**
+     * The implementation of the TimeDesc interface. The combination
+     * of a public interface and a private implementation is suggested
+     * in _Java in a Nutshell_.
      */
-    class TimeDescImpl implements TimeDesc
-    {
-        private long _hours;
-        private long _minutes;
-        private long _seconds;
-        private long _frames;
+    class TimeDescImpl implements TimeDesc {
         private long _samples;
         private double _sampleRate;
-        private long _frameCount;
-        
-	/* Constructor rewritten to avoid rounding errors when converting to
-	 * TCF. Now uses integer remainder math instead of floating point.
-	 * Changed the base unit from a double representing seconds to a long
-	 * representing samples. Changed all existing calls (that I could find)
-	 * to this method to accomodate this change.
-	 *
-	 * @author David Ackerman
-	 */
-        public TimeDescImpl (long samples)
-	{
-	    long _sample_count = samples;
-	    _frameCount = 30;
-	    _sampleRate = _curFormatRegion.getSampleRate ();
-			
-	    /* It seems that this method is initially called before a valid
-	     * sample rate has been established, causing a divide by zero
-	     * error.
-	     */
-	    if (_sampleRate < 0) {
-                _sampleRate = 44100.0; //reasonable default value 
+
+        /*
+         * Constructor rewritten to avoid rounding errors when converting to
+         * TCF. Now uses integer remainder math instead of floating point.
+         * Changed the base unit from a double representing seconds to a long
+         * representing samples. Changed all existing calls (that I could find)
+         * to this method to accomodate this change.
+         *
+         * @author David Ackerman
+         */
+        public TimeDescImpl(long samples) {
+            _samples = samples;
+            _sampleRate = _curFormatRegion.getSampleRate();
+
+            /*
+             * It seems that this method is initially called before a valid
+             * sample rate has been established, causing a divide by zero
+             * error.
+             */
+            if (_sampleRate < 0) {
+                _sampleRate = 44100.0; // reasonable default value
             }
 
-	    long sample_in_1_frame = (long)(_sampleRate/_frameCount);
-	    long sample_in_1_second = sample_in_1_frame * _frameCount;
-	    long sample_in_1_minute = sample_in_1_frame * _frameCount * 60;
-	    long sample_in_1_hour = sample_in_1_frame * _frameCount * 60 * 60;
-	    long sample_in_1_day = sample_in_1_frame * _frameCount * 60 * 60 * 24;
-			
-	    // BWF allows for a negative timestamp but tcf does not, so adjust
-	    // time accordingly
-	    // this might be a good place to report a warning during validation
-	    if (_sample_count < 0) {
-		_sample_count += sample_in_1_day;
-		_sample_count = (_sample_count % sample_in_1_day);
-	    }
-		
-	    _hours = _sample_count / sample_in_1_hour;
-	    _sample_count -= _hours * sample_in_1_hour;
-	    _minutes = _sample_count / sample_in_1_minute;
-	    _sample_count -= _minutes * sample_in_1_minute;
-	    _seconds = _sample_count / sample_in_1_second;
-	    _sample_count -= _seconds * sample_in_1_second;
-	    _frames = _sample_count / sample_in_1_frame;
-	    _sample_count -= _frames * sample_in_1_frame;
-	    _samples = _sample_count;
-			
-	    /* At present TCF does not have the ability to handle time stamps
-	     * > midnight. Industry practice is to roll the clock forward to
-	     * zero or back to 23:59:59:29... when crossing this boundary
-	     * condition.
-	     */
-	    _hours = _hours % 24;	
-        }
-        
-        /** Returns the hours component. */
-        @Override
-        public long getHours () {
-            return _hours;
         }
 
-        /** Returns the minutes component. */
+        /**
+         * Returns the number of samples.
+         */
         @Override
-        public long getMinutes () {
-            return _minutes;
-        }
-
-        /** Returns the seconds component. */
-        @Override
-        public long getSeconds () {
-            return _seconds;
-        }
-
-        /** Returns the frames component of the fraction of a second.
-         *  We always consider frames to be thirtieths of a second. */
-        @Override
-        public long getFrames () {
-            return _frames;
-        }
-
-        /** Returns the samples remaining after the frames part of
-         *  the fractional second. */
-        @Override
-        public long getSamples () {
+        public long getSamples() {
             return _samples;
         }
-        
-        /** Returns the sample rate on which the samples remainder
-         *  is based. */
+
+        /**
+         * Returns the sample rate.
+         */
         @Override
-        public double getSampleRate () {
+        public double getSampleRate() {
             return _sampleRate;
         }
     } /* End of TimeDescImpl */
 
-    /** The implementation of the Face interface.  The combination
-     *  of a public interface and a private implementation is suggested
-     *  in _Java in a Nutshell_.
+    /**
+     * The implementation of the Face interface. The combination
+     * of a public interface and a private implementation is suggested
+     * in _Java in a Nutshell_.
      */
     class FaceImpl implements Face {
         private List<FaceRegion> _regionList;
         private TimeDesc _startTime;
         private TimeDesc _duration;
         private String _direction;
-        
-        
-        /** Constructor.  Initially the duration is set
-         *  to null, indicating unknown value. */
-        public FaceImpl ()
-        {
+
+        /**
+         * Constructor. Initially the duration is set
+         * to null, indicating unknown value.
+         */
+        public FaceImpl() {
             _regionList = new ArrayList<>();
-            _startTime = new TimeDescImpl (0);
+            _startTime = new TimeDescImpl(0);
             _duration = null;
         }
 
-
         /** Returns an indexed FaceRegion. */
         @Override
-        public FaceRegion getFaceRegion (int i) {
-            return _regionList.get (i);
+        public FaceRegion getFaceRegion(int i) {
+            return _regionList.get(i);
         }
-        
-        /** Adds a FaceRegion. This may be called repeatedly to
-         *  add multiple FaceRegions. */
+
+        /**
+         * Adds a FaceRegion. This may be called repeatedly to
+         * add multiple FaceRegions.
+         */
         @Override
-        public void addFaceRegion () {
-            _regionList.add (new FaceRegionImpl ());
+        public void addFaceRegion() {
+            _regionList.add(new FaceRegionImpl());
         }
-        
-        /** Returns the starting time. Will be zero if not
-         *  explicitly specified. */
+
+        /**
+         * Returns the starting time. Will be zero if not
+         * explicitly specified.
+         */
         @Override
-        public TimeDesc getStartTime () {
+        public TimeDesc getStartTime() {
             return _startTime;
         }
-        
-        /** Returns the duration. May be null if the duration
-         *  is unspecified. */
+
+        /**
+         * Returns the duration. May be null if the duration
+         * is unspecified.
+         */
         @Override
-        public TimeDesc getDuration () {
+        public TimeDesc getDuration() {
             return _duration;
         }
 
         /** Returns the direction. */
         @Override
-        public String getDirection ()
-        {
+        public String getDirection() {
             return _direction;
         }
 
-        /** Sets the starting time.  This will be converted
-         *  into a TimeDesc. */
-        @Override
-        public void setStartTime (long samples)
-        {
-            _startTime = new TimeDescImpl (samples);
-        }
-        
-        /** Sets the duration. This will be converted
-         *  into a TimeDesc. */
-        @Override
-        public void setDuration (long samples)
-        {
-            _duration = new TimeDescImpl (samples);
-        }
-
-        /** Sets the direction.  This must be one of the
-         *  directionTypes.  FORWARD is recommended for most
-         *  or all cases. 
+        /**
+         * Sets the starting time. This will be converted
+         * into a TimeDesc.
          */
         @Override
-        public void setDirection (String direction)
-        {
+        public void setStartTime(long samples) {
+            _startTime = new TimeDescImpl(samples);
+        }
+
+        /**
+         * Sets the duration. This will be converted
+         * into a TimeDesc.
+         */
+        @Override
+        public void setDuration(long samples) {
+            _duration = new TimeDescImpl(samples);
+        }
+
+        /**
+         * Sets the direction. This must be one of the
+         * directionTypes. FORWARD is recommended for most
+         * or all cases.
+         */
+        @Override
+        public void setDirection(String direction) {
             _direction = direction;
         }
 
         /* End of FaceImpl */
     }
 
-
-    /** The implementation of the Face interface.  The combination
-     *  of a public interface and a private implementation is suggested
-     *  in _Java in a Nutshell_.
+    /**
+     * The implementation of the Face interface. The combination
+     * of a public interface and a private implementation is suggested
+     * in _Java in a Nutshell_.
      */
     class FaceRegionImpl implements FaceRegion {
         private TimeDesc _startTime;
         private TimeDesc _duration;
         private String[] _mapLocations;
-        
-        public FaceRegionImpl ()
-        {
-            _startTime = new TimeDescImpl (0);
+
+        public FaceRegionImpl() {
+            _startTime = new TimeDescImpl(0);
             _duration = null;
         }
-        
+
         /** Returns the starting time. */
         @Override
-        public TimeDesc getStartTime () {
+        public TimeDesc getStartTime() {
             return _startTime;
         }
-        
+
         /** Returns the duration. */
         @Override
-        public TimeDesc getDuration () {
+        public TimeDesc getDuration() {
             return _duration;
         }
-        
-        /** Returns the channel map locations.  The array length
-         *  will equal the number of channels. */
+
+        /**
+         * Returns the channel map locations. The array length
+         * will equal the number of channels.
+         */
         @Override
-        public String[] getMapLocations ()
-        {
+        public String[] getMapLocations() {
             return _mapLocations;
         }
 
-        /** Sets the duration. This will be converted
-         *  into a TimeDesc. */
+        /**
+         * Sets the duration. This will be converted
+         * into a TimeDesc.
+         */
         @Override
-        public void setStartTime (long samples) {
-            _startTime = new TimeDescImpl (samples);
-        }
-        
-        /** Sets the duration. This will be converted
-         *  into a TimeDesc. */
-        @Override
-        public void setDuration (long samples)
-        {
-            _duration = new TimeDescImpl (samples);
+        public void setStartTime(long samples) {
+            _startTime = new TimeDescImpl(samples);
         }
 
-        /** Sets the channel map locations.  The array length must
-         *  equal the number of channels. */
+        /**
+         * Sets the duration. This will be converted
+         * into a TimeDesc.
+         */
         @Override
-        public void setMapLocations (String[] locations)
-        {
+        public void setDuration(long samples) {
+            _duration = new TimeDescImpl(samples);
+        }
+
+        /**
+         * Sets the channel map locations. The array length must
+         * equal the number of channels.
+         */
+        @Override
+        public void setMapLocations(String[] locations) {
             _mapLocations = locations;
-        }        
+        }
         /* End of FaceRegionImpl */
     }
-   
+
     /* End of inner classes */
 
     /******************************************************************
@@ -626,345 +589,327 @@ public class AESAudioMetadata
      * Accessor methods.
      ******************************************************************/
 
-    /** Returns analog/digital flag.  Value will always be
-     *  "FILE_DIGITAL" in practice. */
-    public String getAnalogDigitalFlag ()
-    {
+    /**
+     * Returns analog/digital flag. Value will always be
+     * "FILE_DIGITAL" in practice.
+     */
+    public String getAnalogDigitalFlag() {
         return _analogDigitalFlag;
     }
-    
-    /** Returns application-specific data.  We assume this is
-     *  representable in String format. 
+
+    /**
+     * Returns application-specific data. We assume this is
+     * representable in String format.
      */
-    public String getAppSpecificData ()
-    {
+    public String getAppSpecificData() {
         return _appSpecificData;
     }
-    
+
     /** Returns audio data encoding. */
-    public String getAudioDataEncoding ()
-    {
+    public String getAudioDataEncoding() {
         return _audioDataEncoding;
     }
 
-    /** Returns the bitrate reduction (compression information).
-     *  This will be an array of seven strings (which may be
-     *  empty, but should never be null) interpreted as follows:
-     *  <ul>
-     *  <li>0: codecName
-     *  <li>1: codecNameVersion
-     *  <li>2: codecCreatorApplication
-     *  <li>3: codecCreatorApplicationVersion
-     *  <li>4: codecQuality
-     *  <li>5: dataRate
-     *  <li>6: dataRateMode
-     *  </ul> 
+    /**
+     * Returns the bitrate reduction (compression information).
+     * This will be an array of seven strings (which may be
+     * empty, but should never be null) interpreted as follows:
+     * <ul>
+     * <li>0: codecName
+     * <li>1: codecNameVersion
+     * <li>2: codecCreatorApplication
+     * <li>3: codecCreatorApplicationVersion
+     * <li>4: codecQuality
+     * <li>5: dataRate
+     * <li>6: dataRateMode
+     * </ul>
      */
-    public String[] getBitrateReduction ()
-    {
+    public String[] getBitrateReduction() {
         return _curFormatRegion.getBitrateReduction();
     }
 
     /* Returns the sample rate. */
-    public double getSampleRate ()
-    {
-	return _curFormatRegion.getSampleRate ();
+    public double getSampleRate() {
+        return _curFormatRegion.getSampleRate();
     }
 
     /** Return the byte order: 0 = big-endian; 1 = little-endian. */
-    public int getByteOrder ()
-    {
+    public int getByteOrder() {
         return _byteOrder;
     }
-    
+
     /** Returns disposition. */
-    public String getDisposition ()
-    {
+    public String getDisposition() {
         return _disposition;
     }
-    
-    /** Gets the list of Faces. Normally there will be only one face
-     *  in a digital file. */
-    public List<Face> getFaceList ()
-    {
+
+    /**
+     * Gets the list of Faces. Normally there will be only one face
+     * in a digital file.
+     */
+    public List<Face> getFaceList() {
         return _faceList;
     }
-    
+
     /** Return the offset of the first byte of sample data. */
-    public long getFirstSampleOffset ()
-    {
+    public long getFirstSampleOffset() {
         return _firstSampleOffset;
     }
 
     /** Returns format name. */
-    public String getFormat ()
-    {
+    public String getFormat() {
         return _format;
     }
-    
-    /** Gets the list of Format Regions.  Since one is created
-     *  automatically on initialization, it's possible that the
-     *  list will contain a Format Region with only default values.
-     *  This should be checked with isEmpty ().
+
+    /**
+     * Gets the list of Format Regions. Since one is created
+     * automatically on initialization, it's possible that the
+     * list will contain a Format Region with only default values.
+     * This should be checked with isEmpty ().
      */
-    public List<FormatRegion> getFormatList ()
-    {
+    public List<FormatRegion> getFormatList() {
         return _formatList;
     }
-    
-    /** Returns the names of the map locations.
-     *  The returned
-     *  value is an array whose length equals the number of
-     *  channels and whose elements correspond to channels 0, 1,
-     *  etc. 
+
+    /**
+     * Returns the names of the map locations.
+     * The returned
+     * value is an array whose length equals the number of
+     * channels and whose elements correspond to channels 0, 1,
+     * etc.
      */
     public String[] getMapLocations() {
         return _curFace.getFaceRegion(0).getMapLocations();
     }
-    
+
     /** Returns number of channels. */
-    public int getNumChannels ()
-    {
+    public int getNumChannels() {
         return _numChannels;
     }
 
     /** Returns primary identifier. */
-    public String getPrimaryIdentifier ()
-    {
+    public String getPrimaryIdentifier() {
         return _primaryIdentifier;
     }
 
     /** Returns primary identifier type. */
-    public String getPrimaryIdentifierType ()
-    {
+    public String getPrimaryIdentifierType() {
         return _primaryIdentifierType;
     }
 
     /** Returns schema version. */
-    public String getSchemaVersion ()
-    {
+    public String getSchemaVersion() {
         return _schemaVersion;
     }
-    
+
     /** Returns specification version of the document format. */
-    public String getSpecificationVersion ()
-    {
+    public String getSpecificationVersion() {
         return _specificationVersion;
     }
-    
-    /** Returns the use (role of the document).
-     *  The value returned is an array of two strings,
-     *  the useType and the otherType. */
-    public String[] getUse ()
-    {
+
+    /**
+     * Returns the use (role of the document).
+     * The value returned is an array of two strings,
+     * the useType and the otherType.
+     */
+    public String[] getUse() {
         return _use;
     }
-    
-
-    
-
 
     /******************************************************************
      * Mutator methods.
      ******************************************************************/
-    
-    /** Sets the analog/digital flag.  The value set should always
-     *  be "FILE_DIGITAL". */
-    public void  setAnalogDigitalFlag (String flagType)
-    {
+
+    /**
+     * Sets the analog/digital flag. The value set should always
+     * be "FILE_DIGITAL".
+     */
+    public void setAnalogDigitalFlag(String flagType) {
         _analogDigitalFlag = flagType;
     }
 
     /** Sets the bitrate reduction (compression type). */
-    public void setBitrateReduction (String codecName,
+    public void setBitrateReduction(String codecName,
             String codecNameVersion,
             String codecCreatorApplication,
             String codecCreatorApplicationVersion,
             String codecQuality,
             String dataRate,
-            String dataRateMode)
-    {
-        _curFormatRegion.setBitrateReduction (codecName,
+            String dataRateMode) {
+        _curFormatRegion.setBitrateReduction(codecName,
                 codecNameVersion, codecCreatorApplication,
                 codecCreatorApplicationVersion,
                 codecQuality, dataRate, dataRateMode);
     }
-    
+
     /** Set the bitrate reduction information to null (no compression). */
-    public void clearBitrateReduction ()
-    {
-        _curFormatRegion.clearBitrateReduction ();
+    public void clearBitrateReduction() {
+        _curFormatRegion.clearBitrateReduction();
     }
 
-    /** Sets the byte order.
+    /**
+     * Sets the byte order.
+     * 
      * @param order Byte order: 0 = big-endian, 1 = little-endian
      */
-    public void setByteOrder (int order)
-    {
-	   _byteOrder = order;
+    public void setByteOrder(int order) {
+        _byteOrder = order;
     }
 
-    /** Sets the byte order.
+    /**
+     * Sets the byte order.
      */
-    public void setByteOrder (String order)
-    {
-    	if (order.substring (0, 3).toLowerCase ().equals ("big")) {
-    	    _byteOrder = BIG_ENDIAN;
-    	}
-    	else if (order.substring (0, 6).toLowerCase ().equals ("little")) {
-    	    _byteOrder = LITTLE_ENDIAN;
-    	}
+    public void setByteOrder(String order) {
+        if (order.substring(0, 3).toLowerCase().equals("big")) {
+            _byteOrder = BIG_ENDIAN;
+        } else if (order.substring(0, 6).toLowerCase().equals("little")) {
+            _byteOrder = LITTLE_ENDIAN;
+        }
     }
 
     /** Sets the audio data encoding. */
-    public void setAudioDataEncoding (String audioDataEncoding)
-    {
+    public void setAudioDataEncoding(String audioDataEncoding) {
         _audioDataEncoding = audioDataEncoding;
     }
-    
-    /** Set the application-specific data.  For present purposes,
-     *  we assume this is representable as a text string. */
-    public void setAppSpecificData (String data)
-    {
+
+    /**
+     * Set the application-specific data. For present purposes,
+     * we assume this is representable as a text string.
+     */
+    public void setAppSpecificData(String data) {
         _appSpecificData = data;
     }
-    
+
     /** Sets the bit depth. */
-    public void setBitDepth (int bitDepth)
-    {
-        _curFormatRegion.setBitDepth (bitDepth);
+    public void setBitDepth(int bitDepth) {
+        _curFormatRegion.setBitDepth(bitDepth);
     }
-    
+
     /** Sets the disposition. */
-    public void setDisposition (String disposition)
-    {
+    public void setDisposition(String disposition) {
         _disposition = disposition;
     }
 
-    /** Sets the direction.  
-     *  This must be one of the values 
-     *  FORWARD, REVERSE, A_WIND, B_WIND, C_WIND, D_WIND,
-     *  FRONT, BACK.  FORWARD may be the only one that
-     *  makes sense for digital formats.
+    /**
+     * Sets the direction.
+     * This must be one of the values
+     * FORWARD, REVERSE, A_WIND, B_WIND, C_WIND, D_WIND,
+     * FRONT, BACK. FORWARD may be the only one that
+     * makes sense for digital formats.
      */
-    public void setDirection (String direction)
-    {
-        _curFace.setDirection (direction);
+    public void setDirection(String direction) {
+        _curFace.setDirection(direction);
     }
-    
-    /** Sets the duration in samples. 
+
+    /**
+     * Sets the duration in samples.
      * This affects the current face and its first FaceRegion.
      */
-    public void setDuration (long duration)
-    {
-	_curFace.setDuration (duration);
-	_curFace.getFaceRegion(0).setDuration (duration);
+    public void setDuration(long duration) {
+        _curFace.setDuration(duration);
+        _curFace.getFaceRegion(0).setDuration(duration);
     }
 
     /** Sets the offset of the first byte of sample data. */
-    public void setFirstSampleOffset (long offset)
-    {
+    public void setFirstSampleOffset(long offset) {
         _firstSampleOffset = offset;
     }
 
     /** Sets the format name. */
-    public void setFormat (String format)
-    {
+    public void setFormat(String format) {
         _format = format;
     }
-    
-    /** Sets the array of channel map locations. The length
-     *  of the array must equal the number of channels. */
-    public void setMapLocations (String[] locations) {
-        _curFace.getFaceRegion(0).setMapLocations (locations);
+
+    /**
+     * Sets the array of channel map locations. The length
+     * of the array must equal the number of channels.
+     */
+    public void setMapLocations(String[] locations) {
+        _curFace.getFaceRegion(0).setMapLocations(locations);
     }
 
     /** Sets the number of channels. */
-    public void setNumChannels (int numChannels)
-    {
+    public void setNumChannels(int numChannels) {
         _numChannels = numChannels;
     }
 
     /** Sets the primary identifier. */
-    public void setPrimaryIdentifier (String primaryIdentifier)
-    {
+    public void setPrimaryIdentifier(String primaryIdentifier) {
         _primaryIdentifier = primaryIdentifier;
     }
-    
-    /** Sets the primary identifier type. If the primary identifier
-     *  type is OTHER, use setOtherPrimaryIdentifierType instead.
+
+    /**
+     * Sets the primary identifier type. If the primary identifier
+     * type is OTHER, use setOtherPrimaryIdentifierType instead.
      */
-    public void setPrimaryIdentifierType (String primaryIdentifierType)
-    {
+    public void setPrimaryIdentifierType(String primaryIdentifierType) {
         _primaryIdentifierType = primaryIdentifierType;
     }
 
-    /** Sets the primary identifier type as "OTHER", and
-     *  set the otherType.
+    /**
+     * Sets the primary identifier type as "OTHER", and
+     * set the otherType.
      */
-    public void setOtherPrimaryIdentifierType (String otherType)
-    {
+    public void setOtherPrimaryIdentifierType(String otherType) {
         _primaryIdentifierType = "OTHER";
         _primaryIdentifierOtherType = otherType;
     }
-    
+
     /** Sets the sample rate. */
-    public void setSampleRate (double sampleRate)
-    {
-        _curFormatRegion.setSampleRate (sampleRate);
+    public void setSampleRate(double sampleRate) {
+        _curFormatRegion.setSampleRate(sampleRate);
     }
-    
-    /** Sets the specification version of the document format.*/
-    public void setSpecificationVersion (String specificationVersion)
-    {
+
+    /** Sets the specification version of the document format. */
+    public void setSpecificationVersion(String specificationVersion) {
         _specificationVersion = specificationVersion;
     }
 
-    /** Sets the start time in samples. 
+    /**
+     * Sets the start time in samples.
      * This affects the current face and its first FaceRegion.
      */
-    public void setStartTime (long samples)
-    {
-	_curFace.setStartTime (samples);
-	_curFace.getFaceRegion(0).setStartTime (samples);
+    public void setStartTime(long samples) {
+        _curFace.setStartTime(samples);
+        _curFace.getFaceRegion(0).setStartTime(samples);
     }
-    
-    /** Sets the role of the document. Permitted values are
-     *  ORIGINAL_MASTER, PRESERVATION_MASTER, PRODUCTION_MASTER, 
-     *  SERVICE, PREVIEW, or OTHER.
-     *  If useType is "OTHER", then otherType
-     *  is significant.  Since OTHER is the only meaningful
-     *  value for a digital document, the code assumes this will always
-     *  be the case and uses otherType. */
-    public void setUse (String useType, String otherType)
-    {
-        _use = new String[] {useType, otherType};
+
+    /**
+     * Sets the role of the document. Permitted values are
+     * ORIGINAL_MASTER, PRESERVATION_MASTER, PRODUCTION_MASTER,
+     * SERVICE, PREVIEW, or OTHER.
+     * If useType is "OTHER", then otherType
+     * is significant. Since OTHER is the only meaningful
+     * value for a digital document, the code assumes this will always
+     * be the case and uses otherType.
+     */
+    public void setUse(String useType, String otherType) {
+        _use = new String[] { useType, otherType };
     }
-    
+
     /** Sets the word size. */
-    public void setWordSize (int wordSize)
-    {
-        _curFormatRegion.setWordSize (wordSize);
+    public void setWordSize(int wordSize) {
+        _curFormatRegion.setWordSize(wordSize);
     }
-    
-    /** Adds a FormatRegion object to a FormatSize list.
-     *  The most recently added FormatRegion object will
-     *  be filled in by setBitDepth, setSampleRate, and
-     *  setWordSize.
+
+    /**
+     * Adds a FormatRegion object to a FormatSize list.
+     * The most recently added FormatRegion object will
+     * be filled in by setBitDepth, setSampleRate, and
+     * setWordSize.
      */
-    public void addFormatRegion ()
-    {
-        _curFormatRegion = new FormatRegionImpl ();
-        _formatList.add (_curFormatRegion);
+    public void addFormatRegion() {
+        _curFormatRegion = new FormatRegionImpl();
+        _formatList.add(_curFormatRegion);
     }
-    
-    /** Adds a Face.  
+
+    /**
+     * Adds a Face.
      */
-    public void addFace ()
-    {
-        _curFace = new FaceImpl ();
-        _faceList.add (_curFace);
+    public void addFace() {
+        _curFace = new FaceImpl();
+        _faceList.add(_curFace);
         _curFace.addFaceRegion();
     }
-    
+
 }

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/AESAudioMetadata.java
@@ -760,9 +760,9 @@ public class AESAudioMetadata {
      * Sets the byte order.
      */
     public void setByteOrder(String order) {
-        if (order.substring(0, 3).toLowerCase().equals("big")) {
+        if (order.substring(0, 3).equalsIgnoreCase("big")) {
             _byteOrder = BIG_ENDIAN;
-        } else if (order.substring(0, 6).toLowerCase().equals("little")) {
+        } else if (order.substring(0, 6).equalsIgnoreCase("little")) {
             _byteOrder = LITTLE_ENDIAN;
         }
     }
@@ -851,7 +851,7 @@ public class AESAudioMetadata {
      * set the otherType.
      */
     public void setOtherPrimaryIdentifierType(String otherType) {
-        _primaryIdentifierType = "OTHER";
+        _primaryIdentifierType = OTHER;
         _primaryIdentifierOtherType = otherType;
     }
 

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/JsonHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/JsonHandler.java
@@ -1944,13 +1944,11 @@ public class JsonHandler extends HandlerBase {
 			if (nchan != AESAudioMetadata.NULL) {
 				faceBuilder.add("aes:numChannels", nchan);
 			}
-			String[] locs = aes.getMapLocations();
 			JsonArrayBuilder streamsBuilder = Json.createArrayBuilder();
 			for (int ch = 0; ch < nchan; ch++) {
 				// write a stream description for each channel
 				streamsBuilder.add(Json.createObjectBuilder()
-						.add("aes:channelNum", ch)
-						.add("aes:mapLocation", locs[ch]));
+						.add("aes:channelNum", ch));
 			}
 			faceBuilder.add("aes:streams", streamsBuilder);
 			aesBuilder.add("aes:face", faceBuilder);
@@ -2016,72 +2014,26 @@ public class JsonHandler extends HandlerBase {
 	 */
 	private JsonObjectBuilder writeAESTimeRange(
 			AESAudioMetadata.TimeDesc start, AESAudioMetadata.TimeDesc duration) {
-		double sr = start.getSampleRate();
-		if (sr == 1.0) {
-			sr = _sampleRate;
-		}
-
 		JsonObjectBuilder timerangeBuilder = Json.createObjectBuilder();
-		timerangeBuilder
-				.add("tcf:startTime",
-						Json.createObjectBuilder()
-								.add("tcf:frameCount", 30)
-								.add("tcf:timeBase", 1000)
-								.add("tcf:videoField", "FIELD_1")
-								.add("tcf:countingMode", NTSC_NON_DROP_FRAME)
-								.add("tcf:hours", start.getHours())
-								.add("tcf:minutes", start.getMinutes())
-								.add("tcf:seconds", start.getSeconds())
-								.add("tcf:frames", start.getFrames())
-								.add("tcf:samples",
-										Json.createObjectBuilder()
-												.add("tcf:sampleRate",
-														"S"
-																+ Integer
-																		.toString((int) sr))
-												.add("tcf:numberOfSamples",
-														start.getSamples()))
-								.add("tcf:filmFraming",
-										Json.createObjectBuilder()
-												.add("tcf:framing",
-														"NOT_APPLICABLE")
-												.add("tcf:framingType",
-														"tcf:ntscFilmFramingType")));
+        this.writeAESTimeRangePart(timerangeBuilder, "aes:start", start);
+
 		if (duration != null) {
-			sr = duration.getSampleRate();
-			if (sr == 1.0) {
-				sr = _sampleRate;
-			}
-			timerangeBuilder
-					.add("tcf:duration",
-							Json.createObjectBuilder()
-									.add("tcf:frameCount", 30)
-									.add("tcf:timeBase", 1000)
-									.add("tcf:videoField", "FIELD_1")
-									.add("tcf:countingMode",
-											NTSC_NON_DROP_FRAME)
-									.add("tcf:hours", duration.getHours())
-									.add("tcf:minutes", duration.getMinutes())
-									.add("tcf:seconds", duration.getSeconds())
-									.add("tcf:frames", duration.getFrames())
-									.add("tcf:samples",
-											Json.createObjectBuilder()
-													.add("tcf:sampleRate",
-															"S"
-																	+ Integer
-																			.toString((int) sr))
-													.add("tcf:numberOfSamples",
-															duration.getSamples()))
-									.add("tcf:filmFraming",
-											Json.createObjectBuilder()
-													.add("tcf:framing",
-															"NOT_APPLICABLE")
-													.add("tcf:framingType",
-															"tcf:ntscFilmFramingType")));
+            this.writeAESTimeRangePart(timerangeBuilder, "aes:duration", duration);
 		}
 		return timerangeBuilder;
 	}
 
+    private void writeAESTimeRangePart(final JsonObjectBuilder timerangeBuilder, final String name,
+        AESAudioMetadata.TimeDesc part) {
+            double sr = (part.getSampleRate() == 1.0) ? _sampleRate : part.getSampleRate();
+            timerangeBuilder
+            .add(name,
+                    Json.createObjectBuilder()
+                            .add("aes:value", part.getSamples())
+                            .add("aes:editRate", (int) sr)
+                            .add("aes:factorNumerator", "1")
+                            .add("aes:factorDenominator", "1"));
+    }
 	protected JsonArrayBuilder showArray(int[] iarray) {
 		JsonArrayBuilder aBuilder = Json.createArrayBuilder();
 		for (int i : iarray) {

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/TextHandler.java
@@ -933,17 +933,23 @@ public class TextHandler extends HandlerBase {
 			if (startTime != null) {
 				writeAESTimeRange(margn3, startTime, f.getDuration());
 			}
+
+            // For the present, assume just one face region
+            AESAudioMetadata.FaceRegion facergn = f.getFaceRegion(0);
+            _writer.println(margn3 + "Region: ");
+            _writer.println (margn4 + "TimeRange: ");
+            writeAESTimeRange(margn4, facergn.getStartTime(), facergn.getDuration());
+
 			int nchan = aes.getNumChannels();
 			if (nchan != AESAudioMetadata.NULL) {
 				_writer.println(margn4 + "NumChannels: "
 						+ Integer.toString(nchan));
 			}
-			String[] locs = aes.getMapLocations();
-			for (int ch = 0; ch < nchan; ch++) {
+
+            for (int ch = 0; ch < nchan; ch++) {
 				// write a stream description for each channel
 				_writer.println(margn4 + "Stream:");
 				_writer.println(margn5 + "ChannelNum: " + Integer.toString(ch));
-				_writer.println(margn5 + "ChannelAssignment: " + locs[ch]);
 			}
 		}
 
@@ -997,58 +1003,28 @@ public class TextHandler extends HandlerBase {
 	/* start must be non-null, but duration may be null */
 	private void writeAESTimeRange(String baseIndent,
 			AESAudioMetadata.TimeDesc start, AESAudioMetadata.TimeDesc duration) {
-		final String margn1 = baseIndent + " ";
-		final String margn2 = margn1 + " ";
-		final String margn3 = margn2 + " ";
-		_writer.println(margn1 + "StartTime:");
-		_writer.println(margn2 + "FrameCount: 30");
-		_writer.println(margn2 + "TimeBase: 1000");
-		_writer.println(margn2 + "VideoField: FIELD_1");
-		_writer.println(margn2 + "CountingMode: NTSC_NON_DROP_FRAME");
-		_writer.println(margn2 + "Hours: " + Long.toString(start.getHours()));
-		_writer.println(margn2 + "Minutes: "
-				+ Long.toString(start.getMinutes()));
-		_writer.println(margn2 + "Seconds: "
-				+ Long.toString(start.getSeconds()));
-		_writer.println(margn2 + "Frames: " + Long.toString(start.getFrames()));
-		_writer.println(margn2 + "Samples: ");
-		double sr = start.getSampleRate();
-		if (sr == 1.0) {
-			sr = _sampleRate;
-		}
-		_writer.println(margn3 + "SampleRate: S" + Integer.toString((int) sr));
-		_writer.println(margn3 + "NumberOfSamples: "
-				+ Long.toString(start.getSamples()));
-		_writer.println(margn2 + "FilmFraming: NOT_APPLICABLE");
-		_writer.println(margn3 + "Type: ntscFilmFramingType");
+        writeAESTimeRangePart(baseIndent, "StartTime", start);
 
 		if (duration != null) {
-			_writer.println(margn1 + "Duration:");
-			_writer.println(margn2 + "FrameCount: 30");
-			_writer.println(margn2 + "TimeBase: 1000");
-			_writer.println(margn2 + "VideoField: FIELD_1");
-			_writer.println(margn2 + "CountingMode: NTSC_NON_DROP_FRAME");
-			_writer.println(margn2 + "Hours: "
-					+ Long.toString(duration.getHours()));
-			_writer.println(margn2 + "Minutes: "
-					+ Long.toString(duration.getMinutes()));
-			_writer.println(margn2 + "Seconds: "
-					+ Long.toString(duration.getSeconds()));
-			_writer.println(margn2 + "Frames: "
-					+ Long.toString(duration.getFrames()));
-			_writer.println(margn2 + "Samples: ");
-			sr = duration.getSampleRate();
-			if (sr == 1.0) {
-				sr = _sampleRate;
-			}
-			_writer.println(margn3 + "SampleRate: S"
-					+ Integer.toString((int) sr));
-			_writer.println(margn3 + "NumberOfSamples: "
-					+ Long.toString(duration.getSamples()));
-			_writer.println(margn2 + "FilmFraming: NOT_APPLICABLE");
-			_writer.println(margn3 + "Type: ntscFilmFramingType");
+            writeAESTimeRangePart(baseIndent, "Duration", duration);
 		}
 	}
+    private void writeAESTimeRangePart(String baseIndent, String name, AESAudioMetadata.TimeDesc timeDesc) {
+        String margn1 = baseIndent + " ";
+        String margn2 = margn1 + " ";
+
+        _writer.println (margn1 + name + ": ");
+
+        double sampleRate = timeDesc.getSampleRate();
+        if (sampleRate == 1.0) {
+            sampleRate = _sampleRate;
+        }
+
+        _writer.println (margn2 + "Value: " + String.valueOf(timeDesc.getSamples()));
+        _writer.println (margn2 + "EditRate: " + Integer.toString ((int) sampleRate));
+        _writer.println (margn2 + "FactorNumerator: 1");
+        _writer.println (margn2 + "FactorDenominator: 1");
+    }
 
 	/**
 	 * Display the NISO image metadata formatted according to the MIX schema.

--- a/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
+++ b/jhove-core/src/main/java/edu/harvard/hul/ois/jhove/handler/XmlHandler.java
@@ -4247,7 +4247,6 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
         _sampleRate = aes.getSampleRate();
 
         final String[][] attrs = { { "xmlns:aes", "http://www.aes.org/audioObject" },
-                { "xmlns:tcf", "http://www.aes.org/tcf" },
                 { "xmlns:xsi",
                         "http://www.w3.org/2001/XMLSchema-instance" },
                 { "ID", audioObjectID },
@@ -4255,7 +4254,7 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
                         aes.getAnalogDigitalFlag() },
                 { "disposition",
                         "Validated by JHOVE" },
-                { "schemaVersion", "1.02b" } };
+                { "schemaVersion", aes.getSchemaVersion() } };
         _writer.println(margin + elementStart("aes:audioObject", attrs));
         String s = aes.getFormat();
         if (s != null) {
@@ -4340,7 +4339,7 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
             AESAudioMetadata.FaceRegion facergn = f.getFaceRegion(0);
             _writer.println(margn3 + elementStart("aes:region", faceRegionAttrs));
             _writer.println(margn4 + elementStart("aes:timeRange"));
-            writeAESTimeRange(margn3,
+            writeAESTimeRange(margn4,
                     facergn.getStartTime(), facergn.getDuration());
             _writer.println(margn4 + elementEnd("aes:timeRange"));
             int nchan = aes.getNumChannels();
@@ -4348,7 +4347,6 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
                 _writer.println(margn4 + element("aes:numChannels",
                         Integer.toString(nchan)));
             }
-            String[] locs = aes.getMapLocations();
             for (int ch = 0; ch < nchan; ch++) {
                 // write a stream element for each channel
                 String[][] streamAttrs = {
@@ -4359,8 +4357,7 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
                 };
                 _writer.println(margn4 + elementStart("aes:stream", streamAttrs));
                 String[][] chanAttrs = {
-                        { "channelNum", Integer.toString(ch) },
-                        { "mapLocation", locs[ch] }
+                        { "channelNum", Integer.toString(ch) }
                 };
                 _writer.println(margn5 + element("aes:channelAssignment", chanAttrs));
                 _writer.println(margn4 + elementEnd("aes:stream"));
@@ -4386,7 +4383,10 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
                     sampleRate != AESAudioMetadata.NILL ||
                     wordSize != AESAudioMetadata.NULL) {
                 _writer.println(margn2 + elementStart("aes:formatList"));
-                String[][] frAttr = { { "ID", formatRegionID } };
+                String[][] frAttr = { { "ID", formatRegionID }, 
+                    {"xsi:type", "aes:formatRegionType"}, 
+                    {"ownerRef", faceRegionID},
+                    {"label", "JHOVE"}};
                 _writer.println(margn3 + elementStart("aes:formatRegion", frAttr));
                 if (bitDepth != AESAudioMetadata.NULL) {
                     _writer.println(margn4 + element("aes:bitDepth",
@@ -4427,36 +4427,32 @@ public class XmlHandler extends edu.harvard.hul.ois.jhove.HandlerBase
         _level -= 3;
     }
 
-    /*
-     * Break out the writing of a timeRangeType element.
-     * This always gives a start time of 0. This is all
-     * FAKE DATA for the moment.
-     */
     private void writeAESTimeRange(String baseIndent,
             AESAudioMetadata.TimeDesc start,
             AESAudioMetadata.TimeDesc duration) {
         final String margn1 = baseIndent + " ";
-        final String margn2 = margn1 + " ";
-        final String[][] attrs = {
-                { "tcf:frameCount", "30" },
-                { "tcf:timeBase", "1000" },
-                { "tcf:videoField", "FIELD_1" },
-                { "tcf:countingMode", "NTSC_NON_DROP_FRAME" }
-        };
-        _writer.println(margn1 + elementStart("tcf:startTime", attrs));
-        _writer.println(margn2 + element("tcf:hours",
-                Long.toString(start.getHours())));
-        _writer.println(margn2 + element("tcf:minutes",
-                Long.toString(start.getMinutes())));
-        _writer.println(margn2 + element("tcf:seconds",
-                Long.toString(start.getSeconds())));
-        _writer.println(margn2 + element("tcf:frames",
-                Long.toString(start.getFrames())));
-        _writer.println(margn1 + elementEnd("tcf:startTime"));
-        double sr = start.getSampleRate();
-        if (sr == 1.0) {
-            sr = _sampleRate;
+
+        writeAESTimeRangePart(margn1, "aes:startTime", start);
+
+        if (duration != null) {
+            writeAESTimeRangePart(margn1, "aes:duration", duration);
         }
+    }
+
+    private void writeAESTimeRangePart(String indent, String elementName, AESAudioMetadata.TimeDesc timeDesc) {
+        double sampleRate = timeDesc.getSampleRate();
+        if (sampleRate == 1.0) {
+            sampleRate = _sampleRate;
+        }
+
+        String[][] attributes = {
+                {"editRate", formatters.get().format(sampleRate)},
+                {"factorNumerator", "1"},
+                {"factorDenominator", "1"}
+            };
+
+        _writer.println(indent +
+                element(elementName, attributes, String.valueOf(timeDesc.getSamples())));
     }
 
     /*

--- a/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/handler/JsonHandlerTest.java
+++ b/jhove-core/src/test/java/edu/harvard/hul/ois/jhove/handler/JsonHandlerTest.java
@@ -45,449 +45,442 @@ import edu.harvard.hul.ois.jhove.TextMDMetadata;
 
 @RunWith(JUnit4.class)
 public class JsonHandlerTest {
-	private static final Logger LOGGER = Logger.getLogger(JsonHandlerTest.class
-			.getName());
+    private static final Logger LOGGER = Logger.getLogger(JsonHandlerTest.class
+            .getName());
 
-	private static final String TIME_PATTERN = "\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2})?\"";
-	private static final String DATE_PATTERN = "\"date\":\"[^\"]+\"";
-	private static final String DATE_REPLACEMENT = "\"date\":\"2010-01-01\"";
-	private static final String RELEASE_PATTERN = "\"release\":\"[^\"]+\"";
-	private static final String RELEASE_REPLACEMENT = "\"release\":\"DUMMY\"";
-	private static final String DIR_PATTERN = "\"tempDirectory\":\"[^\"]+\"";
-	private static final String DIR_REPLACEMENT = "\"tempDirectory\":\"DUMMY\"";
-	private static final String CONF_PATTERN = "\"configuration\":\"[^\"]+\"";
-	private static final String CONF_REPLACEMENT = "\"configuration\":\"DUMMY\"";
-	private static final String RIGHTS_PATTERN = "\"rights\":\"[^\"]+\"";
-	private static final String RIGHTS_REPLACEMENT = "\"rights\":\"DUMMY\"";
-	private static final String VENDOR_PATTERN = "\"vendor\":\\{[^\\}]+\\}";
-	private static final String VENDOR_REPLACEMENT = "\"vendor\":{\"kind\":\"Vendor\"}";
-	private static final String DUMMY = "\"DUMMY\"";
-	private static final String DUMMY_CK = "8747e564eb53cb2f1dcb9aae0779c2aa";
-	private static final String BYTESTREAM = "BYTESTREAM";
-	private static final String APP_JSON = 
-			"\"name\":\"TEST\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\",\"executionTime\":\"DUMMY\"";
-	private static final String API_JSON = 
-			"\"app\":{\"api\":{\"version\":\"1.0\",\"date\":\"2010-01-01\"}," +
-			"\"configuration\":\"DUMMY\",\"jhoveHome\":\"TEST\",\"encoding\":\"utf-8\",\"tempDirectory\":\"DUMMY\"," +
-		    "\"bufferSize\":131072,\"modules\":[{\"module\":\"BYTESTREAM\",\"release\":\"DUMMY\"}]," +
-		    "\"outputHandlers\":[{\"outputHandler\":\"Audit\",\"release\":\"DUMMY\"}," +
-		    "{\"outputHandler\":\"JSON\",\"release\":\"DUMMY\"},{\"outputHandler\":\"TEXT\",\"release\":\"DUMMY\"}," +
-		    "{\"outputHandler\":\"XML\",\"release\":\"DUMMY\"}],\"usage\":\"usage\",\"rights\":\"DUMMY\"}";
-	private static final String HANDLER_JSON = 
-			"\"handler\":{\"name\":\"JSON\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\"," +
-			"\"vendor\":{\"kind\":\"Vendor\",\"name\":\"Bibliothèque nationale de France\",\"type\":\"Educational\"," +
-			"\"web\":\"http://www.bnf.fr\"},\"note\":\"\"," +
-			"\"rights\":\"DUMMY\"}";  
-	private static final String MODULE_JSON = 
-			"\"module\":{\"name\":\"BYTESTREAM\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\"," +
-			"\"formats\":[\"bytestream\"],\"mimeTypes\":[\"application/octet-stream\"]," +
-			"\"features\":[\"edu.harvard.hul.ois.jhove.canValidate\",\"edu.harvard.hul.ois.jhove.canCharacterize\"]," +
-			"\"methodology\":{\"wellFormed\":\"All bytestreams are well-formed\"}," +
-			"\"vendor\":{\"kind\":\"Vendor\"}," +
-			"\"note\":\"This is the default format\",\"rights\":\"DUMMY\"}";  
-	private static final String INFO_JSON =
-			"{\"uri\":\"file://dummy.file\"," +
-		    "\"reportingModule\":{\"name\":\"BYTESTREAM\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\"}," +
-		    "\"size\":1,\"format\":\"bytestream\",\"status\":\"Well-Formed and valid\",\"sigMatch\":[\"BYTESTREAM\"]," +
-		    "\"mimeType\":\"application/octet-stream\",\"properties\":[{\"checksum\":\"" +
-		    DUMMY_CK + "\",\"type\":\"MD5\"}]}";
-	/** Handler string "Find: " */
-	private static final String FIND = "Find: ";
+    private static final String TIME_PATTERN = "\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([+-][0-9]{2}:[0-9]{2})?\"";
+    private static final String DATE_PATTERN = "\"date\":\"[^\"]+\"";
+    private static final String DATE_REPLACEMENT = "\"date\":\"2010-01-01\"";
+    private static final String RELEASE_PATTERN = "\"release\":\"[^\"]+\"";
+    private static final String RELEASE_REPLACEMENT = "\"release\":\"DUMMY\"";
+    private static final String DIR_PATTERN = "\"tempDirectory\":\"[^\"]+\"";
+    private static final String DIR_REPLACEMENT = "\"tempDirectory\":\"DUMMY\"";
+    private static final String CONF_PATTERN = "\"configuration\":\"[^\"]+\"";
+    private static final String CONF_REPLACEMENT = "\"configuration\":\"DUMMY\"";
+    private static final String RIGHTS_PATTERN = "\"rights\":\"[^\"]+\"";
+    private static final String RIGHTS_REPLACEMENT = "\"rights\":\"DUMMY\"";
+    private static final String VENDOR_PATTERN = "\"vendor\":\\{[^\\}]+\\}";
+    private static final String VENDOR_REPLACEMENT = "\"vendor\":{\"kind\":\"Vendor\"}";
+    private static final String DUMMY = "\"DUMMY\"";
+    private static final String DUMMY_CK = "8747e564eb53cb2f1dcb9aae0779c2aa";
+    private static final String BYTESTREAM = "BYTESTREAM";
+    private static final String APP_JSON = "\"name\":\"TEST\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\",\"executionTime\":\"DUMMY\"";
+    private static final String API_JSON = "\"app\":{\"api\":{\"version\":\"1.0\",\"date\":\"2010-01-01\"}," +
+            "\"configuration\":\"DUMMY\",\"jhoveHome\":\"TEST\",\"encoding\":\"utf-8\",\"tempDirectory\":\"DUMMY\"," +
+            "\"bufferSize\":131072,\"modules\":[{\"module\":\"BYTESTREAM\",\"release\":\"DUMMY\"}]," +
+            "\"outputHandlers\":[{\"outputHandler\":\"Audit\",\"release\":\"DUMMY\"}," +
+            "{\"outputHandler\":\"JSON\",\"release\":\"DUMMY\"},{\"outputHandler\":\"TEXT\",\"release\":\"DUMMY\"}," +
+            "{\"outputHandler\":\"XML\",\"release\":\"DUMMY\"}],\"usage\":\"usage\",\"rights\":\"DUMMY\"}";
+    private static final String HANDLER_JSON = "\"handler\":{\"name\":\"JSON\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\","
+            +
+            "\"vendor\":{\"kind\":\"Vendor\",\"name\":\"Bibliothèque nationale de France\",\"type\":\"Educational\"," +
+            "\"web\":\"http://www.bnf.fr\"},\"note\":\"\"," +
+            "\"rights\":\"DUMMY\"}";
+    private static final String MODULE_JSON = "\"module\":{\"name\":\"BYTESTREAM\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\","
+            +
+            "\"formats\":[\"bytestream\"],\"mimeTypes\":[\"application/octet-stream\"]," +
+            "\"features\":[\"edu.harvard.hul.ois.jhove.canValidate\",\"edu.harvard.hul.ois.jhove.canCharacterize\"]," +
+            "\"methodology\":{\"wellFormed\":\"All bytestreams are well-formed\"}," +
+            "\"vendor\":{\"kind\":\"Vendor\"}," +
+            "\"note\":\"This is the default format\",\"rights\":\"DUMMY\"}";
+    private static final String INFO_JSON = "{\"uri\":\"file://dummy.file\"," +
+            "\"reportingModule\":{\"name\":\"BYTESTREAM\",\"release\":\"DUMMY\",\"date\":\"2010-01-01\"}," +
+            "\"size\":1,\"format\":\"bytestream\",\"status\":\"Well-Formed and valid\",\"sigMatch\":[\"BYTESTREAM\"]," +
+            "\"mimeType\":\"application/octet-stream\",\"properties\":[{\"checksum\":\"" +
+            DUMMY_CK + "\",\"type\":\"MD5\"}]}";
+    /** Handler string "Find: " */
+    private static final String FIND = "Find: ";
 
-	private static App mockApp;
-	private static JhoveBase je;
+    private static App mockApp;
+    private static JhoveBase je;
 
-	private File outputFile;
-	private StringWriter outString;
-	private PrintWriter writer;
-	private JsonHandler handler;
+    private File outputFile;
+    private StringWriter outString;
+    private PrintWriter writer;
+    private JsonHandler handler;
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws JhoveException {
-		mockApp = new App("TEST", "1.0", new int[]{2019,10,28}, "usage", "rights");
-		je = new JhoveBase();
-		je.setLogLevel("INFO");
-		String fileConf = JsonHandlerTest.class.getResource("/jhove_test.conf").getPath();
-		LOGGER.info("jhove.conf in:[" + fileConf + "]");
-		je.init(fileConf, null);
-	}
-	
-	@Before
-	public void setUp() throws IOException {
-		// Prepare for a new test
-		this.outputFile = File.createTempFile("jhove_", ".json");
-		
-		outString = new StringWriter();
-	    writer = new PrintWriter(outString);
-		
-		this.handler = new JsonHandler();
-		this.handler.setApp(mockApp);
-		this.handler.setBase(je);
-		this.handler.setWriter(writer);
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws JhoveException {
+        mockApp = new App("TEST", "1.0", new int[] { 2019, 10, 28 }, "usage", "rights");
+        je = new JhoveBase();
+        je.setLogLevel("INFO");
+        String fileConf = JsonHandlerTest.class.getResource("/jhove_test.conf").getPath();
+        LOGGER.info("jhove.conf in:[" + fileConf + "]");
+        je.init(fileConf, null);
+    }
 
-	@After
-	public void tearDown() {
-		if (this.outputFile != null && this.outputFile.exists()) {
-			this.outputFile.delete();
-		}
-	}
+    @Before
+    public void setUp() throws IOException {
+        // Prepare for a new test
+        this.outputFile = File.createTempFile("jhove_", ".json");
 
-	public void buildJson(JsonObjectBuilder builder) {
+        outString = new StringWriter();
+        writer = new PrintWriter(outString);
+
+        this.handler = new JsonHandler();
+        this.handler.setApp(mockApp);
+        this.handler.setBase(je);
+        this.handler.setWriter(writer);
+    }
+
+    @After
+    public void tearDown() {
+        if (this.outputFile != null && this.outputFile.exists()) {
+            this.outputFile.delete();
+        }
+    }
+
+    public void buildJson(JsonObjectBuilder builder) {
         JsonObject jsonObject = builder.build();
         JsonWriter jsonWriter = Json.createWriter(writer);
         jsonWriter.writeObject(jsonObject);
-	}
+    }
 
-	public void buildJson(JsonArrayBuilder builder) {
-		JsonObjectBuilder job = Json.createObjectBuilder().add("ARRAY", builder);
+    public void buildJson(JsonArrayBuilder builder) {
+        JsonObjectBuilder job = Json.createObjectBuilder().add("ARRAY", builder);
         JsonObject jsonObject = job.build();
         JsonWriter jsonWriter = Json.createWriter(writer);
         jsonWriter.writeObject(jsonObject);
-	}
+    }
 
-	@Test
-	public void testShow() {
+    @Test
+    public void testShow() {
         handler.showHeader();
         handler.show();
         handler.showFooter();
         handler.close();
-		
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT);
-	    assertEquals(
-	    		"{\"jhove\":{" + APP_JSON + "}}", result);
-    
-	}
-	
-	@Test
-	public void testShowApp() {
-        handler.showHeader();
-       	handler.show(mockApp);
-        handler.showFooter();
-        handler.close();
-        
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
-				.replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
-				.replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
-				.replaceAll(DIR_PATTERN, DIR_REPLACEMENT);
-		LOGGER.info(FIND + result);
-		String expected = "{\"jhove\":{" + APP_JSON + "," + API_JSON + "}}";
 
-	    assertEquals(expected, result);
-	}
-	
-	@Test
-	public void testShowOutputHandler() {
-		OutputHandler jsonHandler = je.getHandler("JSON");
-		
-        handler.showHeader();
-       	handler.show(jsonHandler);
-        handler.showFooter();
-        handler.close();
-        
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
-				.replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
-				.replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
-				.replaceAll(DIR_PATTERN, DIR_REPLACEMENT);
-		LOGGER.info(FIND + result);
-		String expected = "{\"jhove\":{" + APP_JSON + "," + HANDLER_JSON + "}}";
-		 
-	    assertEquals(expected, result);
-	}
-	
-	@Test
-	public void testShowModule() {
-		Module module = je.getModule(BYTESTREAM);
-		
-        handler.showHeader();
-       	handler.show(module);
-        handler.showFooter();
-        handler.close();
-        
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
-				.replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
-				.replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
-				.replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
-				.replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
-		LOGGER.info(FIND + result);
-		String expected = "{\"jhove\":{" + APP_JSON + "," + MODULE_JSON + "}}";
-		 
-	    assertEquals(expected, result);
-	}
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT);
+        assertEquals(
+                "{\"jhove\":{" + APP_JSON + "}}", result);
 
-	@Test
-	public void testShowRepInfo() {
-		Module module = je.getModule(BYTESTREAM);
-		RepInfo info = new RepInfo("file://dummy.file");
-		info.setModule(module);
-		info.setFormat(module.getFormat()[0]);
-		info.setMimeType(module.getMimeType()[0]);
-		info.setSigMatch(module.getName());
-		info.setChecksum(new Checksum(DUMMY_CK, ChecksumType.MD5));
-		info.setSize(1);
-		
+    }
+
+    @Test
+    public void testShowApp() {
         handler.showHeader();
-       	handler.show(info);
+        handler.show(mockApp);
         handler.showFooter();
         handler.close();
-        
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
-				.replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
-				.replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
-				.replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
-				.replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
-		LOGGER.info(FIND + result);
-		String expected = "{\"jhove\":{" + APP_JSON + ",\"repInfo\":[" + INFO_JSON + "]}}";
-		 
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowRepInfos() {
-		Module module = je.getModule(BYTESTREAM);
-		RepInfo info = new RepInfo("file://dummy.file");
-		info.setModule(module);
-		info.setFormat(module.getFormat()[0]);
-		info.setMimeType(module.getMimeType()[0]);
-		info.setSigMatch(module.getName());
-		info.setChecksum(new Checksum(DUMMY_CK, ChecksumType.MD5));
-		info.setSize(1);
-		
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
+                .replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
+                .replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
+                .replaceAll(DIR_PATTERN, DIR_REPLACEMENT);
+        LOGGER.info(FIND + result);
+        String expected = "{\"jhove\":{" + APP_JSON + "," + API_JSON + "}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowOutputHandler() {
+        OutputHandler jsonHandler = je.getHandler("JSON");
+
         handler.showHeader();
-       	handler.show(info);
-       	handler.show(info);
+        handler.show(jsonHandler);
         handler.showFooter();
         handler.close();
-        
-		String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
-				.replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
-				.replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
-				.replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
-				.replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
-				.replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
-				.replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
-		LOGGER.info(FIND + result);
-		String expected = "{\"jhove\":{" + APP_JSON + ",\"repInfo\":[" + INFO_JSON + "," + INFO_JSON + "]}}";
-		 
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowVendor() {
-		OutputHandler jsonHandler = je.getHandler("JSON");
-		Agent v = jsonHandler.getVendor(); 
-		
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
+                .replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
+                .replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
+                .replaceAll(DIR_PATTERN, DIR_REPLACEMENT);
+        LOGGER.info(FIND + result);
+        String expected = "{\"jhove\":{" + APP_JSON + "," + HANDLER_JSON + "}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowModule() {
+        Module module = je.getModule(BYTESTREAM);
+
+        handler.showHeader();
+        handler.show(module);
+        handler.showFooter();
+        handler.close();
+
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
+                .replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
+                .replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
+                .replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
+                .replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
+        LOGGER.info(FIND + result);
+        String expected = "{\"jhove\":{" + APP_JSON + "," + MODULE_JSON + "}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowRepInfo() {
+        Module module = je.getModule(BYTESTREAM);
+        RepInfo info = new RepInfo("file://dummy.file");
+        info.setModule(module);
+        info.setFormat(module.getFormat()[0]);
+        info.setMimeType(module.getMimeType()[0]);
+        info.setSigMatch(module.getName());
+        info.setChecksum(new Checksum(DUMMY_CK, ChecksumType.MD5));
+        info.setSize(1);
+
+        handler.showHeader();
+        handler.show(info);
+        handler.showFooter();
+        handler.close();
+
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
+                .replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
+                .replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
+                .replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
+                .replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
+        LOGGER.info(FIND + result);
+        String expected = "{\"jhove\":{" + APP_JSON + ",\"repInfo\":[" + INFO_JSON + "]}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowRepInfos() {
+        Module module = je.getModule(BYTESTREAM);
+        RepInfo info = new RepInfo("file://dummy.file");
+        info.setModule(module);
+        info.setFormat(module.getFormat()[0]);
+        info.setMimeType(module.getMimeType()[0]);
+        info.setSigMatch(module.getName());
+        info.setChecksum(new Checksum(DUMMY_CK, ChecksumType.MD5));
+        info.setSize(1);
+
+        handler.showHeader();
+        handler.show(info);
+        handler.show(info);
+        handler.showFooter();
+        handler.close();
+
+        String result = outString.toString().replaceAll(TIME_PATTERN, DUMMY)
+                .replaceAll(DATE_PATTERN, DATE_REPLACEMENT)
+                .replaceAll(RELEASE_PATTERN, RELEASE_REPLACEMENT)
+                .replaceAll(CONF_PATTERN, CONF_REPLACEMENT)
+                .replaceAll(RIGHTS_PATTERN, RIGHTS_REPLACEMENT)
+                .replaceAll(DIR_PATTERN, DIR_REPLACEMENT)
+                .replaceAll(VENDOR_PATTERN, VENDOR_REPLACEMENT);
+        LOGGER.info(FIND + result);
+        String expected = "{\"jhove\":{" + APP_JSON + ",\"repInfo\":[" + INFO_JSON + "," + INFO_JSON + "]}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowVendor() {
+        OutputHandler jsonHandler = je.getHandler("JSON");
+        Agent v = jsonHandler.getVendor();
+
         JsonObjectBuilder json = handler.showAgent(v, "OTHER");
         buildJson(json);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"kind\":\"OTHER\",\"name\":\"Bibliothèque nationale de France\"," +
-				"\"type\":\"Educational\",\"web\":\"http://www.bnf.fr\"}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowScalarProperty() throws IOException {
-		final Property prop = new Property("test", PropertyType.INTEGER, PropertyArity.SCALAR, 2);
-		JsonObjectBuilder b = this.handler.showScalarProperty(prop);
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"kind\":\"OTHER\",\"name\":\"Bibliothèque nationale de France\"," +
+                "\"type\":\"Educational\",\"web\":\"http://www.bnf.fr\"}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowScalarProperty() throws IOException {
+        final Property prop = new Property("test", PropertyType.INTEGER, PropertyArity.SCALAR, 2);
+        JsonObjectBuilder b = this.handler.showScalarProperty(prop);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"test\":2}";
-		
-	    assertEquals(expected, result);
-	}
-	
-	@Test
-	public void testShowListProperty() throws IOException {
-		final List<Double> testList = Arrays.asList(new Double[]{1.0, 2.0});
-		Property prop = new Property("test", PropertyType.DOUBLE, PropertyArity.LIST, testList);
-		JsonObjectBuilder b = this.handler.showListProperty(prop);
-		buildJson(b);
+
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"test\":2}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowListProperty() throws IOException {
+        final List<Double> testList = Arrays.asList(new Double[] { 1.0, 2.0 });
+        Property prop = new Property("test", PropertyType.DOUBLE, PropertyArity.LIST, testList);
+        JsonObjectBuilder b = this.handler.showListProperty(prop);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"test\":[1.0,2.0]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowSetProperty() throws IOException {
-		// use a LinkedHashSet to be sure of the output order...
-		final Set<Rational> testSet = new LinkedHashSet<>(
-				Arrays.asList(new Rational[]{new Rational(300, 1), new Rational(4, 2)}));
-		Property prop = new Property("test", PropertyType.RATIONAL, PropertyArity.SET, testSet);
-		JsonObjectBuilder b = this.handler.showSetProperty(prop);
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"test\":[1.0,2.0]}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowSetProperty() throws IOException {
+        // use a LinkedHashSet to be sure of the output order...
+        final Set<Rational> testSet = new LinkedHashSet<>(
+                Arrays.asList(new Rational[] { new Rational(300, 1), new Rational(4, 2) }));
+        Property prop = new Property("test", PropertyType.RATIONAL, PropertyArity.SET, testSet);
+        JsonObjectBuilder b = this.handler.showSetProperty(prop);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"test\":[[300,1],[4,2]]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowMapProperty() throws IOException {
-		final Map<String,String> testMap = Collections.singletonMap("mykey", "myvalue");
-		Property prop = new Property("test", PropertyType.STRING, PropertyArity.MAP, testMap);
-		JsonObjectBuilder b = this.handler.showMapProperty(prop);
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"test\":[[300,1],[4,2]]}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowMapProperty() throws IOException {
+        final Map<String, String> testMap = Collections.singletonMap("mykey", "myvalue");
+        Property prop = new Property("test", PropertyType.STRING, PropertyArity.MAP, testMap);
+        JsonObjectBuilder b = this.handler.showMapProperty(prop);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"test\":{\"mykey\":\"myvalue\"}}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowArrayMapProperty() throws IOException {
-		final boolean[] testArray = new boolean[]{true, false, true};
-		Property prop = new Property("test", PropertyType.BOOLEAN, PropertyArity.ARRAY, testArray);
-		JsonObjectBuilder b = this.handler.showArrayProperty(prop);
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"test\":{\"mykey\":\"myvalue\"}}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowArrayMapProperty() throws IOException {
+        final boolean[] testArray = new boolean[] { true, false, true };
+        Property prop = new Property("test", PropertyType.BOOLEAN, PropertyArity.ARRAY, testArray);
+        JsonObjectBuilder b = this.handler.showArrayProperty(prop);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"test\":[true,false,true]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowTextMD() throws IOException {
-		final TextMDMetadata textMD = new TextMDMetadata();
-		textMD.setCharset("UTF-8");
-		textMD.setLanguage("fr");
-	
-		JsonObjectBuilder b = this.handler.showTextMDMetadata(textMD);
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"test\":[true,false,true]}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowTextMD() throws IOException {
+        final TextMDMetadata textMD = new TextMDMetadata();
+        textMD.setCharset("UTF-8");
+        textMD.setLanguage("fr");
+
+        JsonObjectBuilder b = this.handler.showTextMDMetadata(textMD);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"textmd:charset\":\"UTF-8\",\"textmd:byte_order\":\"big\"," +
-				"\"textmd:linebreak\":\"CR/LF\",\"textmd:language\":\"fre\"}";
 
-	    assertEquals(expected, result);
-	}
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"textmd:charset\":\"UTF-8\",\"textmd:byte_order\":\"big\"," +
+                "\"textmd:linebreak\":\"CR/LF\",\"textmd:language\":\"fre\"}";
 
-	@Test
-	public void testShowAESAudioMetadata() throws IOException {
-		final AESAudioMetadata aes = new AESAudioMetadata();
-		aes.setFormat("audio/wav");
-	
-		JsonObjectBuilder b = this.handler.showAESAudioMetadata(aes);
-		buildJson(b);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowAESAudioMetadata() throws IOException {
+        final AESAudioMetadata aes = new AESAudioMetadata();
+        aes.setFormat("audio/wav");
+
+        JsonObjectBuilder b = this.handler.showAESAudioMetadata(aes);
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"aes:schemaVersion\":\"1.02b\",\"aes:format\":\"audio/wav\"," +
-				"\"aes:face\":{\"aes:timeline\":{\"tcf:startTime\":{\"tcf:frameCount\":30,\"tcf:timeBase\":1000," +
-				"\"tcf:videoField\":\"FIELD_1\",\"tcf:countingMode\":\"NTSC_NON_DROP_FRAME\",\"tcf:hours\":0," +
-				"\"tcf:minutes\":0,\"tcf:seconds\":0,\"tcf:frames\":0," +
-				"\"tcf:samples\":{\"tcf:sampleRate\":\"S44100\",\"tcf:numberOfSamples\":0}," +
-				"\"tcf:filmFraming\":{\"tcf:framing\":\"NOT_APPLICABLE\",\"tcf:framingType\":\"tcf:ntscFilmFramingType\"}}}," +
-				"\"aes:streams\":[]}}";
 
-	    assertEquals(expected, result);
-	}
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"aes:schemaVersion\":\"1.0.0\",\"aes:format\":\"audio/wav\"," +
+                "\"aes:face\":{\"aes:timeline\":{\"aes:start\":{\"aes:value\":0,\"aes:editRate\":44100," +
+                "\"aes:factorNumerator\":\"1\",\"aes:factorDenominator\":\"1\"}}," +
+                "\"aes:streams\":[]}}";
 
-	@Test
-	public void testShowArrayInt() throws IOException {
-		final int[] iArrayTest = { 1, 2, 3 };
-		JsonArrayBuilder b = this.handler.showArray(iArrayTest);
+        assertEquals(expected, result);
+    }
 
-		buildJson(b);
+    @Test
+    public void testShowArrayInt() throws IOException {
+        final int[] iArrayTest = { 1, 2, 3 };
+        JsonArrayBuilder b = this.handler.showArray(iArrayTest);
+
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"ARRAY\":[1,2,3]}";
-		
-	    assertEquals(expected, result);
-	}
-	
-	@Test
-	public void testShowArrayDouble() throws IOException {
-		final double[] dArrayTest = { -1.0, 0, 1.0 };
-		JsonArrayBuilder b = this.handler.showArray(dArrayTest);
 
-		buildJson(b);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"ARRAY\":[1,2,3]}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowArrayDouble() throws IOException {
+        final double[] dArrayTest = { -1.0, 0, 1.0 };
+        JsonArrayBuilder b = this.handler.showArray(dArrayTest);
+
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"ARRAY\":[-1.0,0.0,1.0]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowArrayString() throws IOException {
-		final String[] sArrayTest = { null, "", "DUMMY" };
-		JsonArrayBuilder b = this.handler.showArray(sArrayTest);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"ARRAY\":[-1.0,0.0,1.0]}";
 
-		buildJson(b);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowArrayString() throws IOException {
+        final String[] sArrayTest = { null, "", "DUMMY" };
+        JsonArrayBuilder b = this.handler.showArray(sArrayTest);
+
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"ARRAY\":[null,\"\",\"DUMMY\"]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	
-	@Test
-	public void testShowArrayRational() throws IOException {
-		final Rational[] rArrayTest = { new Rational(1L,1L), new Rational(-1, 2) };
-		JsonArrayBuilder b = this.handler.showArray(rArrayTest);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"ARRAY\":[null,\"\",\"DUMMY\"]}";
 
-		buildJson(b);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowArrayRational() throws IOException {
+        final Rational[] rArrayTest = { new Rational(1L, 1L), new Rational(-1, 2) };
+        JsonArrayBuilder b = this.handler.showArray(rArrayTest);
+
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"ARRAY\":[[1,1],[-1,2]]}";
-		
-	    assertEquals(expected, result);
-	}
 
-	@Test
-	public void testShowRational() throws IOException {
-		final Rational r = new Rational(123456,43211);
-		JsonArrayBuilder b = this.handler.showRational(r);
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"ARRAY\":[[1,1],[-1,2]]}";
 
-		buildJson(b);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testShowRational() throws IOException {
+        final Rational r = new Rational(123456, 43211);
+        JsonArrayBuilder b = this.handler.showRational(r);
+
+        buildJson(b);
         handler.close();
-        
-		String result = outString.toString();
-		LOGGER.info(FIND + result);
-		final String expected = "{\"ARRAY\":[123456,43211]}";
-		
-	    assertEquals(expected, result);
-	}
+
+        String result = outString.toString();
+        LOGGER.info(FIND + result);
+        final String expected = "{\"ARRAY\":[123456,43211]}";
+
+        assertEquals(expected, result);
+    }
 }


### PR DESCRIPTION
Copied from #357 contributed by @pwinckles, thanks! Apologies the PR was old enough to make merging difficult. My only contribution was the JSON handler output.

The AES output that JHOVE currently generates does not conform to the AES57-2011 spec. The schema can be found [here](https://www.loc.gov/standards/amdvmd/audiovideoMDschemas.html).

This commit updates JHOVE to produce a valid AES57-2011 document. The bulk of the changes are related to how times and durations are reported. The original code generated a structure like this:
```xml
<tcf:duration tcf:frameCount="30" tcf:timeBase="1000" tcf:videoField="FIELD_1" tcf:countingMode="NTSC_NON_DROP_FRAME">
  <tcf:hours>0</tcf:hours>
  <tcf:minutes>0</tcf:minutes>
  <tcf:seconds>12</tcf:seconds>
  <tcf:frames>29</tcf:frames>
  <tcf:samples tcf:sampleRate="S44100">
    <tcf:numberOfSamples>121</tcf:numberOfSamples>
  </tcf:samples>
  <tcf:filmFraming tcf:framing="NOT_APPLICABLE" xsi:type="tcf:ntscFilmFramingType"/>
</tcf:duration>
```
The same information is now represented like this:
```xml
<aes:duration editRate="44100" factorNumerator="1" factorDenominator="1">571951</aes:duration>
```
Another change affects the "channelAssignment" element. This element does not have a "mapLocation" attribute, as the current code adds. Instead, AES57-2011 uses two new attributes "leftRightPostion" and "frontRearPosition". Detailed descriptions of this attributes can be found on [this page](https://rucore.libraries.rutgers.edu/open/projects/openwms/index.php?sec=guides&sub=metadata&pg=t_sound-qual). I could not determine a way to map all of the possible JHOVE "mapLocations" to the new AES attributes (for example, what does "SURROUND" mean?), so I decided to leave them out rather than include potentially inaccurate data.

(As an aside, I suspect that the way that JHOVE is currently mapping channel location for 4-channel AIFF audio is incorrect. [Per spec](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Docs/AIFF-1.3.pdf), it should be LEFT, CENTER, RIGHT, SURROUND. JHOVE maps it as LEFT, RIGHT, CENTER, SURROUND.)

Fixes #362 #367
Closes #357