### PR TITLE
Bugfix in JPEG2000 module

### DIFF
--- a/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
+++ b/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
@@ -171,35 +171,23 @@ public class ContCodestream {
                 // We're done parsing this marker segment. Let's update the
                 // count of bytes remaining in this codestream (and, if
                 // applicable, tile-part) before parsing the next marker segment
-                // in the next iteration of the while loop.
-                if (!(ms instanceof Marker)) {
-                    // This was a proper marker segment with parameters, so we
-                    // consumed (marker segment length + 2-bytes marker) bytes.
-                    lengthLeft -= markLen + 2;
-                    if (_tileLeft > 0) {
-                        _tileLeft -= markLen + 2;
-                    }
+                // in the next iteration of the while loop. As explained above,
+                // a marker segment has a size of markLen + 2 bytes, where
+                // markLen is 0 for marker segments without parameters.
+                lengthLeft -= markLen + 2;
+                if (_tileLeft > 0) {
+                    _tileLeft -= markLen + 2;
                 }
-                else {
-                    // This was a plain marker without parameters, so we only
-                    // consumed 2 bytes for the marker.
-                    lengthLeft -= 2;
-                    if (_tileLeft > 0) {
-                        _tileLeft -= 2;
-                    }
-                    if (marker == SOD) {
-                        // 0X93 is SOD, which is followed by a bitstream.
-                        // We skip the number of bytes not yet deducted from _tileLeft
-                        // TODO The _tileLeft variable has type long, and the
-                        // skipBytes methods expects a long as well. So why is
-                        // _tileLeft cast to int here?
-                        _module.skipBytes (_dstream, (int) _tileLeft, _module);
-                        lengthLeft -= _tileLeft;
-                        _tileLeft = 0;
-                    }
-                    else if (marker == EOC) {
-                        break;      // end of codestream
-                    }
+                // A SOD marker segment is followed by a bitstream (raw data).
+                // We skip the number of bytes not yet deducted from _tileLeft.
+                if (marker == SOD) {
+                    _module.skipBytes (_dstream, _tileLeft, _module);
+                    lengthLeft -= _tileLeft;
+                    _tileLeft = 0;
+                }
+                if (marker == EOC) {
+                    // End of codestream, we're done.
+                    break;
                 }
             }
         }

--- a/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
+++ b/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
@@ -160,7 +160,7 @@ public class ContCodestream {
                 // this length to the _tileLeft attribute. Now, if _tileLeft is
                 // 0, this tile-part is assumed to contain all data until the
                 // end of the current codestream (see section A.4.2 (page 22) in
-                // https://web.archive.org/web/20130810200214/http://www.jpeg.org/public/fcd15444-1.pdf.
+                // https://web.archive.org/web/20130810200214/http://www.jpeg.org/public/fcd15444-1.pdf).
                 // In other words, if _tileLeft is 0, its length should be the
                 // remaining length of the enclosing codestream, which is
                 // recorded in the lengthLeft variable.

--- a/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
+++ b/jhove-modules/jpeg2000-hul/src/main/java/edu/harvard/hul/ois/jhove/module/jpeg2000/ContCodestream.java
@@ -151,9 +151,23 @@ public class ContCodestream {
                         info.setWellFormed (false);
                         return false;
                 }
-                // markLen includes the marker length bytes, 
-                // but not the marker bytes
-   
+                // An SOT marker marks the beginning of a tile-part. It has yet
+                // another length field apart from the length of the marker
+                // segment. This length field contains the length of the whole
+                // tile-part from the very beginning of this SOT marker segment
+                // to the end of data of that tile-part; it comprises several
+                // other marker segments. The SOTMarkerSegment parser writes
+                // this length to the _tileLeft attribute. Now, if _tileLeft is
+                // 0, this tile-part is assumed to contain all data until the
+                // end of the current codestream (see section A.4.2 (page 22) in
+                // https://web.archive.org/web/20130810200214/http://www.jpeg.org/public/fcd15444-1.pdf.
+                // In other words, if _tileLeft is 0, its length should be the
+                // remaining length of the enclosing codestream, which is
+                // recorded in the lengthLeft variable.
+                if (marker == SOT && _tileLeft == 0) {
+                    _tileLeft = lengthLeft;
+                }
+
                 // We're done parsing this marker segment. Let's update the
                 // count of bytes remaining in this codestream (and, if
                 // applicable, tile-part) before parsing the next marker segment


### PR DESCRIPTION
The JPEG2000 module did not parse a JPEG2000 codestream correctly when the length of a tile-part in a SOT marker segment was set to 0. This means that the tile-part contains all data in the remaining code stream. (See https://web.archive.org/web/20130810200214/http://www.jpeg.org/public/fcd15444-1.pdf section A.4.2) JHOVE however would interpret this incorrectly as meaning "literally 0", thus expecting the beginning of the next marker segment where in fact the tile-part bytestream starts.