### PR TITLE
Update Ubuntu runner image version to 24.04

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Checkout and Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
 
   coverage:
     name: Quality Assurance
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ build ]
 
     steps:


### PR DESCRIPTION
The checks in my previous PRs are currently failing due to the GitHub-Workflow still using Ubuntu 20.04 images.

GitHub [announced](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) the deprecation of Ubuntu 20 images this January (see also https://github.com/actions/runner-images/issues/11101), so an update to a more recent Ubuntu base image is needed. I picked the most recent available Ubuntu version 24.04 as I didn't see any reason to be more conservative given the current workflow steps, but I can change this to 22.04 if you see any reasons to?

@carlwilson 