### PR TITLE
Upgrade EPUB module to use latest epubcheck 5.2.1

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Checkout and Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   coverage:
     name: Quality Assurance
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ build ]
 
     steps:


### PR DESCRIPTION
Sorry I didn't get this in earlier, I know the RC just came out. It can wait for next release. 
This is a change to upgrade to latest epubcheck 5.2.1, which fixes a bunch of bugs. It includes adding back in the test to make sure the created date is populated. The created date was missing in the 5.1.0 release of epubcheck and has now been added back in. (https://github.com/w3c/epubcheck/issues/1532)

Side note: in the current JHOVE RC a warning now appears multiple times when you run the EPUB module - it's there before and after this PR. Not sure if this warrants further investigation:
```
Warning
   XSLT version ignored: only "3.0" is recognized
```
If it seems like something that should be addressed, I can look into it.