### PR TITLE
Added detail to error message including entity URL in XmlModuleHandler

### DIFF
--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
@@ -375,7 +375,7 @@ public class XmlModuleHandler extends DefaultHandler {
             }
         } catch (IOException ioe) {
             // Malformed URL or bad connection.
-            System.err.println("Error resolving entity: " + ioe.getMessage());
+            System.err.println("Error resolving entity: " + entityUrl + " - " + ioe.getMessage());
             throw new SAXException(ioe);
         }
         return null;


### PR DESCRIPTION
I was struggling trying to identify which XSD was being rejected by a HTTP proxy. I wanted to configure XML-hul to map locally all the XSDs so jhove should not go outside to get them.

I added the `entityURL` in error message when `resolveEntity` was called.

Not a big change but it helped me to debug the problem in the final environment.