### PR TITLE
FIX: UTF-8 module bump

### DIFF
--- a/jhove-installer/pom.xml
+++ b/jhove-installer/pom.xml
@@ -27,7 +27,7 @@
     <jpeg.hul.version>1.5.4</jpeg.hul.version>
     <pdf.hul.version>1.12.7</pdf.hul.version>
     <tiff.hul.version>1.9.5</tiff.hul.version>
-    <utf8.hul.version>1.7.3</utf8.hul.version>
+    <utf8.hul.version>1.7.4</utf8.hul.version>
     <wave.hul.version>1.8.3</wave.hul.version>
     <xml.hul.version>1.5.5</xml.hul.version>
   </properties>

--- a/jhove-modules/utf8-hul/pom.xml
+++ b/jhove-modules/utf8-hul/pom.xml
@@ -6,7 +6,7 @@
     <version>1.32.0-RC1</version>
   </parent>
   <artifactId>utf8-hul</artifactId>
-  <version>1.7.3</version>
+  <version>1.7.4</version>
   <name>JHOVE UTF8 Module HUL</name>
   <description>UTF8 module developed by Harvard University Library</description>
 

--- a/jhove-modules/xml-hul/pom.xml
+++ b/jhove-modules/xml-hul/pom.xml
@@ -14,7 +14,7 @@
       <dependency>
         <groupId>org.openpreservation.jhove.modules</groupId>
         <artifactId>utf8-hul</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.4</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
- UTF8-hul version needs bumping for Maven publication; and
- TIFF-hul bumped for 1.32 release.