### PR TITLE
FIX: German XML error message

### DIFF
--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_de.properties
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_de.properties
@@ -1,5 +1,5 @@
 XML-HUL-1 = SAXParseException
-XML-HUL-1-SUB = {0} Zeile = {1,number,integer}, Spalte = {2,number,integer}.
+XML-HUL-1-SUB = Zeile = {0,number,integer}, Spalte = {1,number,integer}.
 XML-HUL-2 = Maximalanzahl {0,number,integer} für Fehlermeldungen erreicht. Weitere Fehler werden nicht mehr angezeigt.
 XML-HUL-3 = SAXException: {0}
 XML-HUL-4 = Typ des Zeilenendes konnte nicht erkannt werden.

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_fr.properties
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_fr.properties
@@ -1,6 +1,6 @@
 XML-HUL-1 = SaxParseException : {0}
 XML-HUL-1-SUB = Line = {0,number,integer}, Column = {1,number,integer}.
-XML-HUL-2 = {0} messages d'erreur supplémentaires non signalés
+XML-HUL-2 = {0,number,integer} messages d'erreur supplémentaires non signalés
 XML-HUL-3 = SaxParseException : {0}
 XML-HUL-4 = Impossible de déterminer le type de fin de ligne 
 XML-HUL-5 = L'interface LexicalHandler n'est pas supportée par votre implémentation XML. Certaines propriétés peuvent ne pas être signalées.

--- a/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_pt_BR.properties
+++ b/jhove-modules/xml-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/xml/ErrorMessages_pt_BR.properties
@@ -1,6 +1,6 @@
 XML-HUL-1 = SaxParseException: {0}
 XML-HUL-1-SUB = Line = {0,number,integer}, Column = {1,number,integer}.
-XML-HUL-2 = As mensagens de erro acima de {0} não reportadas
+XML-HUL-2 = As mensagens de erro acima de {0,number,integer} não reportadas
 XML-HUL-3 = SaxParseException: {0}
 XML-HUL-4 = Não foi possível determinar o tipo de fim de linha
 XML-HUL-5 = A interface LexicalHandler não é suportada por sua implementação XML. Isso pode resultar em algumas propriedades não sendo reportadas.


### PR DESCRIPTION
- fixed formatting of `XML-HUL1` for german translation; and
- added formatting types to french and portugese translations.

Closes #954