### PR TITLE
MAINT: Bumped codacy analysis to v4.4.7

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Codacy analysis reporting
-        uses: codacy/codacy-analysis-cli-action@v4.4.5
+        uses: codacy/codacy-analysis-cli-action@v4.4.7
       - name: Download coverage report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Hoping that this will fix the recent actions errors where the codacy CLI action appears to be the culprit <https://github.com/openpreserve/jhove/actions/runs/16467906027/job/46550469701?pr=1025#step:3:1>.