### PR TITLE
PDF-hul: Fix NullPointerException in PdfModule when Exception message is null

### DIFF
--- a/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/pdf-hul/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1588,8 +1588,9 @@ public class PdfModule extends ModuleBase {
                     e.getClass().getName());
             JhoveMessage message = JhoveMessages.getMessageInstance(
                     MessageConstants.PDF_HUL_157.getId(), mess);
-            info.setMessage(
-                    new ErrorMessage(message, e.getMessage(), _parser.getOffset()));
+            info.setMessage(new ErrorMessage(message,
+                    e.getMessage() != null ? e.getMessage() : e.getClass().getName(),
+                    _parser.getOffset()));
             return false;
         }
         return true;


### PR DESCRIPTION
This commit is intended to fix the following NPE. Line numbers are as per PDF-hul 1.12.7 because that's what we are running. The line numbers have moved a bit but the offending codepath is unchanged in the latest commit as of this writing, 7595dd5b666.

```
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "subMessage" is null
at edu.harvard.hul.ois.jhove.Message.(Message.java:59)
at edu.harvard.hul.ois.jhove.ErrorMessage.(ErrorMessage.java:68)
at edu.harvard.hul.ois.jhove.module.PdfModule.readXRefTables(PdfModule.java:1585)
at edu.harvard.hul.ois.jhove.module.PdfModule.readXRefInfo(PdfModule.java:1438)
at edu.harvard.hul.ois.jhove.module.PdfModule.parse(PdfModule.java:823)
at edu.harvard.hul.ois.jhove.JhoveBase.processFile(JhoveBase.java:831)
```

`Throwable.getMessage()` and thus `Exception.getMessage()` is explicitly documented as nullable. However, `subMessage` in JHOVE's `Message` is assumed to be non-null, so directly passing an exception message can crash with NPE. I don't actually know what Exception triggered it in our case, but the logic is clearly faulty anyway.

I'm proposing to add the `Exception`'s full class name when its message is null: In absence of a message, the type of exception is the best piece of information we can provide. The full name of the `Exception` subclass isn't very human friendly, but neither are many raw exception messages. The code catches `Exception` at this point, so I don't think it will reduce user friendlyness much. Also, passing an empty string instead really isn't an option here because then nobody knows what happened.

Alternatively, one could always include the exception class name in the `PDF_HUL_157` message. This might make some exception messages more useful, at the cost of making all messages more technical. That feels like a more intrusive change (it would change existing error messages) so I went with the less intrusive option to start with.