### PR TITLE
Fix-spelling-errors

### DIFF
--- a/docs/documentation/dev-module/index.md
+++ b/docs/documentation/dev-module/index.md
@@ -213,7 +213,7 @@ A new module *must* override the stub methods `checkSignature()` and `parse()`.
 >     public void checkSignature (File file, ..., RepInfo info) throws IOException
 >     {                /* Do nothing */
 >     }
->     public int  parse (..., RepInfo info, int parseIndex) thows IOException
+>     public int  parse (..., RepInfo info, int parseIndex) throws IOException
 >     {
 >         return 0;    /* Do nothing */
 >     }
@@ -364,11 +364,11 @@ The constructor for a module takes no parameters. It *must* first invoke its the
 
 `private static final String [] FORMAT`
 
-> An array of names for the formats supported by the module. The first entry should be be most generally appropriate format name, e.g. `{"TIFF, "Tagged Image File Format", "TIFF/EP", "TIFF/IT", ...}`.
+> An array of names for the formats supported by the module. The first entry should be the most generally appropriate format name, e.g. `{"TIFF, "Tagged Image File Format", "TIFF/EP", "TIFF/IT", ...}`.
 
 `private static final String [] MIMETYPE`
 
-> An array of MIME types applicable for the formats supported by the module. The first entry should be be most generally appropriate MIME type, e.g. `{image/tiff}`.
+> An array of MIME types applicable for the formats supported by the module. The first entry should be the most generally appropriate MIME type, e.g. `{image/tiff}`.
 
 `private static final String COVERAGE`
 

--- a/docs/documentation/logging/index.md
+++ b/docs/documentation/logging/index.md
@@ -40,7 +40,7 @@ Where the log level honours the following values:
 <xs:enumeration value="ALL"/>
 ```
 
-So setting `<logLevel>ALL</logLevel>` shows all message, where `<logLevel>WARNING</logLevel>` would display `WARNING` and `SEVERE` log messages only. JHOVE's default settings show only `SEVERE` messages.
+So setting `<logLevel>ALL</logLevel>` shows all messages, where `<logLevel>WARNING</logLevel>` would display `WARNING` and `SEVERE` log messages only. JHOVE's default settings show only `SEVERE` messages.
 
 You can also change the logging level by passing a `-l` param with the same level values, e.g. `jhove --version -l ALL` would set the log level to `ALL` and overrides the config setting.
 

--- a/docs/documentation/use-cases/index.md
+++ b/docs/documentation/use-cases/index.md
@@ -11,7 +11,7 @@ Potential use cases for JHOVE include:
 1. Identification
     1. "I have an object; what format is it?"
 2. Validation
-    1. "I have an object that purports to of format _F_; is it?"
+    1. "I have an object that purports to be of format _F_; is it?"
     2. "I have an object of format _F_; does it meet profile _P_ of _F_?"
     3. "I have an object of format _F_ and external metadata about _F_ in schema _S_; are they consistent?"
 3. Characterization

--- a/docs/getting-started/beginners/index.md
+++ b/docs/getting-started/beginners/index.md
@@ -47,7 +47,7 @@ JHOVE is an open source file format identification, validation and characterisat
 7. Once the install dialog is finished then click next:  
 ![Screenshot of the JHOVE installer stage four on Windows](/img/jhv-install-win-4.png "JHOVE installer stage four")
 
-8. If everything has completed properly you'll see a screen reporting successful installation, click the "Done" button to compete installation:  
+8. If everything has completed properly you'll see a screen reporting successful installation, click the "Done" button to complete installation:  
 ![Screenshot of the JHOVE installer stage five on Windows](/img/jhv-install-win-5.png "JHOVE installer stage five")
 
 ### Running JHOVE on a Windows PC

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -51,7 +51,7 @@ Download the [latest JHOVE installer](http://software.openpreservation.org/rel/j
 
     /Downloads/jhove-latest.jar
 
-Installation is OS dependant.
+Installation is OS dependent.
 
 ### Windows
 


### PR DESCRIPTION
Fixes some non-critical spelling and grammar errors in the docs that were in the docs folder