### PR TITLE
FIX: UTF-8 module bump

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,17 +11,17 @@ title: JSTOR/Harvard Object Validation Environment
   <header class="jumbotron vertical-center">
     <img src="img/jhovelogo.png" alt="JHOVE logo"/>
     <h2>Open source file format identification, validation &amp; characterisation</h2>
-    <a href="http://software.openpreservation.org/rel/jhove-latest.jar" class="btn btn-primary btn-lg pad" download>Download JHOVE</a>
+    <a href="https://software.openpreservation.org/rel/jhove-latest.jar" class="btn btn-primary btn-lg pad" download>Download JHOVE</a>
   </header>
   <main>
     <a class="name" name="software">
       <h2>Software</h2>
     </a>
-    <p class="version">Currently v1.28 19-05-2023</p>
+    <p class="version">Currently v1.30.1 31-07-2024</p>
     <p>Details of the latest release, including release notes <a href="https://github.com/openpreserve/jhove/releases/latest">can be found on GitHub</a>.</p>
     <p>
       JHOVE is a file format identification, validation and characterisation tool. It is implemented as a
-      <a href="http://www.oracle.com/technetwork/java/index.html">Java</a>
+      <a href="https://www.oracle.com/java/technologies/">Java</a>
       application and is usable on any Unix, Windows, or OS X platform with appropriate Java installation.
     </p>
     <h3>Supported Formats</h3>
@@ -156,21 +156,21 @@ title: JSTOR/Harvard Object Validation Environment
     </a>
     <p>
       JHOVE is made available by the
-      <a href="http://openpreservation.org" title="Open Preservation Foundation home page.">Open
+      <a href="https://openpreservation.org" title="Open Preservation Foundation home page.">Open
         Preservation Foundation</a>
       under the <a href="http://www.gnu.org/">GNU</a>
-      <a href="http://www.gnu.org/licenses/licenses.html#LGPL">Lesser General Public
+      <a href="https://www.gnu.org/licenses/licenses.html#LGPL">Lesser General Public
       License</a> (LGPL).
     </p>
     <p>
       Note that some previous versions of JHOVE were released under the
-      <a href="http://www.gnu.org/">GNU</a>
-      <a href="http://www.gnu.org/licenses/licenses.html#GPL">General Public
+      <a href="https://www.gnu.org/">GNU</a>
+      <a href="https://www.gnu.org/licenses/licenses.html#GPL">General Public
       License</a> (GPL).
     </p>
       <h2>Mailing list</h2>
     <p>
-      <a href="http://lists.openpreservation.org/listinfo/jhove">Subscribe</a> to the JHOVE mailing list.
+      <a href="https://lists.openpreservation.org/listinfo/jhove">Subscribe</a> to the JHOVE mailing list.
     </p>
   </main>
 </div>

--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -27,7 +27,7 @@
     <jpeg.hul.version>1.5.4</jpeg.hul.version>
     <pdf.hul.version>1.12.7</pdf.hul.version>
     <tiff.hul.version>1.9.5</tiff.hul.version>
-    <utf8.hul.version>1.7.3</utf8.hul.version>
+    <utf8.hul.version>1.7.4</utf8.hul.version>
     <wave.hul.version>1.8.3</wave.hul.version>
     <xml.hul.version>1.5.5</xml.hul.version>
   </properties>

--- a/jhove-modules/utf8-hul/pom.xml
+++ b/jhove-modules/utf8-hul/pom.xml
@@ -6,7 +6,7 @@
     <version>1.32.0-RC1</version>
   </parent>
   <artifactId>utf8-hul</artifactId>
-  <version>1.7.3</version>
+  <version>1.7.4</version>
   <name>JHOVE UTF8 Module HUL</name>
   <description>UTF8 module developed by Harvard University Library</description>
 

--- a/jhove-modules/xml-hul/pom.xml
+++ b/jhove-modules/xml-hul/pom.xml
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>utf8-hul</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.4</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
- UTF8-hul version needs bumping for Maven publication; and
- TIFF-hul bumped for 1.32 release.

Closes #936