### PR TITLE
Fix developer extension version reporting

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1749,9 +1749,10 @@ public class PdfModule extends ModuleBase {
                                     PdfSimpleObject BaseVersion = (PdfSimpleObject) extension.get(DICT_KEY_BASEVERSION);
                                     String infoVersString = _version;
                                     String versString = BaseVersion.getStringValue();
-                                    double ver = Double.parseDouble(versString);
-                                    double infoVer = Double.parseDouble(infoVersString);
                                     try {
+                                        double ver = Double.parseDouble(versString);
+                                        double infoVer = Double.parseDouble(infoVersString);
+
                                         // BaseVersion "shall be less than or equal to the PDF version" and "may be different from the version number in the document header or that supplied by the Version key in the Catalog [...] because it reflects the version of the standard that has been extended and not the version of this particular file"
                                         if (ver > infoVer) {
                                             // FIXME: this needs a separate error ID as this is a distinct case

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1760,7 +1760,7 @@ public class PdfModule extends ModuleBase {
                                                     MessageConstants.PDF_HUL_87.getId(), mess);
                                             info.setMessage(new InfoMessage(message));
                                         } else {
-                                            p = new Property(PROP_NAME_BASEVERSION, PropertyType.STRING, ver);
+                                            p = new Property(PROP_NAME_BASEVERSION, PropertyType.STRING, versString);
                                             _docCatalogList.add(p);
                                         }
                                     } catch (NumberFormatException e) {

--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1752,7 +1752,9 @@ public class PdfModule extends ModuleBase {
                                     double ver = Double.parseDouble(versString);
                                     double infoVer = Double.parseDouble(infoVersString);
                                     try {
-                                        if (infoVer != ver) {
+                                        // BaseVersion "shall be less than or equal to the PDF version" and "may be different from the version number in the document header or that supplied by the Version key in the Catalog [...] because it reflects the version of the standard that has been extended and not the version of this particular file"
+                                        if (ver > infoVer) {
+                                            // FIXME: this needs a separate error ID as this is a distinct case
                                             String mess = MessageFormat.format(
                                                     MessageConstants.PDF_HUL_87.getMessage(),
                                                     infoVersString, ver);


### PR DESCRIPTION
Fixes #890

This fixes an exception that's surfaced when using the JSON handler with PDFs that list extensions in the document catalog. In this case, the parsed `Double` value of the extension's `BaseVersion` key was wrongly used for a `String` property. I also noticed that the version strings were parsed outside the `try`-block here, so the exception handling to report PDF-HUL-88 for extension's base versions didn't work as intended, this is also fixed.

While here, I noticed that extension base versions are checked whether they are the same as the file's PDF version to report an info message for PDF-HUL-87, equivalently to the reporting for mismatching document info version compared to the file header. Since Extension's `BaseVersion` "reflect the version of the standard that has been extended and not the version of this particular file" (see chapter 7.12.4 of the PDF specification) they need to be handled a bit differently. I aligned the check to not report anything for base versions lower than the PDF version as this is expected and only look for the case where the version is higher. Reporting PDF-HUL-87 for this case doesn't really fit then and would need a new error ID, I wasn't sure how to best go about introducing one. What do you think, @carlwilson?