### PR TITLE
Fix failing Codacy Analysis CLI action

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Codacy analysis reporting
-        uses: codacy/codacy-analysis-cli-action@v4.4.5
+        uses: codacy/codacy-analysis-cli-action@v4.4.7
       - name: Download coverage report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
@carlwilson The failing check with `codacy-analysis-cli:7.9.11` in the recent PRs is due to the currently used version 4.4.5 of the [codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action). As mentioned in issue https://github.com/codacy/codacy-analysis-cli-action/issues/138#issuecomment-3084299277 updating to v4.4.7 should fix this as the releases after v4.4.5 added support for the new "High" severity causing current failures.