### PR TITLE
FIX: Check obbject number against trailer size

### DIFF
--- a/jhove-bbt/scripts/create-1.33-target.sh
+++ b/jhove-bbt/scripts/create-1.33-target.sh
@@ -113,3 +113,13 @@ do
 		cp "${candidateRoot}/${filename}" "${targetRoot}/${filename}"
 	fi
 done
+
+# Copy the regression test files affected by the change to object count checking against size
+declare -a xref_size_affected=("errors/modules/PDF-hul/pdf-hul-73-bug-size-int.pdf.jhove.xml"
+				"regression/modules/PDF-hul/issue_531.pdf.jhove.xml")
+for filename in "${xref_size_affected[@]}"
+do
+	if [[ -f "${candidateRoot}/${filename}" ]]; then
+		cp "${candidateRoot}/${filename}" "${targetRoot}/${filename}"
+	fi
+done

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/pdf/MessageConstants.java
@@ -201,6 +201,8 @@ public enum MessageConstants {
     public static final JhoveMessage PDF_HUL_160 = messageFactory.getMessage("PDF-HUL-160");
     public static final JhoveMessage PDF_HUL_161 = messageFactory.getMessage("PDF-HUL-161");
     public static final JhoveMessage PDF_HUL_162 = messageFactory.getMessage("PDF-HUL-162");
+    public static final JhoveMessage PDF_HUL_163 = messageFactory.getMessage("PDF-HUL-163");
+    public static final JhoveMessage PDF_HUL_163_SUB = messageFactory.getMessage("PDF-HUL-163-SUB");
 
     /**
      * Logger Messages

--- a/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
+++ b/jhove-modules/pdf-hul/src/main/resources/edu/harvard/hul/ois/jhove/module/pdf/ErrorMessages.properties
@@ -164,3 +164,5 @@ PDF-HUL-159 = Image height and width are manditory properties
 PDF-HUL-160 = IO Exception reading PDF Header
 PDF-HUL-161 = PDF major version number should be 1.x or 2.x
 PDF-HUL-162 = Malformed PDF version number
+PDF-HUL-163 = Object number exceeds the number of objects reported in the trailer Size entry
+PDF-HUL-163-SUB = Object number {0} + 1 is greater than trailer.Size {1}


### PR DESCRIPTION
- added specific check of object number against trailer size and signal new error `PDF-HUL-163` with details;
- validation continues after these objects which should be ignored according to the PDF specification;
- renamed variables for clarity;
- replaced deprecated used of `new Integer()` with `Integer.valueOf()' in PDF module; and
- fixed error output for test corpus for affected files.