### PR TITLE
FEAT: Slimline and templated Dockerfile

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -5,14 +5,11 @@ FROM maven:3-eclipse-temurin-11-alpine AS dev-builder
 ARG JHOVE_VERSION
 ENV JHOVE_VERSION=${JHOVE_VERSION}
 
-RUN apk add --no-cache git
-WORKDIR /build
-
-# Clone the repo, checkout the revision and build the application
-RUN git clone https://github.com/openpreserve/jhove.git
-
+# Copy the current dev source branch to a local build dir
+COPY . /build/jhove/
 WORKDIR /build/jhove
-RUN git checkout v${JHOVE_VERSION} && mvn clean package && java -jar jhove-installer/target/jhove-xplt-installer-${JHOVE_VERSION}.jar docker-install.xml
+
+RUN mvn clean package && java -jar jhove-installer/target/jhove-xplt-installer-${JHOVE_VERSION}.jar docker-install.xml
 
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink

--- a/Dockerfile_installer
+++ b/Dockerfile_installer
@@ -1,0 +1,52 @@
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# First build the app on a maven open jdk 11 container
+ARG JHOVE_VERSION=1.32
+FROM eclipse-temurin:11-jdk-alpine AS app-installer
+ARG JHOVE_VERSION
+ENV JHOVE_VERSION=${JHOVE_VERSION}
+
+WORKDIR /tmp
+COPY docker-install.xml .
+RUN wget -O /tmp/jhove-installer.jar https://software.openpreservation.org/releases/jhove/jhove-${JHOVE_VERSION}.jar
+RUN java -jar jhove-installer.jar docker-install.xml
+
+# Now build a Java JRE for the Alpine application image
+# https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
+FROM eclipse-temurin:11-jdk-alpine AS jre-builder
+
+# Create a custom Java runtime
+RUN "$JAVA_HOME/bin/jlink" \
+         --add-modules java.base,java.logging,java.xml,jdk.crypto.ec \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+# Now the final application image
+FROM alpine:3
+
+# Set for additional arguments passed to the java run command, no default
+ARG JAVA_OPTS
+ENV JAVA_OPTS=$JAVA_OPTS
+# Specify the veraPDF REST version if you want to (to be used in build automation)
+ARG JHOVE_VERSION
+ENV JHOVE_VERSION=${JHOVE_VERSION}
+
+# Copy the JRE from the previous stage
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
+
+# Since this is a running network service we'll create an unprivileged account
+# which will be used to perform the rest of the work and run the actual service:
+RUN addgroup -S jhove && adduser -S -G jhove -h /opt/jhove jhove
+RUN mkdir --parents /var/opt/jhove/logs && chown -R jhove:jhove /var/opt/jhove
+
+USER jhove
+
+WORKDIR /opt/jhove
+# Copy the application from the previous stage
+COPY --from=app-installer /opt/jhove/ /opt/jhove/
+
+ENTRYPOINT ["/opt/jhove/jhove"]

--- a/Dockerfile_installer
+++ b/Dockerfile_installer
@@ -44,9 +44,12 @@ RUN addgroup -S jhove && adduser -S -G jhove -h /opt/jhove jhove
 RUN mkdir --parents /var/opt/jhove/logs && chown -R jhove:jhove /var/opt/jhove
 
 USER jhove
-
 WORKDIR /opt/jhove
+
 # Copy the application from the previous stage
 COPY --from=app-installer /opt/jhove/ /opt/jhove/
+
+WORKDIR /data
+VOLUME [ "/data" ]
 
 ENTRYPOINT ["/opt/jhove/jhove"]

--- a/pom.xml
+++ b/pom.xml
@@ -202,11 +202,36 @@
             </goals>
           </execution>
           <execution>
-              <id>generate-code-coverage-report</id>
-              <phase>test</phase>
-              <goals>
-                  <goal>report</goal>
-              </goals>
+            <id>generate-code-coverage-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>templates/docker</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -233,6 +258,7 @@
 
   <dependencies>
   </dependencies>
+
   <profiles>
     <profile>
       <id>jdk9</id>
@@ -273,13 +299,13 @@
       </build>
       <dependencies>
 
-      <!-- https://mvnrepository.com/artifact/org.sonarsource.java/sonar-jacoco-listeners -->
-      <dependency>
-        <groupId>org.sonarsource.java</groupId>
-        <artifactId>sonar-jacoco-listeners</artifactId>
-        <version>5.14.0.18788</version>
-        <scope>test</scope>
-      </dependency>
+        <!-- https://mvnrepository.com/artifact/org.sonarsource.java/sonar-jacoco-listeners -->
+        <dependency>
+          <groupId>org.sonarsource.java</groupId>
+          <artifactId>sonar-jacoco-listeners</artifactId>
+          <version>5.14.0.18788</version>
+          <scope>test</scope>
+        </dependency>
 
       </dependencies>
     </profile>
@@ -405,7 +431,6 @@
         </repository>
       </distributionManagement>
     </profile>
-
   </profiles>
 
 </project>

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -1,6 +1,6 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 # First build the app on a maven open jdk 11 container
-ARG JHOVE_VERSION=1.33.0-SNAPSHOT
+ARG JHOVE_VERSION=${project.version}
 FROM maven:3-eclipse-temurin-11-alpine AS dev-builder
 ARG JHOVE_VERSION
 ENV JHOVE_VERSION=${JHOVE_VERSION}

--- a/templates/docker/Dockerfile_dev
+++ b/templates/docker/Dockerfile_dev
@@ -1,18 +1,15 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 # First build the app on a maven open jdk 11 container
-ARG JHOVE_VERSION=1.33.0-SNAPSHOT
+ARG JHOVE_VERSION=${project.version}
 FROM maven:3-eclipse-temurin-11-alpine AS dev-builder
 ARG JHOVE_VERSION
 ENV JHOVE_VERSION=${JHOVE_VERSION}
 
-RUN apk add --no-cache git
-WORKDIR /build
-
-# Clone the repo, checkout the revision and build the application
-RUN git clone https://github.com/openpreserve/jhove.git
-
+# Copy the current dev source branch to a local build dir
+COPY . /build/jhove/
 WORKDIR /build/jhove
-RUN git checkout v${JHOVE_VERSION} && mvn clean package && java -jar jhove-installer/target/jhove-xplt-installer-${JHOVE_VERSION}.jar docker-install.xml
+
+RUN mvn clean package && java -jar jhove-installer/target/jhove-xplt-installer-${JHOVE_VERSION}.jar docker-install.xml
 
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink


### PR DESCRIPTION
- moved to an all Alpine stack for build and the final image;
- now two Dockerfiles:
  - `Dockerfile` builds a tag by cloning the GitHub repo;
  - `Dockerfile_dev` builds a copy of the local project;
- added templated versions of both the above that are so that they are updated automatically as part of the Maven build; and
- updated the main `pom.xml` with a `resource` plugin to copy the `Dockerfile` and `Dockerfile_dev` to the base directory.