### PR TITLE
Fix case insensitive search in jhove.conf

### DIFF
--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -1003,7 +1003,7 @@ public class XmlModule extends ModuleBase {
             String uriParam = param.substring(eq + 1, semi);
             String localParam = param.substring(semi + 1);
             try {
-                String locationUri = new URI(uriParam).toString();
+                String locationUri = new URI(uriParam).toString().toLowerCase();
                 File localFile = new File(localParam);
                 if (localFile.exists()) {
                     _localSchemas.put(locationUri, localFile);

--- a/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
+++ b/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleTest.java
@@ -104,6 +104,44 @@ public class XmlModuleTest {
         assertEquals(RepInfo.FALSE, info.getValid());
     }
 
+    @Test
+    public void validateXmlFailsForFineReaderXML() throws IOException {
+        File file = new File(RESOURCE_DIR + "12745764.xml");
+        RepInfo info = new RepInfo("uri:test");
+
+        module.param("schema=http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml;" + RESOURCE_DIR + "FineReader10-schema-v1.xsd");
+
+        int parseIndex = parse(file, info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = parse(file, info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.FALSE, info.getValid());
+    }
+
+    @Test
+    public void validateXmlFailsForFineReaderExtendedXML() throws IOException {
+        File file = new File(RESOURCE_DIR + "12745764.xml");
+        RepInfo info = new RepInfo("uri:test");
+
+        module.param("schema=http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml;" + RESOURCE_DIR + "FineReader10-schema-v1-with-skew.xsd");
+
+        int parseIndex = parse(file, info, 0);
+
+        assertEquals(1, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+
+        parseIndex = parse(file, info, parseIndex);
+
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.TRUE, info.getValid());
+    }
+
     private int parse(File file, RepInfo info, int parseIndex) throws IOException {
         try (InputStream stream = Files.newInputStream(file.toPath())) {
             return module.parse(stream, info, parseIndex);

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/12745764.xml
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/12745764.xml
@@ -1,0 +1,4273 @@
+<document xmlns="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" producer="ABBYY FineReader Engine 11" languages="" xsi:schemaLocation="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml">
+<page width="2453" height="3142" resolution="300" isSkewCorrect="true" skewAngle="-1.90496160389016E-03">
+<block blockType="Text" blockName="" l="361" t="372" r="1139" b="2739"><region><rect l="361" t="372" r="1139" b="2739"/></region>
+<text>
+<par align="Center" leftIndent="100" lineSpacing="1056">
+<line baseline="417" l="658" t="378" r="811" b="418"><formatting lang="OldFrench" ff="Times New Roman" fs="13." bold="1" spacing="70">
+<charParams l="658" t="378" r="685" b="417" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="0" meanStrokeWidth="60">F</charParams>
+<charParams l="686" t="378" r="712" b="418"> </charParams>
+<charParams l="713" t="378" r="749" b="418" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="51">O</charParams>
+<charParams l="750" t="378" r="774" b="418"> </charParams>
+<charParams l="775" t="378" r="811" b="416" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">U</charParams></formatting></line></par>
+<par align="Justified" lineSpacing="1056">
+<line baseline="460" l="367" t="424" r="1116" b="470"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="367" t="443" r="387" b="465" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="390" t="443" r="408" b="463" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="414" t="440" r="426" b="464" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="427" t="440" r="434" b="464"> </charParams>
+<charParams l="435" t="442" r="452" b="464" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="454" t="442" r="473" b="464" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="52" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="475" t="441" r="492" b="464" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="495" t="441" r="511" b="463" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="512" t="440" r="521" b="463"> </charParams>
+<charParams l="522" t="440" r="538" b="462" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="77" wordPenalty="3" meanStrokeWidth="46">c</charParams>
+<charParams l="541" t="439" r="557" b="462" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="83" wordPenalty="3" meanStrokeWidth="46">e</charParams>
+<charParams l="561" t="440" r="579" b="461" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="3" meanStrokeWidth="46">u</charParams>
+<charParams l="581" t="441" r="599" b="461" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="255" wordPenalty="3" meanStrokeWidth="46">x</charParams>
+<charParams l="600" t="428" r="610" b="461"> </charParams>
+<charParams l="611" t="428" r="631" b="461" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="634" t="440" r="650" b="463" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="653" t="440" r="666" b="462" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="73" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="667" t="440" r="682" b="462"> </charParams>
+<charParams l="683" t="441" r="702" b="461" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">o</charParams>
+<charParams l="705" t="442" r="720" b="461" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">r</charParams>
+<charParams l="724" t="441" r="742" b="470" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">g</charParams>
+<charParams l="745" t="441" r="765" b="461" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="767" t="440" r="784" b="461" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="786" t="440" r="799" b="460" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="73" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="800" t="439" r="812" b="470"> </charParams>
+<charParams l="813" t="439" r="821" b="470" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="29">;</charParams>
+<charParams l="822" t="436" r="831" b="470"> </charParams>
+<charParams l="832" t="436" r="844" b="460" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="848" t="438" r="864" b="459" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="866" t="424" r="874" b="459" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="878" t="438" r="890" b="458" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="73" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="891" t="425" r="902" b="459"> </charParams>
+<charParams l="903" t="425" r="921" b="459" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="66" wordPenalty="3" meanStrokeWidth="40">f</charParams>
+<charParams l="917" t="439" r="936" b="459" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="3" meanStrokeWidth="40">o</charParams>
+<charParams l="939" t="438" r="958" b="458" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="3" meanStrokeWidth="40">n</charParams>
+<charParams l="961" t="435" r="975" b="459" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="61" wordPenalty="3" meanStrokeWidth="40">t</charParams>
+<charParams l="976" t="435" r="983" b="459"> </charParams>
+<charParams l="984" t="437" r="1000" b="459" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1003" t="437" r="1019" b="458" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1022" t="438" r="1041" b="458" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1044" t="438" r="1062" b="458" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">x</charParams>
+<charParams l="1063" t="425" r="1075" b="458"> </charParams>
+<charParams l="1076" t="425" r="1094" b="458" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1099" t="437" r="1116" b="459" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="505" l="367" t="469" r="1115" b="517"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="367" t="475" r="376" b="508" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="0" wordPenalty="3" meanStrokeWidth="47">l</charParams>
+<charParams l="385" t="489" r="396" b="509" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="91" wordPenalty="3" meanStrokeWidth="47">i</charParams>
+<charParams l="397" t="475" r="408" b="509"> </charParams>
+<charParams l="409" t="475" r="426" b="507" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="31" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="421" t="489" r="441" b="509" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="444" t="487" r="459" b="507" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="462" t="487" r="480" b="517" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="483" t="486" r="499" b="507" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="500" t="476" r="512" b="508"> </charParams>
+<charParams l="513" t="476" r="544" b="508" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="58" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">&amp;</charParams>
+<charParams l="545" t="473" r="558" b="508"> </charParams>
+<charParams l="559" t="473" r="577" b="506" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="581" t="485" r="600" b="506" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="601" t="473" r="604" b="516"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="605" t="473" r="638" b="516" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">f</charParams>
+<charParams l="631" t="486" r="649" b="505" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">o</charParams>
+<charParams l="652" t="487" r="671" b="506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">u</charParams>
+<charParams l="674" t="486" r="689" b="505" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">r</charParams>
+<charParams l="691" t="485" r="711" b="506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">n</charParams>
+<charParams l="714" t="486" r="728" b="506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="731" t="486" r="750" b="506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="95" wordPenalty="2" meanStrokeWidth="36">a</charParams>
+<charParams l="753" t="486" r="772" b="505" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">u</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="773" t="471" r="782" b="505"> </charParams>
+<charParams l="783" t="471" r="801" b="505" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="807" t="483" r="824" b="505" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="825" t="470" r="836" b="505"> </charParams>
+<charParams l="837" t="470" r="855" b="504" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="48" wordPenalty="6" meanStrokeWidth="38">f</charParams>
+<charParams l="850" t="484" r="870" b="503" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">u</charParams>
+<charParams l="872" t="469" r="885" b="503" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">s</charParams>
+<charParams l="885" t="469" r="895" b="503" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="0" wordPenalty="6" meanStrokeWidth="38">i</charParams>
+<charParams l="899" t="484" r="918" b="504" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="255" wordPenalty="6" meanStrokeWidth="38">o</charParams>
+<charParams l="921" t="483" r="941" b="503" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">n</charParams>
+<charParams l="942" t="469" r="945" b="511"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="946" t="469" r="978" b="511" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="946" t="469" r="978" b="511" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="975" t="483" r="998" b="515" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="996" t="496" r="1002" b="502" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1003" t="469" r="1016" b="502"> </charParams>
+<charParams l="1017" t="469" r="1034" b="502" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="51" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">8</charParams>
+<charParams l="1040" t="495" r="1046" b="502" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">.</charParams>
+<charParams l="1047" t="470" r="1062" b="503"> </charParams>
+<charParams l="1063" t="470" r="1094" b="503" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="98" wordPenalty="0" meanStrokeWidth="37">A</charParams>
+<charParams l="1096" t="483" r="1115" b="503" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams></formatting></line>
+<line baseline="550" l="368" t="513" r="1115" b="558"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="368" t="532" r="382" b="553" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="385" t="533" r="402" b="554" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="405" t="519" r="429" b="553" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="405" t="519" r="429" b="553" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="433" t="532" r="449" b="553" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="450" t="532" r="459" b="553"> </charParams>
+<charParams l="460" t="532" r="477" b="552" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="478" t="519" r="486" b="532" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="490" t="531" r="508" b="552" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="510" t="517" r="534" b="551" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="510" t="517" r="534" b="551" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="535" t="517" r="549" b="551"> </charParams>
+<charParams l="550" t="517" r="557" b="551" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="562" t="530" r="579" b="551" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="582" t="530" r="600" b="551" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="603" t="530" r="617" b="550" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="618" t="530" r="633" b="551"> </charParams>
+<charParams l="634" t="530" r="653" b="551" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="658" t="516" r="673" b="550" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="669" t="529" r="684" b="549" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="3" meanStrokeWidth="38">a</charParams>
+<charParams l="687" t="529" r="706" b="558" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="53" wordPenalty="3" meanStrokeWidth="38">g</charParams>
+<charParams l="709" t="530" r="726" b="550" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="729" t="543" r="737" b="558" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">,</charParams>
+<charParams l="738" t="519" r="758" b="558"> </charParams>
+<charParams l="759" t="519" r="790" b="551" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="65" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&amp;</charParams>
+<charParams l="791" t="519" r="810" b="551"> </charParams>
+<charParams l="811" t="530" r="831" b="549" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="833" t="529" r="854" b="549" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">o</charParams>
+<charParams l="855" t="529" r="874" b="549" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="0" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="875" t="515" r="889" b="549"> </charParams>
+<charParams l="890" t="515" r="897" b="549" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">!</charParams>
+<charParams l="901" t="528" r="917" b="548" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="74" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="918" t="513" r="931" b="548"> </charParams>
+<charParams l="932" t="513" r="953" b="547" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="932" t="513" r="953" b="547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="957" t="528" r="975" b="558" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="978" t="529" r="996" b="548" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1000" t="528" r="1015" b="548" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1018" t="527" r="1035" b="548" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1043" t="542" r="1051" b="557" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">,</charParams>
+<charParams l="1052" t="528" r="1063" b="557"> </charParams>
+<charParams l="1064" t="528" r="1080" b="555" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="1086" t="528" r="1103" b="548" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1107" t="514" r="1115" b="547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams></formatting></line>
+<line baseline="594" l="369" t="553" r="1117" b="604"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="369" t="565" r="388" b="598" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="392" t="563" r="409" b="598" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">&#233;</charParams>
+<charParams l="412" t="577" r="428" b="597" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="430" t="564" r="438" b="597" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="442" t="564" r="462" b="597" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="465" t="576" r="482" b="597" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="486" t="589" r="492" b="596" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">.</charParams>
+<charParams l="493" t="563" r="521" b="597"> </charParams>
+<charParams l="522" t="563" r="553" b="597" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">O</charParams>
+<charParams l="556" t="575" r="576" b="595" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="49">n</charParams>
+<charParams l="577" t="574" r="601" b="595"> </charParams>
+<charParams l="602" t="574" r="618" b="595" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="37" wordPenalty="2" meanStrokeWidth="39">a</charParams>
+<charParams l="620" t="575" r="639" b="604" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">p</charParams>
+<charParams l="642" t="575" r="662" b="604" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="96" wordPenalty="2" meanStrokeWidth="39">p</charParams>
+<charParams l="665" t="573" r="682" b="595" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="83" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="684" t="560" r="693" b="594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">l</charParams>
+<charParams l="696" t="560" r="705" b="595" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">l</charParams>
+<charParams l="709" t="573" r="726" b="595" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="83" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="727" t="573" r="754" b="595"> </charParams>
+<charParams l="755" t="573" r="773" b="595" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="776" t="574" r="794" b="594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="66" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="798" t="573" r="813" b="593" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="816" t="574" r="835" b="594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="839" t="573" r="854" b="593" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="857" t="573" r="875" b="594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="876" t="573" r="901" b="594"> </charParams>
+<charParams l="902" t="573" r="917" b="592" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="919" t="571" r="936" b="593" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="939" t="572" r="957" b="602" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="960" t="560" r="969" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="973" t="559" r="998" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="973" t="559" r="998" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1000" t="573" r="1014" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1017" t="571" r="1033" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1036" t="572" r="1049" b="593" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="10" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1050" t="553" r="1073" b="593"> </charParams>
+<charParams l="1074" t="553" r="1083" b="591" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1087" t="571" r="1103" b="593" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1105" t="571" r="1117" b="592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams></formatting></line>
+<line baseline="638" l="369" t="603" r="1119" b="648"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="369" t="611" r="384" b="642" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="386" t="622" r="406" b="642" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="410" t="607" r="434" b="648" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="410" t="607" r="434" b="648" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="435" t="622" r="450" b="641" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="452" t="621" r="470" b="641" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="473" t="621" r="504" b="641" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="507" t="620" r="521" b="640" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="524" t="620" r="543" b="640" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="546" t="621" r="562" b="640" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">s</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="563" t="619" r="586" b="640"> </charParams>
+<charParams l="587" t="619" r="608" b="640" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="46">o</charParams>
+<charParams l="611" t="619" r="629" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="46">u</charParams>
+<charParams l="630" t="617" r="658" b="639"> </charParams>
+<charParams l="659" t="617" r="675" b="638" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="678" t="617" r="695" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="698" t="619" r="710" b="640" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="41" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="711" t="619" r="732" b="648"> </charParams>
+<charParams l="733" t="619" r="753" b="648" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="756" t="618" r="773" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="776" t="616" r="788" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="791" t="606" r="799" b="638" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="803" t="616" r="816" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="818" t="619" r="830" b="639" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="73" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="831" t="618" r="849" b="646"> </charParams>
+<charParams l="850" t="618" r="868" b="646" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="97" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="871" t="618" r="886" b="638" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="37" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="889" t="617" r="905" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="907" t="617" r="923" b="638" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="74" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="926" t="603" r="932" b="636" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="936" t="604" r="944" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="948" t="603" r="964" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="966" t="603" r="975" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="979" t="604" r="985" b="636" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="991" t="617" r="1008" b="646" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="1011" t="604" r="1020" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="1025" t="617" r="1042" b="646" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="1046" t="616" r="1062" b="636" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1065" t="604" r="1082" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1087" t="616" r="1105" b="637" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1107" t="616" r="1119" b="636" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="41" wordPenalty="0" meanStrokeWidth="36">s</charParams></formatting></line>
+<line baseline="683" l="370" t="647" r="1117" b="692"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="370" t="654" r="389" b="687" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="394" t="665" r="411" b="686" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="412" t="664" r="423" b="686"> </charParams>
+<charParams l="424" t="664" r="436" b="686" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="439" t="665" r="456" b="686" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="458" t="665" r="472" b="685" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="474" t="665" r="488" b="685" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="490" t="665" r="508" b="686" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="509" t="664" r="521" b="686"> </charParams>
+<charParams l="522" t="664" r="537" b="684" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="540" t="665" r="558" b="684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="562" t="651" r="570" b="684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="574" t="663" r="587" b="684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="590" t="663" r="607" b="684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="618" t="676" r="627" b="692" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">,</charParams>
+<charParams l="628" t="663" r="644" b="692"> </charParams>
+<charParams l="645" t="663" r="663" b="692" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">q</charParams>
+<charParams l="666" t="663" r="686" b="683" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="86" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="688" t="649" r="696" b="663" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">&#8217;</charParams>
+<charParams l="700" t="664" r="719" b="685" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="722" t="664" r="743" b="683" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="744" t="663" r="762" b="684"> </charParams>
+<charParams l="763" t="663" r="793" b="684" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="798" t="662" r="815" b="684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="818" t="661" r="830" b="683" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="831" t="650" r="849" b="683"> </charParams>
+<charParams l="850" t="650" r="868" b="683" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="71" wordPenalty="5" meanStrokeWidth="35">d</charParams>
+<charParams l="874" t="661" r="891" b="683" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="83" wordPenalty="5" meanStrokeWidth="35">e</charParams>
+<charParams l="894" t="662" r="912" b="683" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="50" wordPenalty="5" meanStrokeWidth="35">v</charParams>
+<charParams l="915" t="662" r="931" b="682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="37" wordPenalty="5" meanStrokeWidth="35">a</charParams>
+<charParams l="935" t="662" r="954" b="682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="100" wordPenalty="5" meanStrokeWidth="35">n</charParams>
+<charParams l="957" t="660" r="970" b="682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="61" wordPenalty="5" meanStrokeWidth="35">t</charParams>
+<charParams l="971" t="648" r="986" b="682"> </charParams>
+<charParams l="987" t="648" r="995" b="682" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1000" t="661" r="1017" b="682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1019" t="662" r="1031" b="681" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="10" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1032" t="647" r="1044" b="681"> </charParams>
+<charParams l="1045" t="647" r="1062" b="681" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="66" wordPenalty="5" meanStrokeWidth="38">s</charParams>
+<charParams l="1059" t="661" r="1078" b="681" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="255" wordPenalty="5" meanStrokeWidth="38">o</charParams>
+<charParams l="1081" t="661" r="1100" b="682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="5" meanStrokeWidth="38">u</charParams>
+<charParams l="1105" t="669" r="1117" b="673" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="5" meanStrokeWidth="38">&#172;</charParams></formatting></line>
+<line baseline="730" l="369" t="693" r="718" b="741"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="369" t="710" r="389" b="741" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="96" wordPenalty="5" meanStrokeWidth="37">p</charParams>
+<charParams l="392" t="698" r="401" b="731" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="5" meanStrokeWidth="37">i</charParams>
+<charParams l="404" t="710" r="418" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="5" meanStrokeWidth="37">r</charParams>
+<charParams l="421" t="710" r="437" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="37" wordPenalty="5" meanStrokeWidth="37">a</charParams>
+<charParams l="439" t="710" r="457" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="5" meanStrokeWidth="37">u</charParams>
+<charParams l="462" t="710" r="480" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="255" wordPenalty="5" meanStrokeWidth="37">x</charParams>
+<charParams l="481" t="696" r="491" b="730"> </charParams>
+<charParams l="492" t="696" r="510" b="729" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="71" wordPenalty="0" meanStrokeWidth="35">d</charParams>
+<charParams l="515" t="708" r="532" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="35">e</charParams>
+<charParams l="533" t="695" r="544" b="730"> </charParams>
+<charParams l="545" t="695" r="555" b="729" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="26" wordPenalty="0" meanStrokeWidth="42">l</charParams>
+<charParams l="558" t="708" r="573" b="729" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="37" wordPenalty="0" meanStrokeWidth="42">a</charParams>
+<charParams l="574" t="708" r="585" b="729"> </charParams>
+<charParams l="586" t="708" r="615" b="728" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="3" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="620" t="708" r="639" b="729" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="642" t="708" r="660" b="728" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="665" t="693" r="679" b="728" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="679" t="694" r="687" b="728" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="691" t="707" r="709" b="730" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="711" t="722" r="718" b="729" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="773" l="416" t="737" r="1118" b="780"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="416" t="742" r="449" b="775" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="100" wordPenalty="0" meanStrokeWidth="30">U</charParams>
+<charParams l="453" t="754" r="472" b="774" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="30">n</charParams>
+<charParams l="478" t="753" r="494" b="774" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="30">e</charParams>
+<charParams l="495" t="753" r="507" b="774"> </charParams>
+<charParams l="508" t="754" r="528" b="774" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="531" t="754" r="549" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="555" t="753" r="571" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="52" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="576" t="752" r="592" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="595" t="753" r="610" b="772" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="612" t="750" r="624" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="627" t="753" r="646" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="649" t="753" r="663" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="666" t="751" r="684" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="685" t="739" r="694" b="773"> </charParams>
+<charParams l="695" t="739" r="712" b="772" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="48" wordPenalty="0" meanStrokeWidth="36">f</charParams>
+<charParams l="709" t="753" r="725" b="774" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="727" t="752" r="746" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="748" t="739" r="758" b="772" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="762" t="752" r="778" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="779" t="752" r="787" b="773"> </charParams>
+<charParams l="788" t="752" r="804" b="772" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="74" wordPenalty="0" meanStrokeWidth="48">a</charParams>
+<charParams l="806" t="752" r="825" b="772" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="48">u</charParams>
+<charParams l="826" t="752" r="835" b="772"> </charParams>
+<charParams l="836" t="752" r="866" b="771" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="872" t="739" r="880" b="772" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="883" t="737" r="891" b="771" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="894" t="737" r="902" b="771" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="906" t="750" r="923" b="771" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="925" t="751" r="943" b="772" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="944" t="738" r="953" b="772"> </charParams>
+<charParams l="954" t="738" r="973" b="771" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="978" t="751" r="996" b="771" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="997" t="738" r="1007" b="771"> </charParams>
+<charParams l="1008" t="738" r="1026" b="771" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1031" t="738" r="1050" b="771" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">&#244;</charParams>
+<charParams l="1055" t="751" r="1084" b="770" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="3" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="1088" t="749" r="1105" b="771" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1109" t="764" r="1118" b="780" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">,</charParams></formatting></line>
+<line baseline="817" l="370" t="781" r="1119" b="828"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="370" t="785" r="388" b="819" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="48" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="384" t="799" r="400" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="37" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="404" t="786" r="410" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="415" t="797" r="428" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="429" t="797" r="446" b="828"> </charParams>
+<charParams l="447" t="799" r="465" b="828" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="469" t="799" r="487" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="491" t="797" r="508" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="509" t="785" r="520" b="819"> </charParams>
+<charParams l="521" t="785" r="528" b="818" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="532" t="797" r="550" b="818" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="37" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="551" t="796" r="569" b="818"> </charParams>
+<charParams l="570" t="796" r="585" b="817" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="587" t="785" r="609" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="98" wordPenalty="0" meanStrokeWidth="37">h</charParams>
+<charParams l="611" t="798" r="626" b="818" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="629" t="784" r="638" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="641" t="797" r="657" b="818" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="660" t="797" r="678" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="93" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="682" t="797" r="697" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="698" t="797" r="713" b="819"> </charParams>
+<charParams l="714" t="797" r="731" b="819" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="734" t="784" r="759" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="734" t="784" r="759" b="817" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="760" t="784" r="778" b="826"> </charParams>
+<charParams l="779" t="798" r="798" b="826" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="97" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="801" t="797" r="816" b="817" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="819" t="797" r="834" b="817" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="835" t="805" r="847" b="810" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">-</charParams>
+<charParams l="852" t="794" r="865" b="817" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="867" t="797" r="886" b="817" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="889" t="796" r="908" b="816" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="912" t="793" r="925" b="816" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="926" t="782" r="939" b="816"> </charParams>
+<charParams l="940" t="782" r="956" b="816" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="29">&#233;</charParams>
+<charParams l="958" t="796" r="976" b="825" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="53" wordPenalty="0" meanStrokeWidth="29">g</charParams>
+<charParams l="979" t="796" r="995" b="815" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="37" wordPenalty="0" meanStrokeWidth="29">a</charParams>
+<charParams l="998" t="781" r="1004" b="815" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="50" wordPenalty="0" meanStrokeWidth="29">l</charParams>
+<charParams l="1009" t="795" r="1026" b="816" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="83" wordPenalty="0" meanStrokeWidth="29">e</charParams>
+<charParams l="1027" t="782" r="1044" b="816"> </charParams>
+<charParams l="1045" t="782" r="1063" b="816" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="71" wordPenalty="5" meanStrokeWidth="35">d</charParams>
+<charParams l="1067" t="797" r="1082" b="815" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="53" wordPenalty="5" meanStrokeWidth="35">a</charParams>
+<charParams l="1086" t="795" r="1105" b="815" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="5" meanStrokeWidth="35">n</charParams>
+<charParams l="1107" t="795" r="1119" b="815" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="41" wordPenalty="5" meanStrokeWidth="35">s</charParams></formatting></line>
+<line baseline="862" l="370" t="822" r="1118" b="873"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="370" t="830" r="380" b="864" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="57">1</charParams>
+<charParams l="381" t="830" r="383" b="864" suspicious="1"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1" smallcaps="1">
+<charParams l="384" t="843" r="401" b="864" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="5" meanStrokeWidth="36">q</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="402" t="831" r="406" b="873"> </charParams>
+<charParams l="407" t="831" r="439" b="873" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">f</charParams>
+<charParams l="432" t="844" r="450" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="453" t="844" r="472" b="864" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="477" t="844" r="490" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="493" t="843" r="512" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="515" t="843" r="531" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="533" t="843" r="551" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="95" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="555" t="843" r="575" b="863" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="586" t="855" r="594" b="869" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="63" serifProbability="255" wordPenalty="0" meanStrokeWidth="20">,</charParams>
+<charParams l="595" t="832" r="610" b="869"> </charParams>
+<charParams l="611" t="832" r="631" b="864" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">S</charParams>
+<charParams l="631" t="841" r="642" b="863" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="643" t="841" r="653" b="871"> </charParams>
+<charParams l="654" t="843" r="673" b="871" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="676" t="828" r="684" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="688" t="843" r="706" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="93" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="709" t="843" r="722" b="863" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="723" t="841" r="734" b="863"> </charParams>
+<charParams l="735" t="841" r="751" b="862" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="754" t="842" r="773" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="776" t="843" r="795" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="800" t="842" r="815" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="817" t="841" r="834" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="838" t="842" r="856" b="861" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="66" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="861" t="838" r="873" b="862" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="876" t="841" r="890" b="860" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="892" t="826" r="908" b="861" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="911" t="840" r="928" b="861" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="929" t="839" r="938" b="871"> </charParams>
+<charParams l="939" t="839" r="947" b="871" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="16" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">;</charParams>
+<charParams l="948" t="822" r="959" b="871"> </charParams>
+<charParams l="960" t="822" r="978" b="860" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="71" wordPenalty="2" meanStrokeWidth="36">d</charParams>
+<charParams l="984" t="828" r="991" b="840" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">&#8217;</charParams>
+<charParams l="994" t="840" r="1010" b="859" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="37" wordPenalty="2" meanStrokeWidth="36">a</charParams>
+<charParams l="1014" t="828" r="1022" b="860" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="0" wordPenalty="2" meanStrokeWidth="36">i</charParams>
+<charParams l="1027" t="827" r="1032" b="859" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="1036" t="826" r="1044" b="859" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="50" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="1048" t="839" r="1066" b="860" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="83" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="1067" t="841" r="1085" b="861" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="93" wordPenalty="2" meanStrokeWidth="36">u</charParams>
+<charParams l="1091" t="841" r="1104" b="860" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">r</charParams>
+<charParams l="1106" t="839" r="1118" b="860" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="41" wordPenalty="2" meanStrokeWidth="36">s</charParams></formatting></line>
+<line baseline="907" l="371" t="871" r="1118" b="917"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="371" t="875" r="382" b="909" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="0" wordPenalty="0" meanStrokeWidth="46">i</charParams>
+<charParams l="386" t="874" r="394" b="908" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="50" wordPenalty="0" meanStrokeWidth="46">l</charParams>
+<charParams l="395" t="874" r="411" b="909"> </charParams>
+<charParams l="412" t="888" r="429" b="909" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="83" wordPenalty="0" meanStrokeWidth="45">e</charParams>
+<charParams l="432" t="874" r="457" b="908" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="255" wordPenalty="0" meanStrokeWidth="45">s</charParams>
+<charParams l="432" t="874" r="457" b="908" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="255" wordPenalty="0" meanStrokeWidth="45">t</charParams>
+<charParams l="458" t="874" r="468" b="917"> </charParams>
+<charParams l="469" t="888" r="488" b="917" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="96" wordPenalty="3" meanStrokeWidth="39">p</charParams>
+<charParams l="491" t="874" r="498" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="50" wordPenalty="3" meanStrokeWidth="39">l</charParams>
+<charParams l="503" t="887" r="521" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="93" wordPenalty="3" meanStrokeWidth="39">u</charParams>
+<charParams l="524" t="886" r="536" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="41" wordPenalty="3" meanStrokeWidth="39">s</charParams>
+<charParams l="537" t="886" r="548" b="907"> </charParams>
+<charParams l="549" t="886" r="566" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="37" wordPenalty="3" meanStrokeWidth="40">a</charParams>
+<charParams l="569" t="873" r="578" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="0" wordPenalty="3" meanStrokeWidth="40">i</charParams>
+<charParams l="580" t="873" r="597" b="906" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="3" meanStrokeWidth="40">s</charParams>
+<charParams l="594" t="873" r="611" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="3" meanStrokeWidth="40">&#233;</charParams>
+<charParams l="612" t="873" r="625" b="907"> </charParams>
+<charParams l="626" t="874" r="644" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="650" t="886" r="667" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="668" t="873" r="683" b="907"> </charParams>
+<charParams l="684" t="873" r="691" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="694" t="887" r="711" b="908" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="37" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="712" t="873" r="725" b="908"> </charParams>
+<charParams l="726" t="873" r="744" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="740" t="885" r="757" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="759" t="885" r="775" b="906" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="777" t="887" r="807" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="812" t="885" r="829" b="907" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="832" t="886" r="847" b="906" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="849" t="899" r="856" b="906" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">.</charParams>
+<charParams l="857" t="873" r="874" b="917"> </charParams>
+<charParams l="875" t="873" r="906" b="917" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="78" wordPenalty="0" meanStrokeWidth="41">Q</charParams>
+<charParams l="910" t="885" r="928" b="905" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="93" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="931" t="885" r="947" b="905" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="0" wordPenalty="0" meanStrokeWidth="41">a</charParams>
+<charParams l="950" t="885" r="970" b="904" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="972" t="872" r="991" b="905" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="41">d</charParams>
+<charParams l="992" t="872" r="1005" b="905"> </charParams>
+<charParams l="1006" t="872" r="1013" b="904" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1017" t="871" r="1026" b="904" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1027" t="871" r="1043" b="915"> </charParams>
+<charParams l="1044" t="885" r="1061" b="915" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="49" wordPenalty="0" meanStrokeWidth="56">y</charParams>
+<charParams l="1062" t="884" r="1079" b="915"> </charParams>
+<charParams l="1080" t="884" r="1097" b="905" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1098" t="884" r="1118" b="904" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams></formatting></line>
+<line baseline="951" l="372" t="917" r="1119" b="962"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="372" t="932" r="391" b="953" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="53" wordPenalty="0" meanStrokeWidth="41">a</charParams>
+<charParams l="392" t="931" r="407" b="953"> </charParams>
+<charParams l="408" t="931" r="421" b="953" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="423" t="933" r="437" b="953" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">r</charParams>
+<charParams l="439" t="933" r="459" b="953" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="463" t="920" r="471" b="952" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="0" meanStrokeWidth="41">i</charParams>
+<charParams l="474" t="931" r="488" b="952" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="41" wordPenalty="0" meanStrokeWidth="41">s</charParams>
+<charParams l="489" t="931" r="507" b="952"> </charParams>
+<charParams l="508" t="932" r="528" b="952" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="44">o</charParams>
+<charParams l="530" t="932" r="549" b="952" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="96" wordPenalty="0" meanStrokeWidth="44">u</charParams>
+<charParams l="550" t="932" r="562" b="961"> </charParams>
+<charParams l="563" t="932" r="581" b="961" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="584" t="931" r="603" b="952" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="606" t="931" r="622" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="625" t="928" r="637" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="640" t="931" r="654" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="656" t="930" r="674" b="952" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="684" t="946" r="691" b="962" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="57" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="692" t="920" r="704" b="962"> </charParams>
+<charParams l="705" t="920" r="712" b="952" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="44">i</charParams>
+<charParams l="716" t="918" r="725" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="26" wordPenalty="0" meanStrokeWidth="44">l</charParams>
+<charParams l="726" t="918" r="738" b="951"> </charParams>
+<charParams l="739" t="919" r="757" b="951" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="751" t="931" r="767" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="770" t="932" r="788" b="952" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="93" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="792" t="928" r="806" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="807" t="917" r="821" b="951"> </charParams>
+<charParams l="822" t="917" r="830" b="951" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="835" t="930" r="852" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="853" t="931" r="866" b="951" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="867" t="927" r="877" b="951"> </charParams>
+<charParams l="878" t="927" r="891" b="950" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="894" t="930" r="910" b="950" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="912" t="929" r="932" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="936" t="917" r="944" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="948" t="929" r="964" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="965" t="927" r="974" b="949"> </charParams>
+<charParams l="975" t="927" r="988" b="949" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="50">t</charParams>
+<charParams l="990" t="930" r="1009" b="950" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="255" wordPenalty="0" meanStrokeWidth="50">o</charParams>
+<charParams l="1013" t="930" r="1031" b="950" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="100" wordPenalty="0" meanStrokeWidth="50">u</charParams>
+<charParams l="1035" t="917" r="1041" b="958" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="0" wordPenalty="0" meanStrokeWidth="50">j</charParams>
+<charParams l="1046" t="929" r="1065" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="255" wordPenalty="0" meanStrokeWidth="50">o</charParams>
+<charParams l="1068" t="930" r="1086" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="98" wordPenalty="0" meanStrokeWidth="50">u</charParams>
+<charParams l="1090" t="929" r="1104" b="948" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="50">r</charParams>
+<charParams l="1106" t="928" r="1119" b="949" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="32" wordPenalty="0" meanStrokeWidth="50">s</charParams></formatting></line>
+<line baseline="995" l="374" t="960" r="1116" b="1004"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="977" r="394" b="997" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="397" t="977" r="416" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="419" t="977" r="439" b="998" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="442" t="976" r="459" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="461" t="977" r="475" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="479" t="973" r="491" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="493" t="975" r="506" b="997" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="41" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="518" t="989" r="526" b="1004" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="32" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">,</charParams>
+<charParams l="527" t="976" r="543" b="1004"> </charParams>
+<charParams l="544" t="976" r="563" b="996" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="566" t="977" r="584" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="93" wordPenalty="0" meanStrokeWidth="42">u</charParams>
+<charParams l="585" t="962" r="598" b="997"> </charParams>
+<charParams l="599" t="962" r="622" b="997" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="46">s</charParams>
+<charParams l="599" t="962" r="622" b="997" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="46">i</charParams>
+<charParams l="623" t="962" r="640" b="997"> </charParams>
+<charParams l="641" t="976" r="660" b="996" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="663" t="975" r="682" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="683" t="962" r="701" b="996"> </charParams>
+<charParams l="702" t="962" r="711" b="996" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="715" t="975" r="731" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="735" t="976" r="747" b="997" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="73" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="748" t="963" r="760" b="997"> </charParams>
+<charParams l="761" t="963" r="780" b="996" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="776" t="975" r="793" b="996" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="795" t="975" r="809" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="813" t="976" r="842" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="3" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="847" t="974" r="864" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="865" t="962" r="878" b="995"> </charParams>
+<charParams l="879" t="962" r="897" b="995" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="901" t="975" r="918" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="920" t="974" r="938" b="994" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="943" t="974" r="955" b="994" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="956" t="961" r="970" b="994"> </charParams>
+<charParams l="971" t="961" r="980" b="994" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="983" t="974" r="1000" b="995" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1001" t="960" r="1015" b="995"> </charParams>
+<charParams l="1016" t="960" r="1034" b="993" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">f</charParams>
+<charParams l="1030" t="974" r="1049" b="993" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="93" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="1052" t="973" r="1060" b="994" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="26" wordPenalty="3" meanStrokeWidth="38">i</charParams>
+<charParams l="1064" t="971" r="1077" b="994" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="3" meanStrokeWidth="38">t</charParams>
+<charParams l="1080" t="972" r="1097" b="993" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1108" t="985" r="1116" b="1001" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams></formatting></line>
+<line baseline="1040" l="373" t="1003" r="1119" b="1051"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="373" t="1020" r="393" b="1041" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="398" t="1021" r="415" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="416" t="1007" r="442" b="1041"> </charParams>
+<charParams l="443" t="1007" r="451" b="1041" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="455" t="1021" r="472" b="1043" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="474" t="1021" r="486" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="487" t="1021" r="509" b="1049"> </charParams>
+<charParams l="510" t="1021" r="529" b="1049" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="97" wordPenalty="0" meanStrokeWidth="33">p</charParams>
+<charParams l="532" t="1021" r="548" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="53" wordPenalty="0" meanStrokeWidth="33">a</charParams>
+<charParams l="550" t="1020" r="563" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="44" wordPenalty="0" meanStrokeWidth="33">s</charParams>
+<charParams l="564" t="1020" r="591" b="1041"> </charParams>
+<charParams l="592" t="1020" r="606" b="1040" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="609" t="1020" r="628" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="631" t="1020" r="650" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="653" t="1020" r="672" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="52" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="676" t="1020" r="690" b="1038" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="693" t="1007" r="701" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="704" t="1020" r="720" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="721" t="1020" r="735" b="1051"> </charParams>
+<charParams l="736" t="1020" r="744" b="1051" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="22" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">;</charParams>
+<charParams l="745" t="1019" r="764" b="1051"> </charParams>
+<charParams l="765" t="1019" r="782" b="1040" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="784" t="1020" r="799" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="802" t="1021" r="817" b="1040" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="818" t="1007" r="840" b="1040"> </charParams>
+<charParams l="841" t="1007" r="852" b="1039" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="855" t="1007" r="863" b="1039" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="864" t="1007" r="886" b="1039"> </charParams>
+<charParams l="887" t="1019" r="904" b="1039" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="908" t="1019" r="920" b="1038" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="922" t="1017" r="937" b="1037" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="939" t="1006" r="948" b="1038" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="951" t="1018" r="969" b="1037" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">v</charParams>
+<charParams l="974" t="1017" r="991" b="1038" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="992" t="1017" r="1012" b="1048"> </charParams>
+<charParams l="1013" t="1019" r="1030" b="1048" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="1034" t="1019" r="1053" b="1038" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1056" t="1017" r="1073" b="1039" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1074" t="1003" r="1090" b="1039"> </charParams>
+<charParams l="1091" t="1003" r="1100" b="1036" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">f</charParams>
+<charParams l="1102" t="1017" r="1119" b="1037" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="2" meanStrokeWidth="39">a</charParams></formatting></line>
+<line baseline="1085" l="373" t="1048" r="1117" b="1095"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="373" t="1066" r="392" b="1095" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="396" t="1065" r="413" b="1085" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="418" t="1065" r="430" b="1085" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="434" t="1063" r="446" b="1086" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="450" t="1053" r="457" b="1085" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="462" t="1064" r="478" b="1086" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="479" t="1053" r="499" b="1086"> </charParams>
+<charParams l="500" t="1053" r="518" b="1084" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="49">d</charParams>
+<charParams l="523" t="1064" r="541" b="1085" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="49">e</charParams>
+<charParams l="542" t="1051" r="563" b="1085"> </charParams>
+<charParams l="564" t="1051" r="572" b="1084" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="575" t="1064" r="592" b="1084" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="92" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="593" t="1064" r="613" b="1084"> </charParams>
+<charParams l="614" t="1065" r="629" b="1084" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="633" t="1063" r="650" b="1084" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="654" t="1062" r="664" b="1084" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="667" t="1065" r="686" b="1084" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="689" t="1063" r="703" b="1083" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="706" t="1062" r="719" b="1085" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="722" t="1063" r="739" b="1085" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="740" t="1063" r="760" b="1093"> </charParams>
+<charParams l="761" t="1065" r="780" b="1093" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="782" t="1064" r="802" b="1084" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="97" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="806" t="1051" r="814" b="1084" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="815" t="1051" r="836" b="1084"> </charParams>
+<charParams l="837" t="1063" r="855" b="1083" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="857" t="1049" r="882" b="1083" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">s</charParams>
+<charParams l="857" t="1049" r="882" b="1083" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="883" t="1049" r="902" b="1083"> </charParams>
+<charParams l="903" t="1063" r="924" b="1083" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">v</charParams>
+<charParams l="928" t="1050" r="936" b="1082" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="940" t="1062" r="951" b="1082" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="73" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="954" t="1070" r="965" b="1074" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">-</charParams>
+<charParams l="966" t="1048" r="983" b="1082" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">&#224;</charParams>
+<charParams l="988" t="1070" r="993" b="1073" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">-</charParams>
+<charParams l="998" t="1063" r="1017" b="1083" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">v</charParams>
+<charParams l="1021" t="1050" r="1028" b="1083" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="1032" t="1063" r="1044" b="1084" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="44" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1059" t="1075" r="1066" b="1090" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="20">,</charParams>
+<charParams l="1067" t="1051" r="1084" b="1090"> </charParams>
+<charParams l="1085" t="1051" r="1117" b="1082" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&amp;</charParams></formatting></line>
+<line baseline="1128" l="374" t="1092" r="1118" b="1138"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="1110" r="392" b="1138" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="396" t="1111" r="414" b="1130" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="418" t="1097" r="427" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="428" t="1097" r="450" b="1129"> </charParams>
+<charParams l="451" t="1109" r="464" b="1129" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="44" wordPenalty="5" meanStrokeWidth="40">s</charParams>
+<charParams l="466" t="1098" r="473" b="1110" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="5" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="477" t="1109" r="495" b="1130" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="497" t="1095" r="522" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="497" t="1095" r="522" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="523" t="1095" r="540" b="1129"> </charParams>
+<charParams l="541" t="1109" r="556" b="1129" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="559" t="1107" r="575" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="578" t="1096" r="596" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="593" t="1109" r="606" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="608" t="1109" r="627" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="630" t="1096" r="640" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="643" t="1095" r="661" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="664" t="1096" r="674" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="678" t="1107" r="694" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="695" t="1107" r="715" b="1138"> </charParams>
+<charParams l="716" t="1109" r="734" b="1138" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="739" t="1108" r="754" b="1129" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="757" t="1109" r="776" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="780" t="1096" r="799" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="802" t="1108" r="817" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="33" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="820" t="1108" r="839" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="842" t="1105" r="856" b="1128" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="857" t="1105" r="874" b="1137"> </charParams>
+<charParams l="875" t="1108" r="892" b="1137" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="896" t="1108" r="913" b="1127" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="916" t="1096" r="923" b="1108" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">&#8217;</charParams>
+<charParams l="926" t="1094" r="935" b="1127" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="938" t="1093" r="945" b="1126" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="949" t="1106" r="962" b="1126" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="44" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="963" t="1106" r="985" b="1127"> </charParams>
+<charParams l="986" t="1107" r="1006" b="1127" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1009" t="1107" r="1027" b="1126" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="50" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1031" t="1105" r="1044" b="1127" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="1045" t="1092" r="1068" b="1127"> </charParams>
+<charParams l="1069" t="1092" r="1085" b="1126" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="1087" t="1104" r="1100" b="1126" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1103" t="1092" r="1118" b="1126" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">&#233;</charParams></formatting></line>
+<line baseline="1172" l="373" t="1137" r="1119" b="1183"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="373" t="1142" r="387" b="1174" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">f</charParams>
+<charParams l="388" t="1153" r="403" b="1174" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="408" t="1154" r="420" b="1173" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="425" t="1154" r="454" b="1173" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="3" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="458" t="1139" r="475" b="1174" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="476" t="1154" r="488" b="1174" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="13" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="502" t="1166" r="510" b="1181" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="81" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="511" t="1153" r="525" b="1182"> </charParams>
+<charParams l="526" t="1153" r="546" b="1182" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="96" wordPenalty="7" meanStrokeWidth="38">p</charParams>
+<charParams l="549" t="1153" r="565" b="1173" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="33" wordPenalty="7" meanStrokeWidth="38">a</charParams>
+<charParams l="568" t="1153" r="582" b="1173" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="7" meanStrokeWidth="38">r</charParams>
+<charParams l="584" t="1153" r="600" b="1173" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="26" wordPenalty="7" meanStrokeWidth="38">c</charParams>
+<charParams l="603" t="1152" r="620" b="1173" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="7" meanStrokeWidth="38">e</charParams>
+<charParams l="621" t="1152" r="641" b="1183"> </charParams>
+<charParams l="642" t="1154" r="660" b="1183" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="663" t="1153" r="681" b="1173" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="98" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="685" t="1152" r="702" b="1173" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="703" t="1140" r="718" b="1173"> </charParams>
+<charParams l="719" t="1140" r="727" b="1173" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="50" wordPenalty="0" meanStrokeWidth="42">l</charParams>
+<charParams l="731" t="1153" r="747" b="1173" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="33" wordPenalty="0" meanStrokeWidth="42">a</charParams>
+<charParams l="748" t="1153" r="768" b="1173"> </charParams>
+<charParams l="769" t="1153" r="784" b="1172" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="786" t="1141" r="806" b="1172" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="98" wordPenalty="0" meanStrokeWidth="37">h</charParams>
+<charParams l="808" t="1152" r="825" b="1172" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="33" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="827" t="1139" r="834" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="838" t="1151" r="855" b="1172" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="858" t="1151" r="876" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="881" t="1151" r="895" b="1170" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="896" t="1151" r="915" b="1170"> </charParams>
+<charParams l="916" t="1151" r="937" b="1170" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="939" t="1138" r="947" b="1151" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="950" t="1151" r="967" b="1171" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="968" t="1151" r="982" b="1179"> </charParams>
+<charParams l="983" t="1151" r="1000" b="1179" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1004" t="1137" r="1011" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1016" t="1151" r="1034" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1037" t="1151" r="1049" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1050" t="1137" r="1068" b="1171"> </charParams>
+<charParams l="1069" t="1137" r="1087" b="1171" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">&#233;</charParams>
+<charParams l="1089" t="1148" r="1100" b="1170" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1103" t="1137" r="1119" b="1171" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">&#233;</charParams></formatting></line>
+<line baseline="1216" l="374" t="1181" r="1120" b="1224"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="1185" r="393" b="1217" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="2" meanStrokeWidth="37">d</charParams>
+<charParams l="398" t="1183" r="414" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="417" t="1196" r="429" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="61" wordPenalty="2" meanStrokeWidth="37">t</charParams>
+<charParams l="431" t="1197" r="448" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="453" t="1198" r="464" b="1218" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="4" wordPenalty="2" meanStrokeWidth="37">r</charParams>
+<charParams l="468" t="1198" r="497" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="3" wordPenalty="2" meanStrokeWidth="37">m</charParams>
+<charParams l="501" t="1185" r="511" b="1218" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="0" wordPenalty="2" meanStrokeWidth="37">i</charParams>
+<charParams l="515" t="1197" r="532" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="50" wordPenalty="2" meanStrokeWidth="37">n</charParams>
+<charParams l="538" t="1184" r="553" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="556" t="1197" r="573" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="574" t="1185" r="599" b="1217"> </charParams>
+<charParams l="600" t="1185" r="620" b="1217" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="623" t="1197" r="641" b="1218" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="642" t="1196" r="662" b="1218"> </charParams>
+<charParams l="663" t="1196" r="680" b="1217" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="683" t="1196" r="700" b="1217" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="701" t="1196" r="719" b="1217"> </charParams>
+<charParams l="720" t="1196" r="735" b="1217" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="738" t="1185" r="757" b="1217" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="54" wordPenalty="0" meanStrokeWidth="38">&#243;</charParams>
+<charParams l="761" t="1194" r="774" b="1217" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="775" t="1183" r="792" b="1217" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="793" t="1204" r="807" b="1209" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">-</charParams>
+<charParams l="810" t="1183" r="818" b="1216" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="822" t="1182" r="838" b="1215" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">&#224;</charParams>
+<charParams l="839" t="1182" r="851" b="1224"> </charParams>
+<charParams l="852" t="1209" r="860" b="1224" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="861" t="1181" r="873" b="1224"> </charParams>
+<charParams l="874" t="1181" r="892" b="1214" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="889" t="1195" r="906" b="1216" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="907" t="1183" r="927" b="1216"> </charParams>
+<charParams l="928" t="1183" r="945" b="1215" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="941" t="1194" r="957" b="1215" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="961" t="1195" r="978" b="1215" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="983" t="1182" r="1000" b="1215" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1001" t="1182" r="1023" b="1224"> </charParams>
+<charParams l="1024" t="1196" r="1044" b="1224" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1046" t="1195" r="1063" b="1215" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1065" t="1194" r="1080" b="1215" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1083" t="1195" r="1099" b="1215" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1102" t="1195" r="1120" b="1217" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="1261" l="375" t="1226" r="1121" b="1270"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1242" r="393" b="1270" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="397" t="1242" r="415" b="1262" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="418" t="1229" r="426" b="1241" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">&#8217;</charParams>
+<charParams l="429" t="1242" r="447" b="1262" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="448" t="1228" r="456" b="1262" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="26" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="460" t="1228" r="467" b="1261" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="472" t="1241" r="488" b="1262" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="489" t="1241" r="499" b="1262"> </charParams>
+<charParams l="500" t="1241" r="517" b="1262" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="519" t="1228" r="545" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">s</charParams>
+<charParams l="519" t="1228" r="545" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">t</charParams>
+<charParams l="546" t="1228" r="555" b="1261"> </charParams>
+<charParams l="556" t="1228" r="574" b="1261" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="569" t="1241" r="584" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="586" t="1241" r="601" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="604" t="1241" r="624" b="1270" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="626" t="1241" r="645" b="1270" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="648" t="1227" r="664" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="666" t="1240" r="684" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="685" t="1229" r="692" b="1262"> </charParams>
+<charParams l="693" t="1229" r="712" b="1262" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="716" t="1228" r="723" b="1241" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="726" t="1241" r="746" b="1261" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="98" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="749" t="1241" r="767" b="1261" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="771" t="1240" r="788" b="1261" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="789" t="1240" r="797" b="1261"> </charParams>
+<charParams l="798" t="1240" r="814" b="1260" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="26" wordPenalty="2" meanStrokeWidth="40">c</charParams>
+<charParams l="815" t="1228" r="836" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="98" wordPenalty="2" meanStrokeWidth="40">h</charParams>
+<charParams l="839" t="1241" r="855" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="33" wordPenalty="2" meanStrokeWidth="40">a</charParams>
+<charParams l="856" t="1227" r="864" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">l</charParams>
+<charParams l="868" t="1239" r="886" b="1261" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="2" meanStrokeWidth="40">e</charParams>
+<charParams l="888" t="1240" r="906" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="910" t="1240" r="924" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">r</charParams>
+<charParams l="925" t="1226" r="931" b="1260"> </charParams>
+<charParams l="932" t="1226" r="950" b="1260" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="48" wordPenalty="5" meanStrokeWidth="38">s</charParams>
+<charParams l="945" t="1240" r="965" b="1259" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="91" wordPenalty="5" meanStrokeWidth="38">u</charParams>
+<charParams l="967" t="1226" r="987" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="5" meanStrokeWidth="38">b</charParams>
+<charParams l="990" t="1226" r="998" b="1259" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1002" t="1236" r="1014" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="61" wordPenalty="5" meanStrokeWidth="38">t</charParams>
+<charParams l="1017" t="1238" r="1034" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="5" meanStrokeWidth="38">e</charParams>
+<charParams l="1035" t="1238" r="1046" b="1260"> </charParams>
+<charParams l="1047" t="1241" r="1053" b="1260" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="87" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">:</charParams>
+<charParams l="1054" t="1239" r="1067" b="1260"> </charParams>
+<charParams l="1068" t="1239" r="1084" b="1260" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="1088" t="1239" r="1105" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1108" t="1237" r="1121" b="1260" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams></formatting></line>
+<line baseline="1305" l="374" t="1270" r="1121" b="1314"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="1272" r="385" b="1305" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="388" t="1285" r="406" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="412" t="1284" r="426" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="429" t="1286" r="449" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="451" t="1285" r="470" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="473" t="1285" r="494" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="51" wordPenalty="0" meanStrokeWidth="40">v</charParams>
+<charParams l="495" t="1272" r="512" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">&#233;</charParams>
+<charParams l="514" t="1285" r="532" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="536" t="1273" r="545" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="549" t="1283" r="565" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="568" t="1285" r="587" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="591" t="1282" r="603" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="604" t="1282" r="617" b="1304"> </charParams>
+<charParams l="618" t="1284" r="635" b="1304" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="638" t="1285" r="652" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="655" t="1284" r="669" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="672" t="1272" r="681" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="685" t="1285" r="704" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="706" t="1285" r="724" b="1306" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="725" t="1273" r="734" b="1306"> </charParams>
+<charParams l="735" t="1273" r="754" b="1305" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="758" t="1272" r="765" b="1285" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="767" t="1285" r="784" b="1305" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="786" t="1285" r="803" b="1306" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="808" t="1281" r="821" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="823" t="1284" r="838" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="62" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="842" t="1284" r="861" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="865" t="1281" r="878" b="1305" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="879" t="1281" r="887" b="1305"> </charParams>
+<charParams l="888" t="1284" r="918" b="1304" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="3" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="921" t="1271" r="931" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="935" t="1284" r="952" b="1305" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="954" t="1284" r="974" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="977" t="1285" r="995" b="1304" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">x</charParams>
+<charParams l="996" t="1285" r="1006" b="1314"> </charParams>
+<charParams l="1007" t="1285" r="1024" b="1314" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="1028" t="1285" r="1046" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1050" t="1270" r="1057" b="1284" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1060" t="1283" r="1078" b="1305" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1081" t="1271" r="1088" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1092" t="1270" r="1099" b="1304" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1104" t="1283" r="1121" b="1305" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams></formatting></line>
+<line baseline="1348" l="374" t="1315" r="1121" b="1357"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="1328" r="392" b="1348" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="395" t="1315" r="420" b="1347" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="395" t="1315" r="420" b="1347" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="421" t="1315" r="434" b="1356"> </charParams>
+<charParams l="435" t="1329" r="455" b="1356" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="96" wordPenalty="2" meanStrokeWidth="36">p</charParams>
+<charParams l="457" t="1315" r="464" b="1347" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="50" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="469" t="1328" r="488" b="1348" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="91" wordPenalty="2" meanStrokeWidth="36">u</charParams>
+<charParams l="490" t="1328" r="503" b="1348" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="44" wordPenalty="2" meanStrokeWidth="36">s</charParams>
+<charParams l="504" t="1315" r="521" b="1348"> </charParams>
+<charParams l="522" t="1315" r="539" b="1347" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">&#233;</charParams>
+<charParams l="539" t="1329" r="559" b="1357" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="563" t="1328" r="576" b="1347" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="581" t="1316" r="589" b="1348" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="593" t="1319" r="602" b="1347" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#237;</charParams>
+<charParams l="606" t="1316" r="614" b="1347" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#237;</charParams>
+<charParams l="617" t="1315" r="634" b="1348" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">&#232;</charParams>
+<charParams l="644" t="1341" r="652" b="1357" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="653" t="1329" r="669" b="1357"> </charParams>
+<charParams l="670" t="1329" r="690" b="1357" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="694" t="1329" r="708" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="710" t="1329" r="726" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="727" t="1315" r="743" b="1349"> </charParams>
+<charParams l="744" t="1315" r="751" b="1348" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="4" meanStrokeWidth="41">l</charParams>
+<charParams l="755" t="1329" r="771" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="62" wordPenalty="4" meanStrokeWidth="41">a</charParams>
+<charParams l="772" t="1329" r="787" b="1349"> </charParams>
+<charParams l="788" t="1329" r="802" b="1349" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="3" meanStrokeWidth="39">r</charParams>
+<charParams l="804" t="1329" r="819" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="62" wordPenalty="3" meanStrokeWidth="39">a</charParams>
+<charParams l="824" t="1317" r="831" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="3" meanStrokeWidth="39">i</charParams>
+<charParams l="835" t="1316" r="852" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="48" wordPenalty="3" meanStrokeWidth="39">s</charParams>
+<charParams l="848" t="1329" r="867" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="255" wordPenalty="3" meanStrokeWidth="39">o</charParams>
+<charParams l="871" t="1328" r="890" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="3" meanStrokeWidth="39">n</charParams>
+<charParams l="891" t="1328" r="910" b="1357"> </charParams>
+<charParams l="911" t="1329" r="929" b="1357" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="932" t="1329" r="949" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="97" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="954" t="1328" r="971" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="972" t="1315" r="991" b="1349"> </charParams>
+<charParams l="992" t="1315" r="1000" b="1349" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1004" t="1329" r="1020" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="62" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1021" t="1326" r="1036" b="1349"> </charParams>
+<charParams l="1037" t="1326" r="1049" b="1349" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1051" t="1329" r="1067" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="62" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1070" t="1315" r="1089" b="1349" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">b</charParams>
+<charParams l="1091" t="1315" r="1099" b="1348" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1104" t="1327" r="1121" b="1348" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="1393" l="374" t="1358" r="1121" b="1401"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="374" t="1358" r="383" b="1390" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="388" t="1370" r="407" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="410" t="1368" r="422" b="1391" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="424" t="1370" r="441" b="1391" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="444" t="1371" r="458" b="1391" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="460" t="1371" r="480" b="1391" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="483" t="1370" r="501" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="502" t="1370" r="514" b="1392"> </charParams>
+<charParams l="515" t="1371" r="534" b="1392" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="539" t="1371" r="556" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="557" t="1371" r="568" b="1400"> </charParams>
+<charParams l="569" t="1371" r="588" b="1400" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="593" t="1370" r="608" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="611" t="1372" r="630" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="98" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="634" t="1370" r="646" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="647" t="1370" r="661" b="1401"> </charParams>
+<charParams l="662" t="1373" r="681" b="1401" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="96" wordPenalty="2" meanStrokeWidth="38">p</charParams>
+<charParams l="685" t="1372" r="700" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="62" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="703" t="1373" r="716" b="1394" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="44" wordPenalty="2" meanStrokeWidth="38">s</charParams>
+<charParams l="717" t="1361" r="732" b="1394"> </charParams>
+<charParams l="733" t="1361" r="751" b="1393" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="58" wordPenalty="0" meanStrokeWidth="38">&#234;</charParams>
+<charParams l="753" t="1371" r="765" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="768" t="1373" r="782" b="1394" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="785" t="1373" r="802" b="1394" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="803" t="1361" r="816" b="1394"> </charParams>
+<charParams l="817" t="1361" r="835" b="1393" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="839" t="1361" r="848" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="852" t="1360" r="859" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="863" t="1373" r="880" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="62" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="883" t="1371" r="894" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="897" t="1358" r="913" b="1392" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="916" t="1372" r="933" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="934" t="1372" r="952" b="1394"> </charParams>
+<charParams l="953" t="1372" r="971" b="1394" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="975" t="1373" r="993" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="994" t="1373" r="1013" b="1393"> </charParams>
+<charParams l="1014" t="1373" r="1045" b="1393" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="3" wordPenalty="0" meanStrokeWidth="31">m</charParams>
+<charParams l="1048" t="1361" r="1065" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="58" wordPenalty="0" meanStrokeWidth="31">&#234;</charParams>
+<charParams l="1069" t="1373" r="1099" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">m</charParams>
+<charParams l="1104" t="1372" r="1121" b="1393" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="31">e</charParams></formatting></line>
+<line baseline="1437" l="375" t="1402" r="1123" b="1447"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1411" r="388" b="1433" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="391" t="1413" r="407" b="1434" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="410" t="1414" r="440" b="1434" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="445" t="1415" r="457" b="1435" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="13" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="458" t="1415" r="478" b="1445"> </charParams>
+<charParams l="479" t="1416" r="496" b="1445" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="500" t="1415" r="518" b="1436" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="522" t="1415" r="540" b="1437" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="541" t="1402" r="559" b="1437"> </charParams>
+<charParams l="560" t="1402" r="569" b="1435" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="572" t="1403" r="580" b="1416" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="583" t="1415" r="600" b="1436" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="603" t="1416" r="620" b="1436" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">x</charParams>
+<charParams l="623" t="1413" r="636" b="1437" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="639" t="1416" r="655" b="1437" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="658" t="1416" r="672" b="1436" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="675" t="1417" r="694" b="1436" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="698" t="1418" r="714" b="1438" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="718" t="1430" r="725" b="1438" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams>
+<charParams l="726" t="1405" r="747" b="1438"> </charParams>
+<charParams l="748" t="1405" r="775" b="1438" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="88" wordPenalty="0" meanStrokeWidth="38">C</charParams>
+<charParams l="779" t="1417" r="795" b="1438" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="798" t="1415" r="811" b="1438" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="812" t="1415" r="836" b="1438"> </charParams>
+<charParams l="837" t="1418" r="857" b="1438" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="98" wordPenalty="3" meanStrokeWidth="37">u</charParams>
+<charParams l="859" t="1403" r="876" b="1437" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="48" wordPenalty="3" meanStrokeWidth="37">s</charParams>
+<charParams l="874" t="1418" r="890" b="1437" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="3" meanStrokeWidth="37">a</charParams>
+<charParams l="892" t="1417" r="911" b="1447" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="53" wordPenalty="3" meanStrokeWidth="37">g</charParams>
+<charParams l="914" t="1416" r="931" b="1437" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="3" meanStrokeWidth="37">e</charParams>
+<charParams l="932" t="1405" r="955" b="1438"> </charParams>
+<charParams l="956" t="1405" r="976" b="1438" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="979" t="1404" r="986" b="1417" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="990" t="1418" r="1008" b="1438" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1012" t="1417" r="1032" b="1438" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1033" t="1404" r="1059" b="1438"> </charParams>
+<charParams l="1060" t="1404" r="1077" b="1438" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1074" t="1417" r="1091" b="1438" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1093" t="1418" r="1111" b="1438" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="86" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="1115" t="1403" r="1123" b="1437" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="26" wordPenalty="3" meanStrokeWidth="38">l</charParams></formatting></line>
+<line baseline="1482" l="375" t="1446" r="1121" b="1490"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1458" r="391" b="1477" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="4" meanStrokeWidth="38">r</charParams>
+<charParams l="394" t="1458" r="411" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="83" wordPenalty="4" meanStrokeWidth="38">e</charParams>
+<charParams l="414" t="1459" r="432" b="1488" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="4" meanStrokeWidth="38">g</charParams>
+<charParams l="434" t="1446" r="444" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="4" meanStrokeWidth="38">i</charParams>
+<charParams l="447" t="1446" r="472" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="4" meanStrokeWidth="38">s</charParams>
+<charParams l="447" t="1446" r="472" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="4" meanStrokeWidth="38">t</charParams>
+<charParams l="475" t="1460" r="489" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="4" meanStrokeWidth="38">r</charParams>
+<charParams l="491" t="1459" r="509" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="83" wordPenalty="4" meanStrokeWidth="38">e</charParams>
+<charParams l="510" t="1459" r="523" b="1480"> </charParams>
+<charParams l="524" t="1460" r="540" b="1480" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="62" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="543" t="1460" r="561" b="1480" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="562" t="1460" r="571" b="1480"> </charParams>
+<charParams l="572" t="1460" r="601" b="1480" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="606" t="1448" r="615" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="618" t="1447" r="625" b="1481" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="630" t="1449" r="636" b="1481" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="641" t="1461" r="657" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="662" t="1462" r="679" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="680" t="1450" r="693" b="1482"> </charParams>
+<charParams l="694" t="1450" r="714" b="1482" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="71" wordPenalty="1" meanStrokeWidth="37">d</charParams>
+<charParams l="718" t="1463" r="736" b="1482" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="91" wordPenalty="1" meanStrokeWidth="37">u</charParams>
+<charParams l="745" t="1450" r="764" b="1482" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="71" wordPenalty="1" meanStrokeWidth="37">d</charParams>
+<charParams l="769" t="1450" r="788" b="1483" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="60" wordPenalty="1" meanStrokeWidth="37">&#244;</charParams>
+<charParams l="791" t="1462" r="822" b="1482" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="3" wordPenalty="1" meanStrokeWidth="37">m</charParams>
+<charParams l="826" t="1462" r="843" b="1483" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="1" meanStrokeWidth="37">e</charParams>
+<charParams l="844" t="1462" r="853" b="1483"> </charParams>
+<charParams l="854" t="1462" r="871" b="1482" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="873" t="1448" r="898" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="873" t="1448" r="898" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="899" t="1448" r="913" b="1482"> </charParams>
+<charParams l="914" t="1449" r="946" b="1482" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="914" t="1449" r="946" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="949" t="1461" r="964" b="1481" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="967" t="1459" r="980" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="981" t="1459" r="987" b="1482"> </charParams>
+<charParams l="988" t="1462" r="1005" b="1482" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1008" t="1462" r="1027" b="1482" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1031" t="1462" r="1046" b="1483" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1048" t="1450" r="1058" b="1483" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1062" t="1462" r="1078" b="1483" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1081" t="1462" r="1101" b="1482" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1113" t="1475" r="1121" b="1490" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="75" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams></formatting></line>
+<line baseline="1526" l="375" t="1492" r="1124" b="1536"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1501" r="391" b="1521" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="394" t="1503" r="413" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="416" t="1503" r="446" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="450" t="1504" r="481" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="3" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="485" t="1502" r="502" b="1525" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="503" t="1502" r="517" b="1525"> </charParams>
+<charParams l="518" t="1504" r="538" b="1525" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="542" t="1505" r="561" b="1525" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="565" t="1504" r="583" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="586" t="1504" r="599" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="600" t="1492" r="614" b="1526"> </charParams>
+<charParams l="615" t="1492" r="634" b="1526" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="31" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="637" t="1505" r="654" b="1525" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="3" meanStrokeWidth="38">a</charParams>
+<charParams l="655" t="1506" r="676" b="1526" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="3" meanStrokeWidth="38">v</charParams>
+<charParams l="678" t="1506" r="697" b="1526" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">o</charParams>
+<charParams l="701" t="1506" r="721" b="1526" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">n</charParams>
+<charParams l="724" t="1506" r="736" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="737" t="1506" r="750" b="1527"> </charParams>
+<charParams l="751" t="1506" r="766" b="1526" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="769" t="1506" r="785" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="789" t="1507" r="819" b="1526" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="823" t="1507" r="839" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="842" t="1507" r="856" b="1526" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="859" t="1507" r="876" b="1536" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="879" t="1507" r="898" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="900" t="1493" r="916" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="917" t="1493" r="931" b="1527"> </charParams>
+<charParams l="932" t="1493" r="949" b="1526" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">&#224;</charParams>
+<charParams l="950" t="1493" r="962" b="1527"> </charParams>
+<charParams l="963" t="1493" r="970" b="1527" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="974" t="1507" r="991" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="992" t="1493" r="1005" b="1527"> </charParams>
+<charParams l="1006" t="1493" r="1024" b="1527" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">s</charParams>
+<charParams l="1020" t="1506" r="1037" b="1528" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="83" wordPenalty="5" meanStrokeWidth="39">e</charParams>
+<charParams l="1041" t="1496" r="1067" b="1528" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">c</charParams>
+<charParams l="1041" t="1496" r="1067" b="1528" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">t</charParams>
+<charParams l="1070" t="1495" r="1078" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="0" wordPenalty="5" meanStrokeWidth="39">i</charParams>
+<charParams l="1082" t="1507" r="1101" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">o</charParams>
+<charParams l="1103" t="1507" r="1124" b="1527" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="100" wordPenalty="5" meanStrokeWidth="39">n</charParams></formatting></line>
+<line baseline="1571" l="375" t="1534" r="1125" b="1581"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1534" r="396" b="1567" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="71" wordPenalty="8" meanStrokeWidth="38">d</charParams>
+<charParams l="398" t="1546" r="416" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="8" meanStrokeWidth="38">e</charParams>
+<charParams l="417" t="1547" r="429" b="1567" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="8" meanStrokeWidth="38">s</charParams>
+<charParams l="430" t="1536" r="439" b="1578"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="440" t="1536" r="473" b="1578" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="466" t="1548" r="483" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="487" t="1549" r="506" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="509" t="1550" r="525" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="526" t="1549" r="546" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="549" t="1549" r="563" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="566" t="1549" r="584" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="95" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="588" t="1550" r="606" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="610" t="1550" r="632" b="1570" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">x</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="633" t="1550" r="652" b="1579"> </charParams>
+<charParams l="653" t="1550" r="672" b="1579" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="96" wordPenalty="9" meanStrokeWidth="38">p</charParams>
+<charParams l="675" t="1538" r="696" b="1570" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="98" wordPenalty="9" meanStrokeWidth="38">h</charParams>
+<charParams l="699" t="1539" r="707" b="1571" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="9" meanStrokeWidth="38">i</charParams>
+<charParams l="711" t="1538" r="717" b="1571" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="50" wordPenalty="9" meanStrokeWidth="38">l</charParams>
+<charParams l="722" t="1551" r="742" b="1571" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="9" meanStrokeWidth="38">o</charParams>
+<charParams l="745" t="1537" r="761" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="48" wordPenalty="9" meanStrokeWidth="38">s</charParams>
+<charParams l="757" t="1551" r="777" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="9" meanStrokeWidth="38">o</charParams>
+<charParams l="780" t="1551" r="798" b="1581" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="96" wordPenalty="9" meanStrokeWidth="38">p</charParams>
+<charParams l="801" t="1539" r="822" b="1571" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="98" wordPenalty="9" meanStrokeWidth="38">h</charParams>
+<charParams l="824" t="1539" r="832" b="1571" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="0" wordPenalty="9" meanStrokeWidth="38">i</charParams>
+<charParams l="836" t="1553" r="853" b="1581" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="9" meanStrokeWidth="38">q</charParams>
+<charParams l="856" t="1552" r="874" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="97" wordPenalty="9" meanStrokeWidth="38">u</charParams>
+<charParams l="878" t="1550" r="896" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="9" meanStrokeWidth="38">e</charParams>
+<charParams l="898" t="1552" r="911" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="10" wordPenalty="9" meanStrokeWidth="38">s</charParams>
+<charParams l="914" t="1566" r="920" b="1573" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="9" meanStrokeWidth="38">.</charParams>
+<charParams l="921" t="1539" r="944" b="1573"> </charParams>
+<charParams l="945" t="1539" r="971" b="1572" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="98" wordPenalty="0" meanStrokeWidth="42">P</charParams>
+<charParams l="974" t="1551" r="990" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="83" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="993" t="1552" r="1014" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="97" wordPenalty="0" meanStrokeWidth="42">u</charParams>
+<charParams l="1015" t="1539" r="1034" b="1572"> </charParams>
+<charParams l="1035" t="1539" r="1054" b="1572" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="71" wordPenalty="2" meanStrokeWidth="37">d</charParams>
+<charParams l="1059" t="1539" r="1066" b="1551" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="255" wordPenalty="22" meanStrokeWidth="37">'</charParams>
+<charParams l="1068" t="1552" r="1085" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="22" meanStrokeWidth="37">a</charParams>
+<charParams l="1087" t="1552" r="1106" b="1572" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="22" meanStrokeWidth="37">u</charParams>
+<charParams l="1109" t="1559" r="1125" b="1565" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="22" meanStrokeWidth="37">&#172;</charParams></formatting></line>
+<line baseline="1616" l="375" t="1583" r="1125" b="1627"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1589" r="390" b="1613" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="61" wordPenalty="22" meanStrokeWidth="38">t</charParams>
+<charParams l="393" t="1591" r="409" b="1613" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="22" meanStrokeWidth="38">e</charParams>
+<charParams l="412" t="1591" r="431" b="1612" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="22" meanStrokeWidth="38">u</charParams>
+<charParams l="436" t="1593" r="449" b="1612" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="22" meanStrokeWidth="38">r</charParams>
+<charParams l="450" t="1592" r="463" b="1613" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="42" wordPenalty="22" meanStrokeWidth="38">s</charParams>
+<charParams l="464" t="1592" r="485" b="1614"> </charParams>
+<charParams l="486" t="1592" r="503" b="1614" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="505" t="1593" r="525" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="526" t="1593" r="545" b="1614"> </charParams>
+<charParams l="546" t="1594" r="566" b="1614" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="570" t="1594" r="588" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="50" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="592" t="1590" r="605" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="606" t="1590" r="621" b="1614"> </charParams>
+<charParams l="622" t="1594" r="653" b="1614" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="3" wordPenalty="0" meanStrokeWidth="40">m</charParams>
+<charParams l="657" t="1584" r="666" b="1615" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="668" t="1595" r="681" b="1615" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="42" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="682" t="1595" r="696" b="1626"> </charParams>
+<charParams l="697" t="1597" r="715" b="1626" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">q</charParams>
+<charParams l="719" t="1596" r="737" b="1616" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="91" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="740" t="1596" r="756" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="33" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="759" t="1594" r="771" b="1616" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">t</charParams>
+<charParams l="772" t="1597" r="788" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="790" t="1595" r="807" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="83" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="811" t="1609" r="818" b="1616" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">.</charParams>
+<charParams l="819" t="1584" r="841" b="1617"> </charParams>
+<charParams l="842" t="1584" r="857" b="1617" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="1" charConfidence="46" serifProbability="100" wordPenalty="2" meanStrokeWidth="49">I</charParams>
+<charParams l="861" t="1583" r="869" b="1616" suspicious="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="1" charConfidence="39" serifProbability="50" wordPenalty="2" meanStrokeWidth="49">I</charParams>
+<charParams l="870" t="1583" r="892" b="1616"> </charParams>
+<charParams l="893" t="1596" r="913" b="1616" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="915" t="1585" r="923" b="1598" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">&#8217;</charParams>
+<charParams l="925" t="1596" r="945" b="1627" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="49" wordPenalty="0" meanStrokeWidth="43">y</charParams>
+<charParams l="946" t="1596" r="965" b="1627"> </charParams>
+<charParams l="966" t="1596" r="982" b="1617" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="33" wordPenalty="0" meanStrokeWidth="43">a</charParams>
+<charParams l="983" t="1595" r="1003" b="1617"> </charParams>
+<charParams l="1004" t="1595" r="1022" b="1617" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1025" t="1597" r="1043" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="91" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="1044" t="1597" r="1063" b="1626"> </charParams>
+<charParams l="1064" t="1597" r="1081" b="1626" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1084" t="1596" r="1103" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1108" t="1595" r="1125" b="1617" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="1660" l="375" t="1623" r="1125" b="1669"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="375" t="1637" r="395" b="1666" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="398" t="1636" r="415" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="420" t="1636" r="437" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="439" t="1623" r="446" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="450" t="1638" r="467" b="1666" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="471" t="1637" r="488" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="493" t="1637" r="510" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="511" t="1637" r="523" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="42" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="524" t="1637" r="546" b="1658"> </charParams>
+<charParams l="547" t="1638" r="576" b="1658" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="581" t="1638" r="596" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="599" t="1639" r="617" b="1659" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="620" t="1639" r="641" b="1659" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="642" t="1638" r="659" b="1659" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="662" t="1627" r="669" b="1659" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="673" t="1639" r="686" b="1660" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="687" t="1639" r="699" b="1661"> </charParams>
+<charParams l="700" t="1641" r="715" b="1661" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="718" t="1640" r="734" b="1660" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="737" t="1638" r="748" b="1661" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="751" t="1628" r="761" b="1661" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="764" t="1627" r="790" b="1661" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="764" t="1627" r="790" b="1661" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="792" t="1639" r="809" b="1662" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="811" t="1641" r="823" b="1662" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="42" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="824" t="1641" r="844" b="1662"> </charParams>
+<charParams l="845" t="1641" r="865" b="1661" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="868" t="1641" r="886" b="1661" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="91" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="887" t="1629" r="905" b="1661"> </charParams>
+<charParams l="906" t="1629" r="925" b="1661" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="920" t="1641" r="939" b="1661" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="941" t="1641" r="959" b="1661" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="964" t="1640" r="978" b="1660" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="980" t="1641" r="1000" b="1661" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1003" t="1641" r="1020" b="1662" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="74" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1021" t="1627" r="1029" b="1661" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1032" t="1628" r="1043" b="1661" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1046" t="1627" r="1070" b="1661" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1046" t="1627" r="1070" b="1661" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1073" t="1641" r="1090" b="1662" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1091" t="1641" r="1104" b="1661" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1115" t="1654" r="1125" b="1669" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams></formatting></line>
+<line baseline="1705" l="377" t="1668" r="1126" b="1710"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="377" t="1681" r="395" b="1710" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">q</charParams>
+<charParams l="398" t="1681" r="417" b="1702" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="98" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="421" t="1668" r="429" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="2" meanStrokeWidth="38">i</charParams>
+<charParams l="430" t="1668" r="451" b="1701"> </charParams>
+<charParams l="452" t="1680" r="469" b="1701" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="472" t="1682" r="491" b="1702" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="492" t="1682" r="519" b="1702"> </charParams>
+<charParams l="520" t="1682" r="539" b="1702" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="542" t="1682" r="560" b="1703" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="50" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="566" t="1680" r="579" b="1703" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="580" t="1670" r="593" b="1703"> </charParams>
+<charParams l="594" t="1670" r="604" b="1703" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="607" t="1683" r="627" b="1703" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="631" t="1681" r="643" b="1704" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="645" t="1683" r="659" b="1703" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="662" t="1684" r="681" b="1704" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="684" t="1671" r="701" b="1705" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="707" t="1685" r="724" b="1705" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="728" t="1672" r="738" b="1705" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="741" t="1683" r="754" b="1706" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="755" t="1683" r="772" b="1706"> </charParams>
+<charParams l="773" t="1685" r="790" b="1705" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="792" t="1684" r="809" b="1706" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="810" t="1684" r="830" b="1706"> </charParams>
+<charParams l="831" t="1685" r="852" b="1705" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="100" wordPenalty="1" meanStrokeWidth="41">n</charParams>
+<charParams l="855" t="1685" r="875" b="1706" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="255" wordPenalty="1" meanStrokeWidth="41">o</charParams>
+<charParams l="879" t="1685" r="909" b="1705" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="51" wordPenalty="1" meanStrokeWidth="41">m</charParams>
+<charParams l="912" t="1673" r="932" b="1706" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="50" wordPenalty="1" meanStrokeWidth="41">b</charParams>
+<charParams l="934" t="1685" r="950" b="1705" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="1" meanStrokeWidth="41">r</charParams>
+<charParams l="953" t="1685" r="970" b="1706" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="83" wordPenalty="1" meanStrokeWidth="41">e</charParams>
+<charParams l="971" t="1673" r="986" b="1706"> </charParams>
+<charParams l="987" t="1673" r="1007" b="1706" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1010" t="1685" r="1027" b="1707" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1028" t="1683" r="1042" b="1707"> </charParams>
+<charParams l="1043" t="1683" r="1056" b="1707" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1059" t="1685" r="1076" b="1707" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1079" t="1686" r="1110" b="1706" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1113" t="1686" r="1126" b="1707" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams></formatting></line>
+<line baseline="1746" l="379" t="1722" r="531" b="1747"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="379" t="1723" r="397" b="1745" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="401" t="1725" r="418" b="1745" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="419" t="1722" r="438" b="1745"> </charParams>
+<charParams l="439" t="1722" r="452" b="1745" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="454" t="1724" r="471" b="1745" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="474" t="1726" r="503" b="1746" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="507" t="1726" r="520" b="1747" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="42" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="523" t="1739" r="531" b="1746" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="1793" l="423" t="1755" r="1123" b="1804"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="423" t="1755" r="445" b="1790" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="73" wordPenalty="0" meanStrokeWidth="37">S</charParams>
+<charParams l="449" t="1758" r="456" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="457" t="1756" r="466" b="1790"> </charParams>
+<charParams l="467" t="1756" r="476" b="1790" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="480" t="1770" r="496" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="498" t="1771" r="510" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="42" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="511" t="1770" r="517" b="1791"> </charParams>
+<charParams l="518" t="1770" r="531" b="1790" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="535" t="1769" r="552" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="554" t="1770" r="573" b="1800" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">g</charParams>
+<charParams l="575" t="1758" r="583" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="588" t="1758" r="613" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="588" t="1758" r="613" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="614" t="1771" r="630" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="632" t="1770" r="650" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="652" t="1772" r="664" b="1792" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="665" t="1758" r="674" b="1792"> </charParams>
+<charParams l="675" t="1758" r="692" b="1792" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="48" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="689" t="1773" r="708" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="711" t="1774" r="730" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="734" t="1771" r="746" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="747" t="1771" r="755" b="1794"> </charParams>
+<charParams l="756" t="1773" r="772" b="1793" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="33" wordPenalty="0" meanStrokeWidth="41">a</charParams>
+<charParams l="775" t="1774" r="793" b="1794" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="91" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="794" t="1773" r="803" b="1794"> </charParams>
+<charParams l="804" t="1773" r="824" b="1793" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="827" t="1773" r="847" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="849" t="1773" r="881" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="51" wordPenalty="0" meanStrokeWidth="40">m</charParams>
+<charParams l="883" t="1760" r="903" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">b</charParams>
+<charParams l="906" t="1773" r="921" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="923" t="1773" r="941" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="942" t="1760" r="950" b="1793"> </charParams>
+<charParams l="951" t="1760" r="970" b="1793" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="974" t="1773" r="991" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="992" t="1773" r="1001" b="1804"> </charParams>
+<charParams l="1002" t="1775" r="1020" b="1804" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="1022" t="1774" r="1040" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1044" t="1773" r="1060" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1062" t="1771" r="1076" b="1794" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1076" t="1774" r="1092" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1093" t="1772" r="1111" b="1793" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1115" t="1787" r="1123" b="1803" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams></formatting></line>
+<line baseline="1837" l="378" t="1804" r="1126" b="1848"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="378" t="1804" r="398" b="1836" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="52">S</charParams>
+<charParams l="398" t="1814" r="409" b="1836" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="61" wordPenalty="0" meanStrokeWidth="52">t</charParams>
+<charParams l="410" t="1812" r="422" b="1836"> </charParams>
+<charParams l="423" t="1812" r="435" b="1835" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="437" t="1814" r="456" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="460" t="1815" r="478" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="482" t="1812" r="495" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="496" t="1812" r="510" b="1835"> </charParams>
+<charParams l="511" t="1815" r="527" b="1835" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="530" t="1815" r="548" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="86" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="553" t="1812" r="564" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="567" t="1816" r="586" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="589" t="1816" r="607" b="1836" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="612" t="1816" r="626" b="1836" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="627" t="1804" r="639" b="1836"> </charParams>
+<charParams l="640" t="1804" r="659" b="1836" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="664" t="1817" r="681" b="1836" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="682" t="1805" r="699" b="1838"> </charParams>
+<charParams l="700" t="1805" r="718" b="1838" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="71" wordPenalty="2" meanStrokeWidth="39">d</charParams>
+<charParams l="723" t="1807" r="743" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">&#244;</charParams>
+<charParams l="745" t="1818" r="775" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="3" wordPenalty="2" meanStrokeWidth="39">m</charParams>
+<charParams l="781" t="1817" r="798" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="83" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="799" t="1805" r="818" b="1838"> </charParams>
+<charParams l="819" t="1805" r="837" b="1838" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="842" t="1818" r="860" b="1837" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="861" t="1806" r="869" b="1848"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="870" t="1806" r="905" b="1848" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="897" t="1819" r="915" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="918" t="1819" r="938" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="940" t="1819" r="956" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="957" t="1818" r="978" b="1837" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="980" t="1818" r="995" b="1837" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="998" t="1818" r="1017" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="95" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1019" t="1818" r="1040" b="1838" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1041" t="1804" r="1059" b="1838"> </charParams>
+<charParams l="1060" t="1804" r="1079" b="1837" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1075" t="1816" r="1092" b="1837" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1093" t="1817" r="1110" b="1837" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">r</charParams>
+<charParams l="1110" t="1824" r="1126" b="1829" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">&#172;</charParams></formatting></line>
+<line baseline="1881" l="377" t="1845" r="1123" b="1890"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="377" t="1859" r="399" b="1881" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="3" meanStrokeWidth="39">v</charParams>
+<charParams l="402" t="1859" r="417" b="1879" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="53" wordPenalty="3" meanStrokeWidth="39">a</charParams>
+<charParams l="420" t="1859" r="439" b="1879" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="3" meanStrokeWidth="39">n</charParams>
+<charParams l="444" t="1857" r="456" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="3" meanStrokeWidth="39">t</charParams>
+<charParams l="457" t="1845" r="478" b="1880"> </charParams>
+<charParams l="479" t="1845" r="496" b="1879" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">&#224;</charParams>
+<charParams l="497" t="1845" r="520" b="1880"> </charParams>
+<charParams l="521" t="1846" r="530" b="1880" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">l</charParams>
+<charParams l="533" t="1859" r="551" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="33" wordPenalty="0" meanStrokeWidth="41">a</charParams>
+<charParams l="552" t="1847" r="568" b="1880"> </charParams>
+<charParams l="569" t="1847" r="587" b="1880" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="591" t="1847" r="600" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="605" t="1846" r="629" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="605" t="1846" r="629" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="632" t="1848" r="640" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="644" t="1847" r="651" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="655" t="1847" r="662" b="1881" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="665" t="1861" r="682" b="1881" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="685" t="1858" r="697" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="699" t="1849" r="708" b="1881" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="710" t="1862" r="730" b="1882" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="733" t="1862" r="754" b="1882" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="755" t="1849" r="780" b="1882"> </charParams>
+<charParams l="781" t="1849" r="801" b="1882" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="805" t="1862" r="823" b="1882" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="824" t="1862" r="848" b="1882"> </charParams>
+<charParams l="849" t="1862" r="869" b="1882" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="872" t="1850" r="881" b="1882" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="883" t="1862" r="903" b="1882" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="907" t="1861" r="923" b="1881" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="927" t="1849" r="933" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="937" t="1861" r="956" b="1889" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">g</charParams>
+<charParams l="958" t="1861" r="973" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="976" t="1860" r="993" b="1881" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1006" t="1875" r="1014" b="1890" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="73" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1015" t="1848" r="1031" b="1890"> </charParams>
+<charParams l="1032" t="1848" r="1050" b="1880" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1055" t="1860" r="1073" b="1881" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1074" t="1846" r="1093" b="1881"> </charParams>
+<charParams l="1094" t="1846" r="1104" b="1879" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">l</charParams>
+<charParams l="1108" t="1860" r="1123" b="1880" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">a</charParams></formatting></line>
+<line baseline="1924" l="379" t="1890" r="1123" b="1935"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="379" t="1903" r="410" b="1923" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="413" t="1904" r="430" b="1924" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="433" t="1903" r="451" b="1923" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="455" t="1903" r="474" b="1924" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="479" t="1903" r="496" b="1924" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="507" t="1916" r="515" b="1931" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="39" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="516" t="1891" r="534" b="1931"> </charParams>
+<charParams l="535" t="1891" r="554" b="1923" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="558" t="1903" r="578" b="1923" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="579" t="1903" r="600" b="1923"> </charParams>
+<charParams l="601" t="1904" r="632" b="1923" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="636" t="1892" r="644" b="1924" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="648" t="1904" r="665" b="1924" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="667" t="1890" r="675" b="1923" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="686" t="1917" r="695" b="1933" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="696" t="1892" r="711" b="1933"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="712" t="1892" r="742" b="1927" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">&amp;</charParams>
+<charParams l="745" t="1906" r="761" b="1925" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="52" wordPenalty="0" meanStrokeWidth="36">c</charParams>
+<charParams l="763" t="1918" r="770" b="1925" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">.</charParams>
+<charParams l="771" t="1892" r="779" b="1933"> </charParams>
+<charParams l="780" t="1892" r="813" b="1933" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="780" t="1892" r="813" b="1933" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="809" t="1904" r="833" b="1935" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="831" t="1917" r="838" b="1924" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="839" t="1903" r="857" b="1935"> </charParams>
+<charParams l="858" t="1903" r="877" b="1935" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="8" meanStrokeWidth="31">7</charParams>
+<charParams l="879" t="1903" r="895" b="1934" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="35" serifProbability="51" wordPenalty="8" meanStrokeWidth="31">4</charParams>
+<charParams l="895" t="1917" r="899" b="1922" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="33" serifProbability="255" wordPenalty="8" meanStrokeWidth="31">.</charParams>
+<charParams l="911" t="1917" r="919" b="1932" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="920" t="1904" r="932" b="1932"> </charParams>
+<charParams l="933" t="1904" r="949" b="1924" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="952" t="1892" r="959" b="1903" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="963" t="1904" r="980" b="1924" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="982" t="1891" r="1006" b="1924" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="982" t="1891" r="1006" b="1924" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1007" t="1891" r="1025" b="1932"> </charParams>
+<charParams l="1026" t="1905" r="1044" b="1932" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">q</charParams>
+<charParams l="1047" t="1904" r="1066" b="1923" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="91" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="1069" t="1890" r="1079" b="1904" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="1081" t="1903" r="1100" b="1923" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="1103" t="1903" r="1123" b="1922" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">n</charParams></formatting></line>
+<line baseline="1966" l="379" t="1932" r="1123" b="1975"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="379" t="1947" r="399" b="1967" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="403" t="1946" r="419" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="420" t="1946" r="442" b="1975"> </charParams>
+<charParams l="443" t="1947" r="461" b="1975" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="466" t="1946" r="482" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="486" t="1947" r="503" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="508" t="1944" r="521" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="522" t="1944" r="541" b="1975"> </charParams>
+<charParams l="542" t="1947" r="562" b="1975" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="565" t="1946" r="582" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="583" t="1946" r="595" b="1965" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="27" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="596" t="1933" r="613" b="1966"> </charParams>
+<charParams l="614" t="1933" r="623" b="1966" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="627" t="1947" r="645" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="647" t="1947" r="659" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="73" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="660" t="1947" r="676" b="1974"> </charParams>
+<charParams l="677" t="1947" r="696" b="1974" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="96" wordPenalty="2" meanStrokeWidth="38">p</charParams>
+<charParams l="700" t="1935" r="707" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="711" t="1948" r="726" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="729" t="1947" r="746" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="2" meanStrokeWidth="38">c</charParams>
+<charParams l="747" t="1947" r="765" b="1968" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="83" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="767" t="1948" r="781" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="782" t="1948" r="802" b="1967"> </charParams>
+<charParams l="803" t="1948" r="819" b="1967" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="822" t="1937" r="830" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="834" t="1935" r="841" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="845" t="1935" r="852" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="857" t="1947" r="874" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="877" t="1948" r="894" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="898" t="1947" r="913" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="915" t="1947" r="928" b="1967" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="940" t="1959" r="948" b="1974" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="949" t="1947" r="963" b="1975"> </charParams>
+<charParams l="964" t="1947" r="982" b="1975" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="986" t="1947" r="1004" b="1966" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1007" t="1934" r="1015" b="1945" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="1017" t="1947" r="1037" b="1966" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1040" t="1946" r="1060" b="1965" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1061" t="1932" r="1077" b="1965"> </charParams>
+<charParams l="1078" t="1932" r="1088" b="1965" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="26" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1091" t="1945" r="1108" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1110" t="1945" r="1123" b="1965" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="42" wordPenalty="0" meanStrokeWidth="36">s</charParams></formatting></line>
+<line baseline="2010" l="378" t="1975" r="1123" b="2018"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="378" t="1977" r="387" b="2010" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="391" t="1991" r="407" b="2010" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="410" t="1978" r="418" b="2009" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="423" t="1978" r="445" b="2010" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="423" t="1978" r="445" b="2010" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="447" t="1989" r="464" b="2010" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="465" t="1989" r="480" b="2010"> </charParams>
+<charParams l="481" t="1990" r="500" b="2010" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="504" t="1990" r="522" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="525" t="1989" r="545" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="548" t="1988" r="565" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="567" t="1989" r="582" b="2008" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="586" t="1985" r="598" b="2008" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="599" t="1989" r="611" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="612" t="1989" r="626" b="2009"> </charParams>
+<charParams l="627" t="1989" r="642" b="2008" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="645" t="1989" r="665" b="2008" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="668" t="1988" r="687" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="692" t="1987" r="704" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="707" t="1979" r="715" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="718" t="1990" r="738" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="742" t="1990" r="759" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="763" t="1990" r="780" b="2010" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="782" t="1977" r="791" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="794" t="1977" r="803" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="807" t="1989" r="824" b="2010" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="827" t="1989" r="857" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="3" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="861" t="1990" r="877" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="880" t="1990" r="900" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="903" t="1988" r="916" b="2011" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="926" t="2002" r="934" b="2017" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="935" t="1980" r="951" b="2017"> </charParams>
+<charParams l="952" t="1980" r="985" b="2010" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="70" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&amp;</charParams>
+<charParams l="986" t="1980" r="998" b="2018"> </charParams>
+<charParams l="999" t="1990" r="1016" b="2018" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1019" t="1989" r="1039" b="2009" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1042" t="1976" r="1049" b="1988" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1052" t="1977" r="1060" b="2008" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1065" t="1975" r="1073" b="2008" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1082" t="1988" r="1100" b="2008" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1105" t="1987" r="1123" b="2009" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="2052" l="378" t="2018" r="1124" b="2061"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="378" t="2020" r="397" b="2052" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">f</charParams>
+<charParams l="393" t="2033" r="409" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="412" t="2033" r="431" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="435" t="2030" r="447" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="448" t="2030" r="466" b="2060"> </charParams>
+<charParams l="467" t="2033" r="484" b="2060" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">q</charParams>
+<charParams l="487" t="2032" r="505" b="2052" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="510" t="2020" r="517" b="2031" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="521" t="2032" r="539" b="2051" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="543" t="2031" r="563" b="2051" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">n</charParams>
+<charParams l="566" t="2031" r="582" b="2051" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="583" t="2031" r="594" b="2051"> </charParams>
+<charParams l="595" t="2031" r="611" b="2050" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="26" wordPenalty="2" meanStrokeWidth="38">c</charParams>
+<charParams l="614" t="2019" r="633" b="2050" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="98" wordPenalty="2" meanStrokeWidth="38">h</charParams>
+<charParams l="635" t="2031" r="652" b="2050" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="655" t="2018" r="662" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="666" t="2031" r="683" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="83" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="685" t="2032" r="703" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="707" t="2031" r="722" b="2050" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="723" t="2020" r="738" b="2052"> </charParams>
+<charParams l="739" t="2020" r="758" b="2052" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="762" t="2033" r="781" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="785" t="2033" r="803" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="807" t="2032" r="823" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="825" t="2032" r="842" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="843" t="2032" r="856" b="2061"> </charParams>
+<charParams l="857" t="2033" r="878" b="2061" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="881" t="2032" r="900" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="904" t="2033" r="920" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="924" t="2032" r="940" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="941" t="2032" r="959" b="2052"> </charParams>
+<charParams l="960" t="2032" r="976" b="2052" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="980" t="2031" r="996" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="998" t="2032" r="1011" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1012" t="2019" r="1023" b="2053"> </charParams>
+<charParams l="1024" t="2019" r="1042" b="2053" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="10" meanStrokeWidth="39">f</charParams>
+<charParams l="1038" t="2032" r="1058" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="10" meanStrokeWidth="39">o</charParams>
+<charParams l="1061" t="2033" r="1075" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="10" meanStrokeWidth="39">r</charParams>
+<charParams l="1078" t="2030" r="1090" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="10" meanStrokeWidth="39">t</charParams>
+<charParams l="1092" t="2031" r="1110" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="10" meanStrokeWidth="39">e</charParams>
+<charParams l="1112" t="2032" r="1124" b="2053" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="42" wordPenalty="10" meanStrokeWidth="39">s</charParams></formatting></line>
+<line baseline="2094" l="379" t="2061" r="599" b="2102"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="379" t="2063" r="399" b="2095" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="402" t="2064" r="409" b="2076" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="412" t="2075" r="430" b="2095" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="434" t="2075" r="451" b="2102" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="455" t="2061" r="471" b="2095" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="471" t="2075" r="487" b="2094" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="489" t="2074" r="506" b="2094" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="60" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="508" t="2072" r="519" b="2093" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="521" t="2061" r="531" b="2093" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="534" t="2074" r="553" b="2093" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="556" t="2073" r="574" b="2093" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="578" t="2074" r="590" b="2094" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="592" t="2088" r="599" b="2095" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="2139" l="425" t="2104" r="1126" b="2149"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="425" t="2106" r="456" b="2149" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="78" wordPenalty="2" meanStrokeWidth="40">Q</charParams>
+<charParams l="459" t="2118" r="477" b="2137" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="481" t="2117" r="501" b="2137" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="504" t="2104" r="513" b="2136" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="517" t="2117" r="533" b="2145" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">q</charParams>
+<charParams l="537" t="2117" r="557" b="2137" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="97" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="559" t="2104" r="566" b="2117" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="570" t="2105" r="579" b="2137" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="0" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="582" t="2104" r="591" b="2138" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="26" wordPenalty="2" meanStrokeWidth="40">l</charParams>
+<charParams l="592" t="2104" r="613" b="2138"> </charParams>
+<charParams l="614" t="2104" r="646" b="2137" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="614" t="2104" r="646" b="2137" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="651" t="2104" r="660" b="2137" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="665" t="2114" r="677" b="2137" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="678" t="2114" r="695" b="2138"> </charParams>
+<charParams l="696" t="2118" r="717" b="2138" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">v</charParams>
+<charParams l="719" t="2118" r="735" b="2139" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="736" t="2119" r="753" b="2139" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="33" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="756" t="2106" r="765" b="2139" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="766" t="2106" r="786" b="2148"> </charParams>
+<charParams l="787" t="2120" r="804" b="2148" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">q</charParams>
+<charParams l="807" t="2119" r="826" b="2139" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="829" t="2106" r="837" b="2119" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="840" t="2119" r="859" b="2140" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">o</charParams>
+<charParams l="862" t="2118" r="882" b="2139" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="883" t="2118" r="905" b="2139"> </charParams>
+<charParams l="906" t="2118" r="923" b="2139" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="33" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="925" t="2120" r="943" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="97" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="948" t="2119" r="965" b="2149" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="969" t="2119" r="998" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1003" t="2118" r="1022" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1023" t="2119" r="1043" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1046" t="2116" r="1058" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1061" t="2119" r="1078" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1079" t="2106" r="1095" b="2141"> </charParams>
+<charParams l="1096" t="2106" r="1105" b="2140" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1108" t="2119" r="1126" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="2183" l="378" t="2148" r="1127" b="2194"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="378" t="2149" r="397" b="2182" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="392" t="2160" r="409" b="2181" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="413" t="2161" r="431" b="2181" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="432" t="2161" r="447" b="2182"> </charParams>
+<charParams l="448" t="2161" r="465" b="2182" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="468" t="2161" r="487" b="2181" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="488" t="2161" r="505" b="2182"> </charParams>
+<charParams l="506" t="2161" r="525" b="2182" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="528" t="2161" r="547" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="97" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="549" t="2162" r="569" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">v</charParams>
+<charParams l="572" t="2161" r="587" b="2181" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="589" t="2162" r="603" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="607" t="2161" r="626" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="630" t="2158" r="643" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="644" t="2148" r="653" b="2182"> </charParams>
+<charParams l="654" t="2148" r="662" b="2181" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="667" t="2161" r="683" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="686" t="2161" r="699" b="2182" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="700" t="2161" r="708" b="2183"> </charParams>
+<charParams l="709" t="2163" r="723" b="2183" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="727" t="2163" r="743" b="2184" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="745" t="2163" r="764" b="2193" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="767" t="2151" r="776" b="2184" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="779" t="2150" r="804" b="2183" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="779" t="2150" r="804" b="2183" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="807" t="2164" r="820" b="2183" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="823" t="2163" r="840" b="2184" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="841" t="2163" r="854" b="2184" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="10" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="865" t="2176" r="874" b="2192" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="875" t="2162" r="889" b="2192"> </charParams>
+<charParams l="890" t="2162" r="906" b="2183" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="909" t="2163" r="926" b="2184" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="928" t="2150" r="936" b="2184" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="940" t="2163" r="955" b="2183" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="956" t="2163" r="967" b="2184"> </charParams>
+<charParams l="968" t="2164" r="988" b="2184" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="992" t="2151" r="1000" b="2164" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1003" t="2165" r="1019" b="2185" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1020" t="2165" r="1028" b="2194"> </charParams>
+<charParams l="1029" t="2165" r="1048" b="2194" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1052" t="2165" r="1070" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1074" t="2165" r="1092" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1096" t="2165" r="1111" b="2185" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1111" t="2173" r="1127" b="2178" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#172;</charParams></formatting></line>
+<line baseline="2228" l="380" t="2192" r="1127" b="2238"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="380" t="2202" r="393" b="2226" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="395" t="2205" r="411" b="2225" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="414" t="2205" r="433" b="2225" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="436" t="2203" r="449" b="2226" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="450" t="2193" r="461" b="2226"> </charParams>
+<charParams l="462" t="2193" r="469" b="2226" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="51" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="474" t="2193" r="483" b="2226" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="487" t="2205" r="503" b="2226" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="506" t="2206" r="525" b="2226" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="526" t="2206" r="541" b="2236"> </charParams>
+<charParams l="542" t="2206" r="559" b="2236" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="562" t="2206" r="582" b="2227" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="98" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="585" t="2193" r="592" b="2207" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="595" t="2193" r="611" b="2227" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">&#224;</charParams>
+<charParams l="612" t="2192" r="630" b="2227"> </charParams>
+<charParams l="631" t="2192" r="639" b="2226" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="642" t="2195" r="649" b="2208" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="652" t="2193" r="669" b="2227" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">&#233;</charParams>
+<charParams l="669" t="2207" r="689" b="2236" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">g</charParams>
+<charParams l="691" t="2206" r="707" b="2227" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="710" t="2207" r="724" b="2228" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="727" t="2196" r="747" b="2229" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="748" t="2196" r="764" b="2229"> </charParams>
+<charParams l="765" t="2196" r="785" b="2229" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="788" t="2208" r="805" b="2229" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="806" t="2207" r="820" b="2229"> </charParams>
+<charParams l="821" t="2207" r="837" b="2229" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="839" t="2208" r="856" b="2230" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="861" t="2209" r="880" b="2229" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="884" t="2208" r="902" b="2229" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">x</charParams>
+<charParams l="903" t="2208" r="919" b="2238"> </charParams>
+<charParams l="920" t="2209" r="938" b="2238" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">q</charParams>
+<charParams l="940" t="2209" r="959" b="2229" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">u</charParams>
+<charParams l="963" t="2196" r="973" b="2228" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="0" wordPenalty="2" meanStrokeWidth="39">i</charParams>
+<charParams l="974" t="2196" r="993" b="2229"> </charParams>
+<charParams l="994" t="2209" r="1013" b="2229" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1017" t="2209" r="1034" b="2230" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1035" t="2196" r="1054" b="2230"> </charParams>
+<charParams l="1055" t="2196" r="1072" b="2230" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="6" meanStrokeWidth="41">f</charParams>
+<charParams l="1069" t="2210" r="1088" b="2230" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="6" meanStrokeWidth="41">o</charParams>
+<charParams l="1091" t="2209" r="1110" b="2230" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="41">n</charParams>
+<charParams l="1115" t="2207" r="1127" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="6" meanStrokeWidth="41">t</charParams></formatting></line>
+<line baseline="2273" l="379" t="2238" r="1126" b="2283"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="379" t="2250" r="400" b="2279" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="403" t="2249" r="419" b="2270" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="421" t="2249" r="433" b="2270" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="42" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="434" t="2248" r="449" b="2271"> </charParams>
+<charParams l="450" t="2248" r="463" b="2271" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="465" t="2250" r="480" b="2270" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="483" t="2251" r="502" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="506" t="2250" r="524" b="2279" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="525" t="2250" r="536" b="2281"> </charParams>
+<charParams l="537" t="2251" r="555" b="2281" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">g</charParams>
+<charParams l="557" t="2251" r="572" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="574" t="2252" r="588" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="592" t="2251" r="613" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="615" t="2238" r="632" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="71" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="637" t="2251" r="648" b="2271" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="42" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="649" t="2250" r="658" b="2282"> </charParams>
+<charParams l="659" t="2250" r="668" b="2282" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="22" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">;</charParams>
+<charParams l="669" t="2250" r="680" b="2282"> </charParams>
+<charParams l="681" t="2251" r="698" b="2271" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="49" wordPenalty="0" meanStrokeWidth="42">c</charParams>
+<charParams l="699" t="2253" r="716" b="2273" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="33" wordPenalty="0" meanStrokeWidth="42">a</charParams>
+<charParams l="719" t="2253" r="733" b="2273" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">r</charParams>
+<charParams l="734" t="2253" r="749" b="2282"> </charParams>
+<charParams l="750" t="2254" r="769" b="2282" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="772" t="2239" r="780" b="2273" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="784" t="2254" r="802" b="2274" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="805" t="2253" r="816" b="2274" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="10" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="817" t="2253" r="827" b="2274"> </charParams>
+<charParams l="828" t="2253" r="848" b="2274" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">o</charParams>
+<charParams l="851" t="2253" r="870" b="2273" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="75" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="871" t="2252" r="890" b="2273"> </charParams>
+<charParams l="891" t="2252" r="908" b="2273" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="911" t="2253" r="930" b="2273" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="931" t="2253" r="944" b="2273"> </charParams>
+<charParams l="945" t="2253" r="964" b="2273" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="967" t="2253" r="985" b="2273" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="988" t="2253" r="1009" b="2274" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="1012" t="2254" r="1025" b="2274" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1028" t="2241" r="1037" b="2274" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1041" t="2253" r="1055" b="2273" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1058" t="2255" r="1078" b="2275" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1081" t="2242" r="1090" b="2274" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1094" t="2253" r="1106" b="2275" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1117" t="2268" r="1126" b="2283" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams></formatting></line>
+<line baseline="2317" l="383" t="2282" r="1127" b="2329"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="383" t="2285" r="416" b="2316" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="81" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">&amp;</charParams>
+<charParams l="417" t="2285" r="441" b="2325"> </charParams>
+<charParams l="442" t="2295" r="461" b="2325" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="96" wordPenalty="0" meanStrokeWidth="33">p</charParams>
+<charParams l="465" t="2282" r="473" b="2315" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="51" wordPenalty="0" meanStrokeWidth="33">l</charParams>
+<charParams l="478" t="2296" r="494" b="2315" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="91" wordPenalty="0" meanStrokeWidth="33">u</charParams>
+<charParams l="498" t="2295" r="510" b="2315" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="10" wordPenalty="0" meanStrokeWidth="33">s</charParams>
+<charParams l="511" t="2295" r="530" b="2316"> </charParams>
+<charParams l="531" t="2296" r="550" b="2316" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="44">o</charParams>
+<charParams l="553" t="2295" r="573" b="2315" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="100" wordPenalty="0" meanStrokeWidth="44">n</charParams>
+<charParams l="574" t="2283" r="595" b="2315"> </charParams>
+<charParams l="596" t="2283" r="615" b="2315" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="620" t="2294" r="636" b="2315" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="639" t="2296" r="657" b="2317" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="660" t="2295" r="675" b="2315" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="677" t="2296" r="697" b="2317" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="700" t="2285" r="710" b="2317" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="714" t="2295" r="726" b="2318" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="727" t="2295" r="747" b="2318"> </charParams>
+<charParams l="748" t="2297" r="765" b="2318" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="92" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="767" t="2298" r="785" b="2318" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="789" t="2298" r="807" b="2327" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">g</charParams>
+<charParams l="811" t="2298" r="840" b="2317" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="844" t="2297" r="861" b="2318" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="865" t="2297" r="884" b="2318" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="888" t="2295" r="900" b="2317" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="902" t="2297" r="919" b="2318" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="921" t="2297" r="937" b="2317" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="938" t="2283" r="957" b="2318"> </charParams>
+<charParams l="958" t="2283" r="965" b="2318" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="969" t="2297" r="986" b="2318" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="987" t="2285" r="1001" b="2318"> </charParams>
+<charParams l="1002" t="2285" r="1020" b="2318" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="1016" t="2297" r="1033" b="2319" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1036" t="2299" r="1055" b="2319" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="97" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1067" t="2313" r="1075" b="2329" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="81" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1076" t="2299" r="1088" b="2329"> </charParams>
+<charParams l="1089" t="2299" r="1105" b="2319" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1108" t="2300" r="1127" b="2320" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams></formatting></line>
+<line baseline="2362" l="380" t="2325" r="1129" b="2370"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="380" t="2325" r="392" b="2360" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="394" t="2327" r="404" b="2359" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="407" t="2339" r="424" b="2360" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="426" t="2340" r="446" b="2361" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="447" t="2340" r="463" b="2370"> </charParams>
+<charParams l="464" t="2341" r="481" b="2370" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="485" t="2340" r="502" b="2360" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="507" t="2327" r="514" b="2340" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="518" t="2341" r="537" b="2361" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="539" t="2340" r="558" b="2360" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="559" t="2326" r="578" b="2360"> </charParams>
+<charParams l="579" t="2326" r="588" b="2360" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="592" t="2340" r="609" b="2361" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="610" t="2327" r="623" b="2361"> </charParams>
+<charParams l="624" t="2327" r="642" b="2360" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="646" t="2328" r="657" b="2360" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="659" t="2340" r="690" b="2360" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="695" t="2329" r="703" b="2361" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="706" t="2342" r="725" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="729" t="2342" r="746" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="751" t="2341" r="769" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="770" t="2341" r="788" b="2362"> </charParams>
+<charParams l="789" t="2342" r="803" b="2362" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">r</charParams>
+<charParams l="804" t="2329" r="820" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="824" t="2342" r="840" b="2363" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="843" t="2329" r="850" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="854" t="2329" r="863" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="26" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="867" t="2343" r="883" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="886" t="2342" r="917" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="3" wordPenalty="2" meanStrokeWidth="37">m</charParams>
+<charParams l="921" t="2341" r="938" b="2363" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="940" t="2342" r="959" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">n</charParams>
+<charParams l="964" t="2339" r="977" b="2362" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="2" meanStrokeWidth="37">t</charParams>
+<charParams l="978" t="2327" r="987" b="2363"> </charParams>
+<charParams l="988" t="2327" r="1012" b="2363" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="988" t="2327" r="1012" b="2363" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1013" t="2327" r="1025" b="2363"> </charParams>
+<charParams l="1026" t="2343" r="1045" b="2363" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">o</charParams>
+<charParams l="1048" t="2343" r="1069" b="2363" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="1070" t="2343" r="1088" b="2365"> </charParams>
+<charParams l="1089" t="2343" r="1106" b="2365" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1108" t="2344" r="1129" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams></formatting></line>
+<line baseline="2407" l="381" t="2371" r="1127" b="2417"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="381" t="2385" r="401" b="2405" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="404" t="2385" r="424" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="425" t="2385" r="446" b="2406" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="448" t="2385" r="462" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="465" t="2384" r="483" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="484" t="2382" r="495" b="2405"> </charParams>
+<charParams l="496" t="2382" r="509" b="2405" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="512" t="2385" r="526" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">r</charParams>
+<charParams l="529" t="2385" r="549" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="551" t="2385" r="571" b="2414" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="96" wordPenalty="0" meanStrokeWidth="41">p</charParams>
+<charParams l="572" t="2385" r="593" b="2414"> </charParams>
+<charParams l="594" t="2385" r="614" b="2405" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="616" t="2384" r="637" b="2405" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="97" wordPenalty="0" meanStrokeWidth="42">u</charParams>
+<charParams l="638" t="2384" r="650" b="2405"> </charParams>
+<charParams l="651" t="2384" r="664" b="2405" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="42" wordPenalty="2" meanStrokeWidth="37">s</charParams>
+<charParams l="665" t="2372" r="673" b="2384" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="676" t="2372" r="686" b="2404" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="2" meanStrokeWidth="37">i</charParams>
+<charParams l="689" t="2371" r="696" b="2404" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="51" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="700" t="2386" r="713" b="2407" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="32" wordPenalty="2" meanStrokeWidth="37">s</charParams>
+<charParams l="714" t="2372" r="726" b="2407"> </charParams>
+<charParams l="727" t="2372" r="744" b="2406" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="6" meanStrokeWidth="41">f</charParams>
+<charParams l="740" t="2386" r="759" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="6" meanStrokeWidth="41">o</charParams>
+<charParams l="763" t="2387" r="782" b="2406" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="41">n</charParams>
+<charParams l="787" t="2384" r="799" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="6" meanStrokeWidth="41">t</charParams>
+<charParams l="800" t="2384" r="812" b="2407"> </charParams>
+<charParams l="813" t="2384" r="826" b="2407" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="828" t="2387" r="844" b="2406" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="846" t="2387" r="866" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="869" t="2387" r="888" b="2416" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="889" t="2387" r="906" b="2417"> </charParams>
+<charParams l="907" t="2387" r="926" b="2417" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">g</charParams>
+<charParams l="929" t="2387" r="943" b="2406" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="946" t="2386" r="963" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="964" t="2386" r="983" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="987" t="2374" r="1007" b="2407" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1010" t="2388" r="1022" b="2408" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1023" t="2388" r="1031" b="2408"> </charParams>
+<charParams l="1032" t="2388" r="1038" b="2408" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="73" serifProbability="255" wordPenalty="0" meanStrokeWidth="20">:</charParams>
+<charParams l="1039" t="2388" r="1050" b="2409"> </charParams>
+<charParams l="1051" t="2389" r="1067" b="2409" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="74" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1070" t="2375" r="1079" b="2408" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1082" t="2389" r="1101" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1105" t="2374" r="1127" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1105" t="2374" r="1127" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">i</charParams></formatting></line>
+<line baseline="2451" l="381" t="2415" r="1129" b="2462"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="381" t="2415" r="391" b="2450" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="0" wordPenalty="0" meanStrokeWidth="47">i</charParams>
+<charParams l="395" t="2415" r="402" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="51" wordPenalty="0" meanStrokeWidth="47">l</charParams>
+<charParams l="403" t="2415" r="420" b="2449"> </charParams>
+<charParams l="421" t="2430" r="439" b="2449" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="9" meanStrokeWidth="39">n</charParams>
+<charParams l="442" t="2418" r="449" b="2431" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="9" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="454" t="2429" r="471" b="2450" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="4" meanStrokeWidth="39">e</charParams>
+<charParams l="473" t="2416" r="498" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="4" meanStrokeWidth="39">s</charParams>
+<charParams l="473" t="2416" r="498" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="4" meanStrokeWidth="39">t</charParams>
+<charParams l="499" t="2416" r="515" b="2460"> </charParams>
+<charParams l="516" t="2431" r="532" b="2460" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">q</charParams>
+<charParams l="537" t="2430" r="554" b="2450" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="91" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="558" t="2429" r="575" b="2450" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="2" meanStrokeWidth="40">e</charParams>
+<charParams l="580" t="2416" r="602" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">s</charParams>
+<charParams l="580" t="2416" r="602" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">t</charParams>
+<charParams l="604" t="2417" r="613" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="617" t="2429" r="636" b="2450" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="640" t="2429" r="660" b="2449" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">n</charParams>
+<charParams l="661" t="2416" r="676" b="2450"> </charParams>
+<charParams l="677" t="2416" r="696" b="2450" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="700" t="2431" r="717" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="62" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="719" t="2431" r="738" b="2451" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="741" t="2431" r="754" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="755" t="2431" r="765" b="2452"> </charParams>
+<charParams l="766" t="2431" r="782" b="2451" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="784" t="2431" r="802" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="805" t="2428" r="818" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="819" t="2428" r="830" b="2452"> </charParams>
+<charParams l="831" t="2431" r="847" b="2452" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="62" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="850" t="2432" r="867" b="2451" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">x</charParams>
+<charParams l="868" t="2419" r="879" b="2451" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="881" t="2432" r="901" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="905" t="2432" r="936" b="2451" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="51" wordPenalty="0" meanStrokeWidth="40">m</charParams>
+<charParams l="939" t="2430" r="956" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="957" t="2430" r="968" b="2460"> </charParams>
+<charParams l="969" t="2444" r="978" b="2460" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="53" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="979" t="2433" r="993" b="2462"> </charParams>
+<charParams l="994" t="2433" r="1013" b="2462" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">q</charParams>
+<charParams l="1015" t="2432" r="1033" b="2452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="100" wordPenalty="2" meanStrokeWidth="36">u</charParams>
+<charParams l="1038" t="2432" r="1055" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="83" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="1056" t="2420" r="1073" b="2454"> </charParams>
+<charParams l="1074" t="2420" r="1092" b="2453" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="71" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1097" t="2432" r="1114" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1117" t="2433" r="1129" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="10" wordPenalty="0" meanStrokeWidth="36">s</charParams></formatting></line>
+<line baseline="2496" l="382" t="2459" r="1130" b="2506"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="382" t="2474" r="397" b="2495" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="400" t="2474" r="417" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="420" t="2474" r="438" b="2504" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="442" t="2462" r="450" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="453" t="2461" r="478" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="453" t="2461" r="478" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="480" t="2474" r="495" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="498" t="2474" r="515" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="517" t="2474" r="530" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="531" t="2474" r="551" b="2505"> </charParams>
+<charParams l="552" t="2475" r="571" b="2505" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="572" t="2474" r="591" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="97" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="595" t="2462" r="603" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="604" t="2459" r="626" b="2495"> </charParams>
+<charParams l="627" t="2459" r="644" b="2494" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="6" meanStrokeWidth="40">f</charParams>
+<charParams l="642" t="2474" r="661" b="2495" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="6" meanStrokeWidth="40">o</charParams>
+<charParams l="664" t="2474" r="683" b="2494" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="40">n</charParams>
+<charParams l="686" t="2472" r="701" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="6" meanStrokeWidth="40">t</charParams>
+<charParams l="702" t="2472" r="721" b="2497"> </charParams>
+<charParams l="722" t="2475" r="739" b="2497" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="741" t="2476" r="762" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="763" t="2476" r="783" b="2506"> </charParams>
+<charParams l="784" t="2477" r="804" b="2506" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="96" wordPenalty="2" meanStrokeWidth="40">p</charParams>
+<charParams l="806" t="2476" r="821" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">r</charParams>
+<charParams l="824" t="2476" r="844" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="846" t="2476" r="865" b="2506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="96" wordPenalty="2" meanStrokeWidth="40">p</charParams>
+<charParams l="868" t="2476" r="887" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="889" t="2476" r="904" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">r</charParams>
+<charParams l="907" t="2473" r="920" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="61" wordPenalty="2" meanStrokeWidth="40">t</charParams>
+<charParams l="921" t="2463" r="932" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="0" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="934" t="2477" r="953" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="957" t="2476" r="977" b="2496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="75" wordPenalty="2" meanStrokeWidth="40">n</charParams>
+<charParams l="978" t="2476" r="1000" b="2497"> </charParams>
+<charParams l="1001" t="2477" r="1019" b="2497" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="62" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1019" t="2477" r="1040" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="1043" t="2476" r="1059" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1063" t="2477" r="1079" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1080" t="2465" r="1099" b="2499"> </charParams>
+<charParams l="1100" t="2465" r="1108" b="2499" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1112" t="2477" r="1130" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams></formatting></line>
+<line baseline="2541" l="383" t="2505" r="475" b="2541"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="383" t="2518" r="399" b="2540" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="401" t="2519" r="417" b="2541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="420" t="2505" r="445" b="2540" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="420" t="2505" r="445" b="2540" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="448" t="2518" r="465" b="2541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="468" t="2533" r="475" b="2540" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="2586" l="428" t="2549" r="1131" b="2594"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="428" t="2551" r="455" b="2585" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="54">L</charParams>
+<charParams l="459" t="2564" r="476" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="82" wordPenalty="0" meanStrokeWidth="54">e</charParams>
+<charParams l="478" t="2564" r="490" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="41" wordPenalty="0" meanStrokeWidth="54">s</charParams>
+<charParams l="491" t="2564" r="498" b="2585"> </charParams>
+<charParams l="499" t="2565" r="514" b="2585" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="516" t="2563" r="534" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="536" t="2564" r="555" b="2594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">g</charParams>
+<charParams l="557" t="2551" r="565" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="569" t="2549" r="594" b="2584" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="569" t="2549" r="594" b="2584" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="595" t="2563" r="610" b="2584" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="612" t="2563" r="629" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="631" t="2564" r="642" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="643" t="2551" r="651" b="2585"> </charParams>
+<charParams l="652" t="2551" r="671" b="2585" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="675" t="2565" r="693" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="696" t="2551" r="705" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="707" t="2565" r="727" b="2586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="729" t="2564" r="746" b="2586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="749" t="2565" r="768" b="2586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="771" t="2561" r="784" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="785" t="2552" r="795" b="2586"> </charParams>
+<charParams l="796" t="2552" r="813" b="2586" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="58" wordPenalty="0" meanStrokeWidth="39">&#234;</charParams>
+<charParams l="816" t="2562" r="829" b="2586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="831" t="2564" r="845" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="847" t="2565" r="864" b="2587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="865" t="2565" r="872" b="2587"> </charParams>
+<charParams l="873" t="2566" r="888" b="2587" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="62" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="890" t="2565" r="911" b="2586" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="912" t="2565" r="923" b="2594"> </charParams>
+<charParams l="924" t="2565" r="943" b="2594" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="945" t="2551" r="954" b="2585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="958" t="2566" r="977" b="2586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="97" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="979" t="2565" r="991" b="2587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="992" t="2565" r="1001" b="2587"> </charParams>
+<charParams l="1002" t="2566" r="1020" b="2587" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="97" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="1024" t="2566" r="1044" b="2587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1045" t="2564" r="1054" b="2587"> </charParams>
+<charParams l="1055" t="2564" r="1067" b="2587" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1069" t="2554" r="1079" b="2587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1083" t="2566" r="1100" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1101" t="2567" r="1117" b="2587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1118" t="2567" r="1131" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="41" wordPenalty="0" meanStrokeWidth="40">s</charParams></formatting></line>
+<line baseline="2630" l="385" t="2596" r="1133" b="2639"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="385" t="2608" r="405" b="2629" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="48">o</charParams>
+<charParams l="408" t="2609" r="428" b="2629" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="91" wordPenalty="0" meanStrokeWidth="48">u</charParams>
+<charParams l="429" t="2609" r="437" b="2629"> </charParams>
+<charParams l="438" t="2609" r="455" b="2629" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="459" t="2609" r="480" b="2629" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="481" t="2609" r="489" b="2639"> </charParams>
+<charParams l="490" t="2610" r="509" b="2639" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="513" t="2611" r="529" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="533" t="2609" r="549" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="33" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="552" t="2609" r="567" b="2629" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="570" t="2608" r="582" b="2629" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="583" t="2596" r="592" b="2630"> </charParams>
+<charParams l="593" t="2596" r="612" b="2630" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="616" t="2609" r="636" b="2629" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="637" t="2597" r="650" b="2630"> </charParams>
+<charParams l="651" t="2597" r="670" b="2630" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="71" wordPenalty="19" meanStrokeWidth="39">d</charParams>
+<charParams l="673" t="2597" r="682" b="2629" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="19" meanStrokeWidth="39">i</charParams>
+<charParams l="685" t="2610" r="702" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="53" wordPenalty="19" meanStrokeWidth="39">a</charParams>
+<charParams l="705" t="2610" r="734" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="51" wordPenalty="19" meanStrokeWidth="39">m</charParams>
+<charParams l="739" t="2610" r="754" b="2632" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="83" wordPenalty="19" meanStrokeWidth="39">&#232;</charParams>
+<charParams l="757" t="2607" r="769" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="19" meanStrokeWidth="39">t</charParams>
+<charParams l="772" t="2610" r="787" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="100" wordPenalty="19" meanStrokeWidth="39">r</charParams>
+<charParams l="789" t="2609" r="806" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="39">e</charParams>
+<charParams l="807" t="2598" r="815" b="2631"> </charParams>
+<charParams l="816" t="2598" r="834" b="2631" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="839" t="2611" r="857" b="2632" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="858" t="2611" r="869" b="2632"> </charParams>
+<charParams l="870" t="2611" r="886" b="2631" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="889" t="2610" r="905" b="2632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="907" t="2611" r="927" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="930" t="2598" r="948" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="952" t="2611" r="966" b="2630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="970" t="2598" r="979" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="983" t="2610" r="999" b="2631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1002" t="2611" r="1017" b="2631" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1027" t="2625" r="1034" b="2639" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="91" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1035" t="2599" r="1049" b="2639"> </charParams>
+<charParams l="1050" t="2599" r="1069" b="2632" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="71" wordPenalty="0" meanStrokeWidth="41">d</charParams>
+<charParams l="1073" t="2612" r="1092" b="2632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1096" t="2612" r="1115" b="2632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1119" t="2609" r="1133" b="2632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams></formatting></line>
+<line baseline="2676" l="385" t="2640" r="1132" b="2686"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="385" t="2640" r="394" b="2682" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="39" wordPenalty="0" meanStrokeWidth="46">j</charParams>
+<charParams l="399" t="2652" r="417" b="2673" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="46">e</charParams>
+<charParams l="418" t="2652" r="432" b="2673"> </charParams>
+<charParams l="433" t="2653" r="449" b="2673" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="451" t="2653" r="466" b="2673" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="469" t="2653" r="488" b="2674" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="492" t="2641" r="500" b="2674" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="503" t="2654" r="516" b="2675" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="10" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="517" t="2654" r="531" b="2685"> </charParams>
+<charParams l="532" t="2656" r="549" b="2685" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">q</charParams>
+<charParams l="553" t="2655" r="571" b="2675" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="91" wordPenalty="2" meanStrokeWidth="40">u</charParams>
+<charParams l="575" t="2641" r="582" b="2655" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="585" t="2655" r="604" b="2675" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">o</charParams>
+<charParams l="607" t="2654" r="626" b="2675" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="2" meanStrokeWidth="40">n</charParams>
+<charParams l="627" t="2654" r="649" b="2684"> </charParams>
+<charParams l="650" t="2655" r="669" b="2684" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="672" t="2653" r="688" b="2675" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="692" t="2655" r="710" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="97" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="714" t="2652" r="727" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="728" t="2652" r="749" b="2676"> </charParams>
+<charParams l="750" t="2656" r="765" b="2676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="767" t="2642" r="783" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="786" t="2655" r="804" b="2686" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="807" t="2642" r="815" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="818" t="2655" r="835" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="837" t="2656" r="852" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="853" t="2643" r="874" b="2676"> </charParams>
+<charParams l="875" t="2643" r="884" b="2676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="886" t="2655" r="903" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="60" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="904" t="2655" r="921" b="2685"> </charParams>
+<charParams l="922" t="2656" r="941" b="2685" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="944" t="2656" r="963" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="966" t="2655" r="980" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="983" t="2653" r="996" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="999" t="2655" r="1017" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1018" t="2643" r="1034" b="2677"> </charParams>
+<charParams l="1035" t="2643" r="1053" b="2677" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="48" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="1050" t="2657" r="1067" b="2677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1073" t="2656" r="1086" b="2676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1087" t="2643" r="1103" b="2677"> </charParams>
+<charParams l="1104" t="2643" r="1112" b="2677" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1115" t="2656" r="1132" b="2678" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="32">e</charParams></formatting></line>
+<line baseline="2723" l="386" t="2685" r="1130" b="2733"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="386" t="2685" r="408" b="2719" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="20" meanStrokeWidth="39">d</charParams>
+<charParams l="409" t="2685" r="419" b="2719" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="20" meanStrokeWidth="39">i</charParams>
+<charParams l="421" t="2697" r="439" b="2721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="92" wordPenalty="20" meanStrokeWidth="39">a</charParams>
+<charParams l="439" t="2697" r="472" b="2721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="20" meanStrokeWidth="39">m</charParams>
+<charParams l="475" t="2698" r="492" b="2721" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="83" wordPenalty="20" meanStrokeWidth="39">&#232;</charParams>
+<charParams l="495" t="2697" r="507" b="2720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="20" meanStrokeWidth="39">t</charParams>
+<charParams l="508" t="2699" r="522" b="2722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="20" meanStrokeWidth="39">r</charParams>
+<charParams l="526" t="2698" r="544" b="2723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="49" wordPenalty="20" meanStrokeWidth="39">e</charParams>
+<charParams l="545" t="2686" r="559" b="2723"> </charParams>
+<charParams l="560" t="2686" r="580" b="2721" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="583" t="2700" r="601" b="2721" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="602" t="2687" r="607" b="2731"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="608" t="2687" r="640" b="2731" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">f</charParams>
+<charParams l="634" t="2700" r="652" b="2721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="255" wordPenalty="1" meanStrokeWidth="38">o</charParams>
+<charParams l="654" t="2700" r="674" b="2721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="678" t="2701" r="692" b="2721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">r</charParams>
+<charParams l="694" t="2702" r="715" b="2722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">n</charParams>
+<charParams l="717" t="2701" r="732" b="2722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="8" wordPenalty="1" meanStrokeWidth="38">e</charParams>
+<charParams l="735" t="2701" r="753" b="2723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="91" wordPenalty="1" meanStrokeWidth="38">a</charParams>
+<charParams l="757" t="2702" r="776" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="779" t="2713" r="786" b="2722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="255" wordPenalty="1" meanStrokeWidth="38">.</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="787" t="2687" r="804" b="2722"> </charParams>
+<charParams l="805" t="2687" r="833" b="2722" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="49" wordPenalty="0" meanStrokeWidth="41">C</charParams>
+<charParams l="836" t="2700" r="853" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="66" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="854" t="2687" r="863" b="2722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">l</charParams>
+<charParams l="866" t="2702" r="887" b="2723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="889" t="2689" r="899" b="2723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="0" meanStrokeWidth="41">i</charParams>
+<charParams l="900" t="2688" r="912" b="2723"> </charParams>
+<charParams l="913" t="2688" r="933" b="2722" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="936" t="2700" r="953" b="2723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="66" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="954" t="2688" r="967" b="2723"> </charParams>
+<charParams l="968" t="2688" r="998" b="2722" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="40" wordPenalty="0" meanStrokeWidth="37">G</charParams>
+<charParams l="1000" t="2687" r="1010" b="2723" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1013" t="2701" r="1029" b="2723" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="60" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1033" t="2703" r="1049" b="2724" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1053" t="2688" r="1074" b="2724" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">b</charParams>
+<charParams l="1077" t="2700" r="1094" b="2725" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1096" t="2701" r="1112" b="2723" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1122" t="2715" r="1130" b="2733" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="39" serifProbability="255" wordPenalty="0" meanStrokeWidth="20">,</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" blockName="" l="1153" t="365" r="1936" b="2732"><region><rect l="1153" t="365" r="1936" b="2732"/></region>
+<text>
+<par align="Justified" leftIndent="7500" lineSpacing="1440">
+<line baseline="408" l="1466" t="371" r="1898" b="420"><formatting lang="OldFrench" ff="Times New Roman" fs="13." bold="1" spacing="70">
+<charParams l="1466" t="371" r="1492" b="410" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="0" meanStrokeWidth="48">F</charParams>
+<charParams l="1519" t="371" r="1555" b="409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="0" meanStrokeWidth="48">O</charParams>
+<charParams l="1582" t="371" r="1616" b="408" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="48">U</charParams>
+<charParams l="1617" t="371" r="1834" b="412" isTab="1"> </charParams>
+<charParams l="1835" t="388" r="1855" b="412" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="255" wordPenalty="50" meanStrokeWidth="76">2</charParams>
+<charParams l="1865" t="388" r="1876" b="420" suspicious="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="255" wordPenalty="50" meanStrokeWidth="76">j</charParams>
+<charParams l="1888" t="388" r="1898" b="412" suspicious="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="50" meanStrokeWidth="76">i</charParams></formatting></line></par>
+<par align="Justified" lineSpacing="1056">
+<line baseline="454" l="1162" t="420" r="1900" b="466"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="436" r="1181" b="466" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="1184" t="435" r="1201" b="456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1203" t="435" r="1218" b="456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1219" t="434" r="1234" b="457"> </charParams>
+<charParams l="1235" t="434" r="1251" b="457" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="83" wordPenalty="0" meanStrokeWidth="47">e</charParams>
+<charParams l="1256" t="436" r="1271" b="456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">x</charParams>
+<charParams l="1278" t="449" r="1283" b="456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">.</charParams>
+<charParams l="1284" t="435" r="1303" b="456"> </charParams>
+<charParams l="1304" t="435" r="1320" b="455" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="33" wordPenalty="0" meanStrokeWidth="44">a</charParams>
+<charParams l="1321" t="434" r="1336" b="455"> </charParams>
+<charParams l="1337" t="434" r="1355" b="455" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1359" t="434" r="1379" b="455" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1380" t="433" r="1399" b="462"> </charParams>
+<charParams l="1400" t="433" r="1418" b="462" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="96" wordPenalty="4" meanStrokeWidth="36">p</charParams>
+<charParams l="1422" t="421" r="1430" b="454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="0" wordPenalty="4" meanStrokeWidth="36">i</charParams>
+<charParams l="1434" t="433" r="1450" b="455" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="83" wordPenalty="4" meanStrokeWidth="36">e</charParams>
+<charParams l="1454" t="421" r="1472" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="4" meanStrokeWidth="36">d</charParams>
+<charParams l="1473" t="420" r="1485" b="454"> </charParams>
+<charParams l="1486" t="420" r="1505" b="454" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1509" t="433" r="1525" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1526" t="420" r="1537" b="453"> </charParams>
+<charParams l="1538" t="420" r="1558" b="452" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="72" wordPenalty="19" meanStrokeWidth="37">d</charParams>
+<charParams l="1561" t="420" r="1569" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="0" wordPenalty="19" meanStrokeWidth="37">i</charParams>
+<charParams l="1574" t="431" r="1590" b="452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="19" meanStrokeWidth="37">a</charParams>
+<charParams l="1593" t="432" r="1622" b="451" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="3" wordPenalty="19" meanStrokeWidth="37">m</charParams>
+<charParams l="1626" t="431" r="1647" b="452" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="83" wordPenalty="19" meanStrokeWidth="37">&#232;</charParams>
+<charParams l="1647" t="429" r="1659" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="19" meanStrokeWidth="37">t</charParams>
+<charParams l="1661" t="432" r="1676" b="452" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="19" meanStrokeWidth="37">r</charParams>
+<charParams l="1679" t="431" r="1696" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="37">e</charParams>
+<charParams l="1697" t="431" r="1707" b="453"> </charParams>
+<charParams l="1708" t="434" r="1713" b="452" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="38" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">:</charParams>
+<charParams l="1714" t="432" r="1728" b="452"> </charParams>
+<charParams l="1729" t="432" r="1745" b="452" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="2" meanStrokeWidth="40">a</charParams>
+<charParams l="1747" t="420" r="1754" b="453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="0" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="1759" t="434" r="1778" b="454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="2" meanStrokeWidth="40">n</charParams>
+<charParams l="1782" t="420" r="1802" b="454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">s</charParams>
+<charParams l="1782" t="420" r="1802" b="454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="40">i</charParams>
+<charParams l="1803" t="420" r="1815" b="455"> </charParams>
+<charParams l="1816" t="422" r="1831" b="455" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="75" wordPenalty="2" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="1834" t="436" r="1851" b="465" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="2" meanStrokeWidth="36">g</charParams>
+<charParams l="1854" t="437" r="1869" b="457" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="2" meanStrokeWidth="36">a</charParams>
+<charParams l="1872" t="423" r="1878" b="456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="51" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="1883" t="435" r="1900" b="457" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="83" wordPenalty="2" meanStrokeWidth="36">e</charParams></formatting></line>
+<line baseline="498" l="1159" t="457" r="1902" b="509"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1159" t="469" r="1178" b="501" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1182" t="468" r="1191" b="501" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="0" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="1195" t="481" r="1226" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="3" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="1230" t="480" r="1246" b="501" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1249" t="481" r="1269" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1273" t="465" r="1292" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1273" t="465" r="1292" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="1297" t="480" r="1316" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="1319" t="480" r="1338" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1339" t="466" r="1356" b="500"> </charParams>
+<charParams l="1357" t="466" r="1374" b="500" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1370" t="480" r="1387" b="499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="1391" t="465" r="1422" b="499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">f</charParams>
+<charParams l="1391" t="465" r="1422" b="499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">f</charParams>
+<charParams l="1391" t="465" r="1422" b="499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">i</charParams>
+<charParams l="1426" t="478" r="1439" b="498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">r</charParams>
+<charParams l="1441" t="478" r="1457" b="498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="60" wordPenalty="3" meanStrokeWidth="38">a</charParams>
+<charParams l="1458" t="478" r="1468" b="507"> </charParams>
+<charParams l="1469" t="478" r="1488" b="507" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="96" wordPenalty="6" meanStrokeWidth="38">p</charParams>
+<charParams l="1492" t="478" r="1512" b="498" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="255" wordPenalty="6" meanStrokeWidth="38">o</charParams>
+<charParams l="1516" t="477" r="1533" b="497" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="91" wordPenalty="6" meanStrokeWidth="38">u</charParams>
+<charParams l="1537" t="477" r="1552" b="497" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">r</charParams>
+<charParams l="1557" t="457" r="1584" b="496" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="6" meanStrokeWidth="38">T</charParams>
+<charParams l="1581" t="477" r="1601" b="497" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="6" meanStrokeWidth="38">o</charParams>
+<charParams l="1603" t="477" r="1623" b="496" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">n</charParams>
+<charParams l="1624" t="463" r="1639" b="497"> </charParams>
+<charParams l="1640" t="463" r="1658" b="497" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="66" wordPenalty="5" meanStrokeWidth="38">s</charParams>
+<charParams l="1654" t="478" r="1673" b="498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="255" wordPenalty="5" meanStrokeWidth="38">o</charParams>
+<charParams l="1675" t="478" r="1694" b="497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="5" meanStrokeWidth="38">u</charParams>
+<charParams l="1697" t="478" r="1716" b="506" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="96" wordPenalty="5" meanStrokeWidth="38">p</charParams>
+<charParams l="1720" t="464" r="1728" b="497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1734" t="477" r="1746" b="496" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="52" wordPenalty="5" meanStrokeWidth="38">r</charParams>
+<charParams l="1749" t="477" r="1764" b="497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="60" wordPenalty="5" meanStrokeWidth="38">a</charParams>
+<charParams l="1767" t="466" r="1776" b="497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1778" t="464" r="1784" b="498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="51" wordPenalty="5" meanStrokeWidth="38">l</charParams>
+<charParams l="1785" t="464" r="1798" b="509"> </charParams>
+<charParams l="1799" t="478" r="1807" b="509" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="20" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">;</charParams>
+<charParams l="1808" t="468" r="1827" b="509"> </charParams>
+<charParams l="1828" t="468" r="1858" b="499" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="92" serifProbability="255" wordPenalty="0" meanStrokeWidth="34">&amp;</charParams>
+<charParams l="1859" t="467" r="1872" b="500"> </charParams>
+<charParams l="1873" t="467" r="1882" b="500" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="100" wordPenalty="7" meanStrokeWidth="37">l</charParams>
+<charParams l="1885" t="480" r="1902" b="500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="83" wordPenalty="7" meanStrokeWidth="37">e</charParams></formatting></line>
+<line baseline="543" l="1161" t="509" r="1903" b="552"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1161" t="524" r="1172" b="545" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="61" wordPenalty="5" meanStrokeWidth="38">t</charParams>
+<charParams l="1177" t="513" r="1185" b="545" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1189" t="524" r="1205" b="546" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="82" wordPenalty="5" meanStrokeWidth="38">e</charParams>
+<charParams l="1209" t="524" r="1223" b="544" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="5" meanStrokeWidth="38">r</charParams>
+<charParams l="1225" t="525" r="1238" b="546" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="10" wordPenalty="5" meanStrokeWidth="38">s</charParams>
+<charParams l="1239" t="525" r="1258" b="546"> </charParams>
+<charParams l="1259" t="525" r="1279" b="546" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="255" wordPenalty="0" meanStrokeWidth="44">o</charParams>
+<charParams l="1282" t="525" r="1302" b="545" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="86" wordPenalty="0" meanStrokeWidth="44">u</charParams>
+<charParams l="1303" t="511" r="1316" b="545"> </charParams>
+<charParams l="1317" t="511" r="1326" b="545" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1330" t="523" r="1347" b="544" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1348" t="523" r="1365" b="552"> </charParams>
+<charParams l="1366" t="524" r="1382" b="552" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">q</charParams>
+<charParams l="1386" t="524" r="1404" b="543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="35">u</charParams>
+<charParams l="1408" t="523" r="1424" b="543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="53" wordPenalty="0" meanStrokeWidth="35">a</charParams>
+<charParams l="1425" t="523" r="1439" b="543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="35">r</charParams>
+<charParams l="1443" t="521" r="1454" b="544" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="35">t</charParams>
+<charParams l="1467" t="535" r="1474" b="549" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="85" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1475" t="521" r="1494" b="549"> </charParams>
+<charParams l="1495" t="521" r="1511" b="542" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1514" t="521" r="1534" b="542" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1538" t="521" r="1567" b="541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="3" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1572" t="522" r="1605" b="541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1607" t="520" r="1625" b="541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1626" t="520" r="1640" b="542"> </charParams>
+<charParams l="1641" t="522" r="1661" b="542" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1664" t="522" r="1684" b="541" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1685" t="521" r="1705" b="541"> </charParams>
+<charParams l="1706" t="521" r="1723" b="541" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="64" wordPenalty="0" meanStrokeWidth="43">a</charParams>
+<charParams l="1724" t="509" r="1737" b="542"> </charParams>
+<charParams l="1738" t="509" r="1758" b="542" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1761" t="510" r="1770" b="542" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1775" t="520" r="1787" b="542" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1798" t="535" r="1806" b="550" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="73" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1807" t="523" r="1824" b="551"> </charParams>
+<charParams l="1825" t="523" r="1844" b="551" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="1848" t="523" r="1866" b="543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1869" t="523" r="1886" b="543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1890" t="525" r="1903" b="544" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams></formatting></line>
+<line baseline="588" l="1161" t="552" r="1906" b="605"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1161" t="557" r="1170" b="590" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="26" wordPenalty="0" meanStrokeWidth="43">l</charParams>
+<charParams l="1173" t="569" r="1191" b="590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="43">e</charParams>
+<charParams l="1192" t="567" r="1209" b="590"> </charParams>
+<charParams l="1210" t="567" r="1223" b="589" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1226" t="570" r="1243" b="590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1247" t="570" r="1265" b="601" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">y</charParams>
+<charParams l="1268" t="570" r="1284" b="590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="64" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1287" t="570" r="1305" b="589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1310" t="582" r="1316" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams>
+<charParams l="1317" t="555" r="1330" b="605"> </charParams>
+<charParams l="1331" t="555" r="1362" b="605" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="78" wordPenalty="0" meanStrokeWidth="40">Q</charParams>
+<charParams l="1364" t="568" r="1383" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1386" t="569" r="1402" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="33" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1405" t="568" r="1423" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1426" t="565" r="1440" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1441" t="565" r="1452" b="588"> </charParams>
+<charParams l="1453" t="567" r="1470" b="587" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="0" meanStrokeWidth="35">a</charParams>
+<charParams l="1473" t="567" r="1490" b="587" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="91" wordPenalty="0" meanStrokeWidth="35">u</charParams>
+<charParams l="1491" t="553" r="1501" b="587"> </charParams>
+<charParams l="1502" t="553" r="1534" b="586" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1502" t="553" r="1534" b="586" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1537" t="566" r="1555" b="586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1558" t="566" r="1578" b="595" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="1580" t="554" r="1590" b="586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1593" t="566" r="1609" b="585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1611" t="565" r="1627" b="586" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="33" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1629" t="553" r="1638" b="585" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1642" t="552" r="1650" b="586" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1664" t="579" r="1671" b="594" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1672" t="553" r="1685" b="594"> </charParams>
+<charParams l="1686" t="553" r="1693" b="594" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="39" wordPenalty="0" meanStrokeWidth="31">j</charParams>
+<charParams l="1699" t="565" r="1716" b="587" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="31">e</charParams>
+<charParams l="1717" t="565" r="1726" b="595"> </charParams>
+<charParams l="1727" t="566" r="1747" b="595" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="96" wordPenalty="3" meanStrokeWidth="38">p</charParams>
+<charParams l="1751" t="566" r="1767" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="83" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1770" t="567" r="1788" b="587" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">n</charParams>
+<charParams l="1792" t="554" r="1808" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1803" t="566" r="1820" b="588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="82" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1821" t="566" r="1833" b="596"> </charParams>
+<charParams l="1834" t="568" r="1851" b="596" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1854" t="568" r="1872" b="588" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1875" t="555" r="1882" b="567" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1885" t="555" r="1895" b="588" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1896" t="555" r="1906" b="588" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams></formatting></line>
+<line baseline="632" l="1162" t="597" r="1908" b="643"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="601" r="1180" b="635" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1175" t="614" r="1194" b="634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="1199" t="600" r="1227" b="634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">f</charParams>
+<charParams l="1199" t="600" r="1227" b="634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">f</charParams>
+<charParams l="1199" t="600" r="1227" b="634" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">i</charParams>
+<charParams l="1232" t="612" r="1245" b="635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="3" meanStrokeWidth="38">t</charParams>
+<charParams l="1246" t="612" r="1254" b="643" suspicious="1"> </charParams>
+<charParams l="1255" t="615" r="1272" b="643" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1277" t="614" r="1294" b="634" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1298" t="600" r="1305" b="613" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1310" t="602" r="1317" b="634" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1321" t="600" r="1329" b="633" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1330" t="600" r="1344" b="633"> </charParams>
+<charParams l="1345" t="607" r="1357" b="633" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="49">f</charParams>
+<charParams l="1358" t="613" r="1377" b="633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">o</charParams>
+<charParams l="1380" t="613" r="1399" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="86" wordPenalty="0" meanStrokeWidth="49">u</charParams>
+<charParams l="1402" t="612" r="1416" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="49">r</charParams>
+<charParams l="1418" t="613" r="1439" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="49">n</charParams>
+<charParams l="1442" t="599" r="1449" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="0" wordPenalty="0" meanStrokeWidth="49">i</charParams>
+<charParams l="1453" t="598" r="1485" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">s</charParams>
+<charParams l="1453" t="598" r="1485" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">s</charParams>
+<charParams l="1479" t="611" r="1496" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="49">e</charParams>
+<charParams l="1497" t="611" r="1509" b="632"> </charParams>
+<charParams l="1510" t="611" r="1526" b="631" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1529" t="610" r="1547" b="631" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1548" t="597" r="1562" b="631"> </charParams>
+<charParams l="1563" t="597" r="1581" b="630" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1577" t="610" r="1597" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1600" t="611" r="1619" b="641" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">y</charParams>
+<charParams l="1622" t="609" r="1639" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1642" t="611" r="1657" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1666" t="609" r="1673" b="642" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">;</charParams>
+<charParams l="1674" t="609" r="1682" b="642"> </charParams>
+<charParams l="1683" t="611" r="1715" b="630" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1719" t="611" r="1736" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1739" t="599" r="1746" b="630" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1750" t="610" r="1762" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1763" t="598" r="1776" b="632"> </charParams>
+<charParams l="1777" t="598" r="1786" b="632" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1790" t="611" r="1808" b="633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1809" t="599" r="1816" b="633"> </charParams>
+<charParams l="1817" t="599" r="1835" b="632" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="1830" t="612" r="1850" b="631" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1852" t="612" r="1871" b="643" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">y</charParams>
+<charParams l="1874" t="611" r="1891" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1894" t="612" r="1908" b="632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams></formatting></line>
+<line baseline="677" l="1163" t="641" r="1910" b="688"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1163" t="659" r="1182" b="679" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1186" t="646" r="1193" b="658" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1197" t="658" r="1213" b="678" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1214" t="658" r="1241" b="688"> </charParams>
+<charParams l="1242" t="659" r="1259" b="688" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="1262" t="659" r="1280" b="679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1284" t="658" r="1301" b="679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1302" t="657" r="1321" b="679"> </charParams>
+<charParams l="1322" t="657" r="1338" b="678" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="26" wordPenalty="0" meanStrokeWidth="36">c</charParams>
+<charParams l="1341" t="657" r="1357" b="679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1361" t="655" r="1372" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1375" t="655" r="1387" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1389" t="656" r="1406" b="678" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1407" t="643" r="1431" b="678"> </charParams>
+<charParams l="1432" t="643" r="1440" b="676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="26" wordPenalty="0" meanStrokeWidth="31">l</charParams>
+<charParams l="1443" t="657" r="1458" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="53" wordPenalty="0" meanStrokeWidth="31">a</charParams>
+<charParams l="1460" t="656" r="1476" b="676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">r</charParams>
+<charParams l="1478" t="657" r="1496" b="686" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="31">g</charParams>
+<charParams l="1499" t="655" r="1516" b="676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="31">e</charParams>
+<charParams l="1518" t="655" r="1537" b="675" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="97" wordPenalty="0" meanStrokeWidth="31">u</charParams>
+<charParams l="1541" t="655" r="1555" b="675" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">r</charParams>
+<charParams l="1569" t="670" r="1576" b="684" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">,</charParams>
+<charParams l="1577" t="644" r="1597" b="684"> </charParams>
+<charParams l="1598" t="644" r="1630" b="676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&amp;</charParams>
+<charParams l="1631" t="644" r="1651" b="676"> </charParams>
+<charParams l="1652" t="655" r="1669" b="676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="83" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1672" t="643" r="1679" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="51" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1684" t="641" r="1691" b="675" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="51" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1694" t="654" r="1712" b="675" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="83" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1713" t="654" r="1733" b="676"> </charParams>
+<charParams l="1734" t="655" r="1752" b="676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1755" t="642" r="1781" b="676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1755" t="642" r="1781" b="676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1782" t="642" r="1801" b="676"> </charParams>
+<charParams l="1802" t="656" r="1834" b="676" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1838" t="646" r="1854" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="58" wordPenalty="0" meanStrokeWidth="38">&#234;</charParams>
+<charParams l="1858" t="656" r="1889" b="676" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1892" t="656" r="1910" b="677" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="722" l="1163" t="686" r="1910" b="731"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1163" t="691" r="1181" b="723" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="31">d</charParams>
+<charParams l="1186" t="691" r="1193" b="723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="0" wordPenalty="0" meanStrokeWidth="31">i</charParams>
+<charParams l="1199" t="703" r="1228" b="723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">m</charParams>
+<charParams l="1233" t="690" r="1241" b="724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="31">i</charParams>
+<charParams l="1245" t="703" r="1265" b="723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="75" wordPenalty="0" meanStrokeWidth="31">n</charParams>
+<charParams l="1269" t="703" r="1287" b="723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">u</charParams>
+<charParams l="1290" t="688" r="1306" b="723" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="0" meanStrokeWidth="31">&#233;</charParams>
+<charParams l="1308" t="702" r="1324" b="724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="83" wordPenalty="0" meanStrokeWidth="31">e</charParams>
+<charParams l="1325" t="702" r="1340" b="731"> </charParams>
+<charParams l="1341" t="703" r="1360" b="731" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="96" wordPenalty="3" meanStrokeWidth="30">p</charParams>
+<charParams l="1362" t="701" r="1378" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="53" wordPenalty="3" meanStrokeWidth="30">a</charParams>
+<charParams l="1380" t="701" r="1395" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="3" meanStrokeWidth="30">r</charParams>
+<charParams l="1396" t="688" r="1411" b="721"> </charParams>
+<charParams l="1412" t="688" r="1419" b="721" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1423" t="701" r="1439" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1440" t="700" r="1453" b="730"> </charParams>
+<charParams l="1454" t="700" r="1473" b="730" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="53" wordPenalty="0" meanStrokeWidth="32">g</charParams>
+<charParams l="1476" t="701" r="1490" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">r</charParams>
+<charParams l="1493" t="688" r="1501" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="0" wordPenalty="0" meanStrokeWidth="32">i</charParams>
+<charParams l="1505" t="686" r="1512" b="719" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="51" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1517" t="686" r="1523" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="51" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1528" t="699" r="1546" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="82" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1547" t="689" r="1565" b="721"> </charParams>
+<charParams l="1566" t="689" r="1585" b="721" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">S</charParams>
+<charParams l="1585" t="699" r="1597" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="61" wordPenalty="0" meanStrokeWidth="35">t</charParams>
+<charParams l="1598" t="687" r="1615" b="721"> </charParams>
+<charParams l="1616" t="687" r="1624" b="719" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1628" t="699" r="1645" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1648" t="700" r="1660" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="10" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1661" t="699" r="1682" b="721"> </charParams>
+<charParams l="1683" t="699" r="1698" b="720" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1700" t="688" r="1720" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">h</charParams>
+<charParams l="1722" t="700" r="1739" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1742" t="700" r="1756" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1760" t="687" r="1779" b="720" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">b</charParams>
+<charParams l="1782" t="701" r="1802" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1805" t="701" r="1825" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1828" t="700" r="1840" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1851" t="702" r="1857" b="721" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">:</charParams>
+<charParams l="1858" t="701" r="1871" b="721"> </charParams>
+<charParams l="1872" t="701" r="1889" b="721" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1892" t="700" r="1910" b="722" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams></formatting></line>
+<line baseline="766" l="1163" t="729" r="1911" b="774"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1163" t="734" r="1181" b="768" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="48" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1178" t="747" r="1194" b="768" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1196" t="747" r="1210" b="767" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1212" t="749" r="1229" b="769" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="92" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1230" t="735" r="1248" b="769"> </charParams>
+<charParams l="1249" t="735" r="1268" b="768" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1272" t="747" r="1291" b="767" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="1292" t="747" r="1312" b="767" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1317" t="747" r="1332" b="767" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="26" wordPenalty="0" meanStrokeWidth="36">c</charParams>
+<charParams l="1333" t="746" r="1352" b="767"> </charParams>
+<charParams l="1353" t="746" r="1368" b="766" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="53" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1372" t="731" r="1404" b="766" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1372" t="731" r="1404" b="766" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1397" t="745" r="1413" b="766" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1417" t="745" r="1432" b="766" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">z</charParams>
+<charParams l="1433" t="745" r="1451" b="774"> </charParams>
+<charParams l="1452" t="746" r="1471" b="774" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="1475" t="745" r="1493" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="1496" t="745" r="1515" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="75" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1520" t="744" r="1533" b="764" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="1534" t="731" r="1555" b="764"> </charParams>
+<charParams l="1556" t="731" r="1564" b="764" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1568" t="743" r="1585" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1586" t="729" r="1601" b="765"> </charParams>
+<charParams l="1602" t="729" r="1619" b="763" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="5" meanStrokeWidth="38">s</charParams>
+<charParams l="1617" t="745" r="1636" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="255" wordPenalty="5" meanStrokeWidth="38">o</charParams>
+<charParams l="1640" t="745" r="1658" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="91" wordPenalty="5" meanStrokeWidth="38">u</charParams>
+<charParams l="1660" t="745" r="1679" b="773" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="96" wordPenalty="5" meanStrokeWidth="38">p</charParams>
+<charParams l="1683" t="733" r="1690" b="764" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1694" t="745" r="1709" b="764" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="5" meanStrokeWidth="38">r</charParams>
+<charParams l="1712" t="744" r="1729" b="764" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="60" wordPenalty="5" meanStrokeWidth="38">a</charParams>
+<charParams l="1731" t="732" r="1739" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="5" meanStrokeWidth="38">i</charParams>
+<charParams l="1744" t="731" r="1751" b="765" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="51" wordPenalty="5" meanStrokeWidth="38">l</charParams>
+<charParams l="1763" t="759" r="1770" b="773" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">,</charParams>
+<charParams l="1771" t="744" r="1789" b="773"> </charParams>
+<charParams l="1790" t="744" r="1806" b="764" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="1809" t="744" r="1827" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1828" t="732" r="1844" b="766"> </charParams>
+<charParams l="1845" t="732" r="1862" b="766" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1857" t="745" r="1874" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1878" t="746" r="1892" b="765" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1894" t="745" r="1911" b="767" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="33" wordPenalty="0" meanStrokeWidth="40">a</charParams></formatting></line>
+<line baseline="810" l="1162" t="775" r="1912" b="822"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="792" r="1193" b="812" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="44" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="1197" t="780" r="1213" b="812" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="58" wordPenalty="0" meanStrokeWidth="36">&#234;</charParams>
+<charParams l="1217" t="791" r="1247" b="812" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="27" wordPenalty="0" meanStrokeWidth="36">m</charParams>
+<charParams l="1251" t="791" r="1267" b="812" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1268" t="788" r="1287" b="812"> </charParams>
+<charParams l="1288" t="788" r="1301" b="811" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1304" t="790" r="1319" b="811" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1321" t="791" r="1340" b="811" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1344" t="790" r="1362" b="819" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1363" t="790" r="1379" b="822"> </charParams>
+<charParams l="1380" t="790" r="1388" b="822" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="22" serifProbability="255" wordPenalty="0" meanStrokeWidth="29">;</charParams>
+<charParams l="1389" t="790" r="1403" b="822"> </charParams>
+<charParams l="1404" t="790" r="1434" b="810" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="44" wordPenalty="5" meanStrokeWidth="36">m</charParams>
+<charParams l="1438" t="789" r="1455" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="64" wordPenalty="5" meanStrokeWidth="36">a</charParams>
+<charParams l="1458" t="778" r="1465" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="0" wordPenalty="5" meanStrokeWidth="36">i</charParams>
+<charParams l="1469" t="789" r="1480" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="10" wordPenalty="5" meanStrokeWidth="36">s</charParams>
+<charParams l="1481" t="776" r="1500" b="810"> </charParams>
+<charParams l="1501" t="776" r="1521" b="809" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1524" t="790" r="1540" b="809" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="60" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1543" t="789" r="1561" b="808" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1565" t="788" r="1577" b="808" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="41" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1578" t="775" r="1598" b="809"> </charParams>
+<charParams l="1599" t="775" r="1608" b="809" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1612" t="788" r="1628" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1629" t="788" r="1650" b="810"> </charParams>
+<charParams l="1651" t="789" r="1667" b="809" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="1671" t="789" r="1687" b="809" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1689" t="788" r="1702" b="809" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1703" t="788" r="1722" b="809"> </charParams>
+<charParams l="1723" t="789" r="1743" b="809" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1748" t="775" r="1767" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">&#249;</charParams>
+<charParams l="1768" t="775" r="1784" b="810"> </charParams>
+<charParams l="1785" t="776" r="1793" b="809" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="26" wordPenalty="0" meanStrokeWidth="56">l</charParams>
+<charParams l="1798" t="776" r="1805" b="789" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="56">&#8217;</charParams>
+<charParams l="1808" t="790" r="1828" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="255" wordPenalty="0" meanStrokeWidth="56">o</charParams>
+<charParams l="1831" t="790" r="1851" b="810" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="56">n</charParams>
+<charParams l="1852" t="790" r="1868" b="810"> </charParams>
+<charParams l="1869" t="791" r="1890" b="810" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1893" t="789" r="1912" b="811" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="855" l="1162" t="819" r="1911" b="866"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="837" r="1181" b="866" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="96" wordPenalty="2" meanStrokeWidth="35">p</charParams>
+<charParams l="1184" t="835" r="1200" b="857" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="82" wordPenalty="2" meanStrokeWidth="35">e</charParams>
+<charParams l="1204" t="836" r="1222" b="856" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="2" meanStrokeWidth="35">u</charParams>
+<charParams l="1226" t="834" r="1238" b="856" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="61" wordPenalty="2" meanStrokeWidth="35">t</charParams>
+<charParams l="1239" t="834" r="1245" b="856"> </charParams>
+<charParams l="1246" t="835" r="1262" b="855" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="64" wordPenalty="7" meanStrokeWidth="35">a</charParams>
+<charParams l="1264" t="836" r="1284" b="865" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="96" wordPenalty="7" meanStrokeWidth="35">p</charParams>
+<charParams l="1286" t="836" r="1305" b="865" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="96" wordPenalty="7" meanStrokeWidth="35">p</charParams>
+<charParams l="1308" t="835" r="1323" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="7" meanStrokeWidth="35">r</charParams>
+<charParams l="1325" t="821" r="1340" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="7" meanStrokeWidth="35">&#233;</charParams>
+<charParams l="1343" t="834" r="1359" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="7" meanStrokeWidth="35">c</charParams>
+<charParams l="1362" t="822" r="1370" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="0" wordPenalty="7" meanStrokeWidth="35">i</charParams>
+<charParams l="1374" t="834" r="1391" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="83" wordPenalty="7" meanStrokeWidth="35">e</charParams>
+<charParams l="1394" t="834" r="1408" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="7" meanStrokeWidth="35">r</charParams>
+<charParams l="1409" t="833" r="1424" b="855"> </charParams>
+<charParams l="1425" t="833" r="1442" b="854" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1444" t="834" r="1462" b="854" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1463" t="821" r="1481" b="862"> </charParams>
+<charParams l="1482" t="821" r="1488" b="862" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="19" wordPenalty="0" meanStrokeWidth="37">j</charParams>
+<charParams l="1494" t="834" r="1513" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="97" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1517" t="820" r="1540" b="853" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1517" t="820" r="1540" b="853" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1543" t="832" r="1560" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1561" t="819" r="1575" b="854"> </charParams>
+<charParams l="1576" t="819" r="1585" b="853" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="26" wordPenalty="0" meanStrokeWidth="33">l</charParams>
+<charParams l="1588" t="833" r="1605" b="853" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="60" wordPenalty="0" meanStrokeWidth="33">a</charParams>
+<charParams l="1606" t="833" r="1624" b="863"> </charParams>
+<charParams l="1625" t="834" r="1642" b="863" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">q</charParams>
+<charParams l="1645" t="834" r="1665" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="97" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="1669" t="833" r="1684" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="60" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="1687" t="833" r="1705" b="853" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="75" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1709" t="831" r="1722" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">t</charParams>
+<charParams l="1725" t="821" r="1733" b="853" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="2" meanStrokeWidth="38">i</charParams>
+<charParams l="1737" t="831" r="1751" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">t</charParams>
+<charParams l="1752" t="820" r="1769" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="2" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1770" t="820" r="1784" b="855"> </charParams>
+<charParams l="1785" t="833" r="1801" b="854" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1804" t="834" r="1823" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1826" t="834" r="1847" b="854" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1850" t="835" r="1868" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">v</charParams>
+<charParams l="1872" t="834" r="1890" b="855" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1891" t="842" r="1911" b="848" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#172;</charParams></formatting></line>
+<line baseline="899" l="1162" t="864" r="1912" b="908"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="881" r="1180" b="901" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1184" t="880" r="1200" b="900" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="60" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1203" t="867" r="1221" b="900" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">b</charParams>
+<charParams l="1224" t="867" r="1232" b="901" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1236" t="880" r="1252" b="901" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1253" t="880" r="1261" b="908"> </charParams>
+<charParams l="1262" t="894" r="1270" b="908" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="82" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1271" t="869" r="1289" b="908"> </charParams>
+<charParams l="1290" t="869" r="1299" b="900" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1303" t="866" r="1310" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1311" t="866" r="1327" b="900"> </charParams>
+<charParams l="1328" t="879" r="1347" b="900" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="50" wordPenalty="0" meanStrokeWidth="36">v</charParams>
+<charParams l="1350" t="878" r="1366" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="64" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1369" t="880" r="1389" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1392" t="877" r="1404" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1405" t="877" r="1418" b="899"> </charParams>
+<charParams l="1419" t="878" r="1449" b="898" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1453" t="866" r="1462" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1466" t="878" r="1483" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1486" t="879" r="1504" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1508" t="878" r="1526" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">x</charParams>
+<charParams l="1527" t="878" r="1544" b="907"> </charParams>
+<charParams l="1545" t="878" r="1565" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="96" wordPenalty="6" meanStrokeWidth="38">p</charParams>
+<charParams l="1568" t="864" r="1583" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="6" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1586" t="877" r="1601" b="897" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="26" wordPenalty="6" meanStrokeWidth="38">c</charParams>
+<charParams l="1604" t="866" r="1624" b="897" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="98" wordPenalty="6" meanStrokeWidth="38">h</charParams>
+<charParams l="1627" t="877" r="1644" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="6" meanStrokeWidth="38">e</charParams>
+<charParams l="1646" t="877" r="1661" b="897" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">r</charParams>
+<charParams l="1662" t="877" r="1681" b="907"> </charParams>
+<charParams l="1682" t="878" r="1702" b="907" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="2" meanStrokeWidth="38">p</charParams>
+<charParams l="1705" t="878" r="1721" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="33" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="1723" t="877" r="1738" b="898" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="1739" t="877" r="1755" b="899"> </charParams>
+<charParams l="1756" t="878" r="1772" b="899" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1775" t="878" r="1792" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1795" t="876" r="1808" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1809" t="876" r="1820" b="900"> </charParams>
+<charParams l="1821" t="878" r="1839" b="900" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1842" t="879" r="1858" b="900" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">x</charParams>
+<charParams l="1861" t="879" r="1877" b="899" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1879" t="866" r="1897" b="900" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">&#232;</charParams>
+<charParams l="1898" t="880" r="1912" b="901" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="41" wordPenalty="0" meanStrokeWidth="39">s</charParams></formatting></line>
+<line baseline="943" l="1162" t="909" r="1912" b="954"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="925" r="1179" b="953" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">q</charParams>
+<charParams l="1183" t="925" r="1200" b="945" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="91" wordPenalty="2" meanStrokeWidth="36">u</charParams>
+<charParams l="1205" t="924" r="1222" b="945" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="82" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="1223" t="924" r="1237" b="954"> </charParams>
+<charParams l="1238" t="925" r="1257" b="954" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="96" wordPenalty="2" meanStrokeWidth="35">p</charParams>
+<charParams l="1260" t="923" r="1277" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="53" wordPenalty="2" meanStrokeWidth="35">a</charParams>
+<charParams l="1279" t="924" r="1293" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="2" meanStrokeWidth="35">r</charParams>
+<charParams l="1294" t="910" r="1312" b="944"> </charParams>
+<charParams l="1313" t="910" r="1321" b="944" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1324" t="923" r="1342" b="945" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1343" t="923" r="1353" b="945"> </charParams>
+<charParams l="1354" t="923" r="1370" b="944" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1373" t="924" r="1392" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1395" t="923" r="1415" b="943" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1419" t="919" r="1431" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1433" t="922" r="1448" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1451" t="922" r="1467" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="76" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1470" t="910" r="1480" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1483" t="923" r="1497" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1500" t="921" r="1518" b="943" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1519" t="921" r="1528" b="953"> </charParams>
+<charParams l="1529" t="921" r="1537" b="953" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">;</charParams>
+<charParams l="1538" t="911" r="1547" b="953"> </charParams>
+<charParams l="1548" t="911" r="1567" b="943" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">S</charParams>
+<charParams l="1567" t="921" r="1580" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1581" t="909" r="1593" b="951"> </charParams>
+<charParams l="1594" t="909" r="1601" b="951" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="19" wordPenalty="0" meanStrokeWidth="32">j</charParams>
+<charParams l="1607" t="921" r="1624" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1625" t="921" r="1636" b="942"> </charParams>
+<charParams l="1637" t="922" r="1654" b="941" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1655" t="921" r="1671" b="942" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1673" t="923" r="1691" b="943" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1695" t="910" r="1705" b="943" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1707" t="922" r="1719" b="943" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="10" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1720" t="922" r="1732" b="952"> </charParams>
+<charParams l="1733" t="923" r="1752" b="952" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="255" wordPenalty="2" meanStrokeWidth="41">q</charParams>
+<charParams l="1754" t="923" r="1772" b="944" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="75" wordPenalty="2" meanStrokeWidth="41">u</charParams>
+<charParams l="1776" t="910" r="1784" b="922" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="41">&#8217;</charParams>
+<charParams l="1787" t="923" r="1806" b="944" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="41">o</charParams>
+<charParams l="1809" t="923" r="1829" b="943" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="41">n</charParams>
+<charParams l="1830" t="912" r="1840" b="944"> </charParams>
+<charParams l="1841" t="912" r="1858" b="944" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1863" t="925" r="1882" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1886" t="912" r="1896" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1899" t="921" r="1912" b="944" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams></formatting></line>
+<line baseline="988" l="1161" t="952" r="1912" b="998"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1161" t="969" r="1174" b="989" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1178" t="957" r="1187" b="970" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1190" t="968" r="1206" b="989" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1209" t="969" r="1227" b="989" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1228" t="967" r="1253" b="990"> </charParams>
+<charParams l="1254" t="967" r="1267" b="990" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1270" t="968" r="1287" b="989" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1290" t="969" r="1308" b="988" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1312" t="956" r="1321" b="988" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1324" t="968" r="1340" b="988" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1341" t="954" r="1365" b="988"> </charParams>
+<charParams l="1366" t="954" r="1384" b="987" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="100" wordPenalty="0" meanStrokeWidth="46">&#224;</charParams>
+<charParams l="1385" t="954" r="1412" b="987"> </charParams>
+<charParams l="1413" t="966" r="1430" b="987" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1432" t="965" r="1450" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1452" t="964" r="1465" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1467" t="964" r="1479" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1482" t="966" r="1499" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1500" t="954" r="1524" b="988"> </charParams>
+<charParams l="1525" t="954" r="1545" b="988" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1549" t="954" r="1558" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1562" t="966" r="1592" b="986" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1596" t="966" r="1613" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1615" t="967" r="1635" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1638" t="952" r="1660" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1638" t="952" r="1660" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1663" t="967" r="1684" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1686" t="967" r="1707" b="987" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1708" t="967" r="1723" b="987"> </charParams>
+<charParams l="1724" t="967" r="1730" b="987" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="83" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">:</charParams>
+<charParams l="1731" t="967" r="1752" b="989"> </charParams>
+<charParams l="1753" t="968" r="1774" b="989" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="86" wordPenalty="0" meanStrokeWidth="42">u</charParams>
+<charParams l="1777" t="968" r="1796" b="988" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1800" t="967" r="1817" b="988" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="1818" t="967" r="1844" b="998"> </charParams>
+<charParams l="1845" t="969" r="1861" b="998" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="96" wordPenalty="0" meanStrokeWidth="36">p</charParams>
+<charParams l="1865" t="956" r="1872" b="989" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1876" t="970" r="1895" b="990" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1899" t="968" r="1912" b="989" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="10" wordPenalty="0" meanStrokeWidth="36">s</charParams></formatting></line>
+<line baseline="1033" l="1161" t="997" r="1911" b="1044"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1161" t="1014" r="1180" b="1044" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="1184" t="1014" r="1198" b="1033" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1199" t="1013" r="1215" b="1033" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="76" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1218" t="1013" r="1237" b="1034" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1241" t="1001" r="1261" b="1034" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="72" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="1264" t="1013" r="1282" b="1034" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1283" t="1013" r="1305" b="1034"> </charParams>
+<charParams l="1306" t="1013" r="1326" b="1033" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="1329" t="1012" r="1347" b="1033" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="43">e</charParams>
+<charParams l="1348" t="998" r="1374" b="1033"> </charParams>
+<charParams l="1375" t="998" r="1393" b="1032" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="48" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="1389" t="1011" r="1407" b="1032" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1409" t="1012" r="1424" b="1031" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1426" t="1012" r="1445" b="1032" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1448" t="999" r="1457" b="1031" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1461" t="1009" r="1474" b="1032" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1475" t="1009" r="1497" b="1039"> </charParams>
+<charParams l="1498" t="1011" r="1516" b="1039" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="1" meanStrokeWidth="38">p</charParams>
+<charParams l="1518" t="1011" r="1534" b="1031" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="53" wordPenalty="1" meanStrokeWidth="38">a</charParams>
+<charParams l="1536" t="1011" r="1549" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="10" wordPenalty="1" meanStrokeWidth="38">s</charParams>
+<charParams l="1550" t="998" r="1574" b="1032"> </charParams>
+<charParams l="1575" t="998" r="1594" b="1031" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="50" wordPenalty="2" meanStrokeWidth="37">f</charParams>
+<charParams l="1591" t="1011" r="1610" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">o</charParams>
+<charParams l="1614" t="1011" r="1632" b="1031" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">n</charParams>
+<charParams l="1636" t="999" r="1655" b="1031" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="72" wordPenalty="2" meanStrokeWidth="37">d</charParams>
+<charParams l="1659" t="997" r="1676" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="1677" t="1011" r="1695" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1696" t="1011" r="1719" b="1032"> </charParams>
+<charParams l="1720" t="1011" r="1738" b="1032" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="82" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="1741" t="1011" r="1760" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="75" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1761" t="1011" r="1783" b="1032"> </charParams>
+<charParams l="1784" t="1012" r="1800" b="1032" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="100" wordPenalty="5" meanStrokeWidth="39">r</charParams>
+<charParams l="1802" t="1013" r="1819" b="1033" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="64" wordPenalty="5" meanStrokeWidth="39">a</charParams>
+<charParams l="1821" t="1000" r="1830" b="1032" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="0" wordPenalty="5" meanStrokeWidth="39">i</charParams>
+<charParams l="1833" t="1000" r="1850" b="1033" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="66" wordPenalty="5" meanStrokeWidth="39">s</charParams>
+<charParams l="1847" t="1014" r="1866" b="1034" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">o</charParams>
+<charParams l="1868" t="1014" r="1890" b="1034" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="5" meanStrokeWidth="39">n</charParams>
+<charParams l="1901" t="1026" r="1911" b="1041" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">,</charParams></formatting></line>
+<line baseline="1078" l="1162" t="1043" r="1913" b="1088"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1162" t="1058" r="1179" b="1079" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1181" t="1058" r="1201" b="1079" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1204" t="1058" r="1235" b="1078" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1239" t="1059" r="1270" b="1078" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1274" t="1058" r="1292" b="1079" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1293" t="1058" r="1304" b="1079"> </charParams>
+<charParams l="1305" t="1058" r="1325" b="1078" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">o</charParams>
+<charParams l="1328" t="1058" r="1346" b="1077" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="1347" t="1057" r="1354" b="1077"> </charParams>
+<charParams l="1355" t="1057" r="1375" b="1077" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="1378" t="1057" r="1397" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1400" t="1044" r="1409" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1413" t="1054" r="1426" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1427" t="1054" r="1435" b="1077"> </charParams>
+<charParams l="1436" t="1056" r="1453" b="1076" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1455" t="1057" r="1473" b="1076" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1474" t="1043" r="1475" b="1085"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1474" t="1043" r="1506" b="1085" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">f</charParams>
+<charParams l="1499" t="1056" r="1517" b="1075" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">o</charParams>
+<charParams l="1520" t="1057" r="1539" b="1076" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1542" t="1057" r="1558" b="1075" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="1560" t="1056" r="1580" b="1075" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1582" t="1056" r="1598" b="1075" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="8" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1600" t="1056" r="1619" b="1075" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="95" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1622" t="1057" r="1642" b="1076" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1643" t="1043" r="1652" b="1076"> </charParams>
+<charParams l="1653" t="1043" r="1671" b="1075" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1676" t="1056" r="1694" b="1077" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1695" t="1043" r="1705" b="1077"> </charParams>
+<charParams l="1706" t="1043" r="1732" b="1076" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="98" wordPenalty="0" meanStrokeWidth="40">B</charParams>
+<charParams l="1736" t="1056" r="1755" b="1076" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1759" t="1056" r="1776" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1778" t="1057" r="1792" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1795" t="1045" r="1815" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="98" wordPenalty="0" meanStrokeWidth="40">h</charParams>
+<charParams l="1817" t="1057" r="1834" b="1077" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="60" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1835" t="1058" r="1852" b="1078" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="64" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1854" t="1058" r="1873" b="1078" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">v</charParams>
+<charParams l="1876" t="1058" r="1894" b="1079" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1895" t="1057" r="1903" b="1088"> </charParams>
+<charParams l="1904" t="1057" r="1913" b="1088" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="28">;</charParams></formatting></line>
+<line baseline="1122" l="1164" t="1086" r="1915" b="1128"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1164" t="1103" r="1182" b="1123" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1184" t="1089" r="1191" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1195" t="1089" r="1202" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1206" t="1101" r="1224" b="1123" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1225" t="1101" r="1243" b="1124"> </charParams>
+<charParams l="1244" t="1102" r="1261" b="1124" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1264" t="1089" r="1288" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1264" t="1089" r="1288" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1289" t="1089" r="1303" b="1122"> </charParams>
+<charParams l="1304" t="1102" r="1336" b="1122" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="44" wordPenalty="4" meanStrokeWidth="37">m</charParams>
+<charParams l="1339" t="1091" r="1356" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="58" wordPenalty="4" meanStrokeWidth="37">&#234;</charParams>
+<charParams l="1359" t="1101" r="1391" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="44" wordPenalty="4" meanStrokeWidth="37">m</charParams>
+<charParams l="1394" t="1101" r="1412" b="1123" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="82" wordPenalty="4" meanStrokeWidth="37">e</charParams>
+<charParams l="1413" t="1101" r="1432" b="1123"> </charParams>
+<charParams l="1433" t="1101" r="1452" b="1121" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1455" t="1100" r="1475" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="86" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1478" t="1088" r="1486" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1490" t="1086" r="1512" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1490" t="1086" r="1512" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1515" t="1086" r="1534" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">b</charParams>
+<charParams l="1537" t="1087" r="1545" b="1119" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1549" t="1100" r="1566" b="1121" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1577" t="1113" r="1584" b="1128" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="65" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1585" t="1100" r="1599" b="1128"> </charParams>
+<charParams l="1600" t="1100" r="1615" b="1120" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="1618" t="1100" r="1638" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="1641" t="1100" r="1673" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1678" t="1101" r="1707" b="1120" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1712" t="1100" r="1729" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1730" t="1088" r="1748" b="1121"> </charParams>
+<charParams l="1749" t="1088" r="1758" b="1121" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="0" wordPenalty="0" meanStrokeWidth="42">i</charParams>
+<charParams l="1762" t="1088" r="1769" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="42">l</charParams>
+<charParams l="1770" t="1088" r="1787" b="1122"> </charParams>
+<charParams l="1788" t="1100" r="1804" b="1122" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1808" t="1088" r="1832" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1808" t="1088" r="1832" b="1121" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1833" t="1088" r="1851" b="1123"> </charParams>
+<charParams l="1852" t="1102" r="1869" b="1123" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1873" t="1090" r="1880" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1884" t="1088" r="1900" b="1122" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="66" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1897" t="1090" r="1915" b="1123" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">&#233;</charParams></formatting></line>
+<line baseline="1166" l="1163" t="1131" r="1914" b="1176"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1163" t="1135" r="1182" b="1168" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="72" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1186" t="1147" r="1204" b="1168" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1205" t="1134" r="1221" b="1168"> </charParams>
+<charParams l="1222" t="1134" r="1229" b="1167" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1232" t="1147" r="1250" b="1168" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1251" t="1147" r="1264" b="1176"> </charParams>
+<charParams l="1265" t="1148" r="1284" b="1176" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1288" t="1147" r="1306" b="1168" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1308" t="1147" r="1328" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1331" t="1132" r="1349" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="66" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1346" t="1146" r="1364" b="1167" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1366" t="1145" r="1379" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1380" t="1145" r="1393" b="1174"> </charParams>
+<charParams l="1394" t="1159" r="1402" b="1174" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="86" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1403" t="1134" r="1417" b="1174"> </charParams>
+<charParams l="1418" t="1134" r="1449" b="1166" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&amp;</charParams>
+<charParams l="1450" t="1134" r="1469" b="1166"> </charParams>
+<charParams l="1470" t="1145" r="1485" b="1166" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1488" t="1145" r="1507" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1512" t="1145" r="1540" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1546" t="1145" r="1575" b="1164" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1580" t="1144" r="1598" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1599" t="1144" r="1610" b="1165"> </charParams>
+<charParams l="1611" t="1145" r="1631" b="1164" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="100" wordPenalty="5" meanStrokeWidth="39">n</charParams>
+<charParams l="1634" t="1145" r="1654" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="255" wordPenalty="5" meanStrokeWidth="39">o</charParams>
+<charParams l="1657" t="1145" r="1677" b="1164" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="86" wordPenalty="5" meanStrokeWidth="39">u</charParams>
+<charParams l="1679" t="1145" r="1691" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="10" wordPenalty="5" meanStrokeWidth="39">s</charParams>
+<charParams l="1692" t="1131" r="1700" b="1165" suspicious="1"> </charParams>
+<charParams l="1701" t="1131" r="1709" b="1165" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1714" t="1144" r="1731" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1732" t="1133" r="1748" b="1166"> </charParams>
+<charParams l="1749" t="1133" r="1768" b="1166" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="72" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1773" t="1133" r="1782" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1785" t="1146" r="1800" b="1165" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1802" t="1146" r="1822" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1824" t="1146" r="1845" b="1166" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1847" t="1146" r="1860" b="1167" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="10" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1861" t="1146" r="1873" b="1167"> </charParams>
+<charParams l="1874" t="1146" r="1891" b="1167" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1894" t="1147" r="1914" b="1167" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams></formatting></line>
+<line baseline="1210" l="1163" t="1176" r="1914" b="1221"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1163" t="1192" r="1183" b="1221" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="1185" t="1191" r="1201" b="1212" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1204" t="1191" r="1217" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1219" t="1178" r="1226" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1230" t="1192" r="1247" b="1213" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1250" t="1192" r="1268" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1273" t="1189" r="1286" b="1212" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1287" t="1179" r="1300" b="1212"> </charParams>
+<charParams l="1301" t="1179" r="1319" b="1212" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1325" t="1190" r="1341" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1343" t="1190" r="1356" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="41" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1357" t="1190" r="1376" b="1211"> </charParams>
+<charParams l="1377" t="1190" r="1393" b="1211" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="33" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1396" t="1188" r="1408" b="1211" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1410" t="1178" r="1431" b="1211" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="98" wordPenalty="0" meanStrokeWidth="40">h</charParams>
+<charParams l="1434" t="1190" r="1450" b="1211" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="33" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1450" t="1190" r="1471" b="1212" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1475" t="1190" r="1494" b="1211" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1497" t="1190" r="1511" b="1210" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1512" t="1189" r="1525" b="1209" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="10" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1527" t="1202" r="1534" b="1210" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">.</charParams>
+<charParams l="1535" t="1177" r="1554" b="1210"> </charParams>
+<charParams l="1555" t="1177" r="1593" b="1209" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="94" wordPenalty="0" meanStrokeWidth="37">M</charParams>
+<charParams l="1597" t="1188" r="1613" b="1209" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="64" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1615" t="1177" r="1623" b="1209" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1628" t="1189" r="1640" b="1210" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1641" t="1177" r="1654" b="1210"> </charParams>
+<charParams l="1655" t="1177" r="1665" b="1209" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="0" wordPenalty="0" meanStrokeWidth="46">i</charParams>
+<charParams l="1668" t="1176" r="1677" b="1209" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="26" wordPenalty="0" meanStrokeWidth="46">l</charParams>
+<charParams l="1678" t="1176" r="1693" b="1209"> </charParams>
+<charParams l="1694" t="1189" r="1715" b="1209" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1717" t="1177" r="1725" b="1189" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="1729" t="1189" r="1746" b="1210" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1750" t="1189" r="1769" b="1210" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1770" t="1189" r="1792" b="1211"> </charParams>
+<charParams l="1793" t="1189" r="1811" b="1211" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1813" t="1177" r="1839" b="1210" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1813" t="1177" r="1839" b="1210" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1840" t="1177" r="1859" b="1220"> </charParams>
+<charParams l="1860" t="1191" r="1880" b="1220" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="1884" t="1191" r="1899" b="1211" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="60" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1901" t="1191" r="1914" b="1212" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="10" wordPenalty="0" meanStrokeWidth="40">s</charParams></formatting></line>
+<line baseline="1256" l="1164" t="1220" r="1915" b="1266"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1164" t="1224" r="1183" b="1257" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1188" t="1235" r="1205" b="1257" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1206" t="1235" r="1220" b="1257"> </charParams>
+<charParams l="1221" t="1235" r="1252" b="1256" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1256" t="1225" r="1273" b="1258" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="58" wordPenalty="0" meanStrokeWidth="37">&#234;</charParams>
+<charParams l="1277" t="1236" r="1306" b="1256" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="27" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1311" t="1236" r="1328" b="1257" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1329" t="1223" r="1337" b="1257"> </charParams>
+<charParams l="1338" t="1223" r="1358" b="1256" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1362" t="1235" r="1380" b="1256" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1381" t="1233" r="1391" b="1256"> </charParams>
+<charParams l="1392" t="1233" r="1405" b="1256" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1408" t="1235" r="1426" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1428" t="1235" r="1447" b="1266" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">y</charParams>
+<charParams l="1450" t="1235" r="1466" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1468" t="1235" r="1486" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1487" t="1234" r="1497" b="1255"> </charParams>
+<charParams l="1498" t="1234" r="1517" b="1255" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="44">o</charParams>
+<charParams l="1520" t="1234" r="1538" b="1254" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="91" wordPenalty="0" meanStrokeWidth="44">u</charParams>
+<charParams l="1539" t="1233" r="1555" b="1254"> </charParams>
+<charParams l="1556" t="1233" r="1572" b="1254" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1573" t="1222" r="1594" b="1253" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">h</charParams>
+<charParams l="1596" t="1234" r="1614" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1618" t="1234" r="1647" b="1253" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1652" t="1221" r="1660" b="1254" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1663" t="1234" r="1683" b="1254" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1685" t="1220" r="1701" b="1254" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1703" t="1233" r="1720" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1721" t="1232" r="1730" b="1265"> </charParams>
+<charParams l="1731" t="1232" r="1740" b="1265" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="18" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">;</charParams>
+<charParams l="1741" t="1221" r="1751" b="1265"> </charParams>
+<charParams l="1752" t="1221" r="1762" b="1255" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1765" t="1221" r="1774" b="1255" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1775" t="1221" r="1785" b="1255"> </charParams>
+<charParams l="1786" t="1235" r="1805" b="1254" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1810" t="1234" r="1827" b="1256" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1828" t="1223" r="1842" b="1256"> </charParams>
+<charParams l="1843" t="1223" r="1862" b="1256" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="72" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1866" t="1236" r="1885" b="1256" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1888" t="1223" r="1897" b="1256" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1901" t="1232" r="1915" b="1257" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams></formatting></line>
+<line baseline="1300" l="1164" t="1266" r="1913" b="1310"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1164" t="1281" r="1184" b="1310" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1186" t="1281" r="1202" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="33" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1205" t="1280" r="1216" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1217" t="1280" r="1233" b="1302"> </charParams>
+<charParams l="1234" t="1281" r="1252" b="1302" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="33" wordPenalty="0" meanStrokeWidth="45">a</charParams>
+<charParams l="1254" t="1280" r="1274" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="50" wordPenalty="0" meanStrokeWidth="45">v</charParams>
+<charParams l="1275" t="1281" r="1296" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="45">o</charParams>
+<charParams l="1298" t="1268" r="1306" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="45">i</charParams>
+<charParams l="1310" t="1281" r="1325" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="45">r</charParams>
+<charParams l="1326" t="1266" r="1339" b="1301"> </charParams>
+<charParams l="1340" t="1266" r="1348" b="1300" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1351" t="1279" r="1369" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1370" t="1279" r="1391" b="1301"> </charParams>
+<charParams l="1392" t="1280" r="1423" b="1300" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="27" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1426" t="1269" r="1443" b="1301" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="58" wordPenalty="0" meanStrokeWidth="37">&#234;</charParams>
+<charParams l="1445" t="1280" r="1477" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1480" t="1278" r="1497" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1498" t="1267" r="1511" b="1300"> </charParams>
+<charParams l="1512" t="1267" r="1531" b="1299" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="72" wordPenalty="19" meanStrokeWidth="39">d</charParams>
+<charParams l="1535" t="1266" r="1544" b="1298" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="0" wordPenalty="19" meanStrokeWidth="39">i</charParams>
+<charParams l="1547" t="1278" r="1563" b="1298" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="33" wordPenalty="19" meanStrokeWidth="39">a</charParams>
+<charParams l="1566" t="1279" r="1598" b="1299" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="27" wordPenalty="19" meanStrokeWidth="39">m</charParams>
+<charParams l="1600" t="1278" r="1618" b="1299" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="39">&#232;</charParams>
+<charParams l="1620" t="1276" r="1633" b="1299" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="61" wordPenalty="19" meanStrokeWidth="39">t</charParams>
+<charParams l="1636" t="1278" r="1651" b="1298" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="19" meanStrokeWidth="39">r</charParams>
+<charParams l="1653" t="1278" r="1671" b="1299" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="39">e</charParams>
+<charParams l="1672" t="1278" r="1685" b="1307"> </charParams>
+<charParams l="1686" t="1279" r="1703" b="1307" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">q</charParams>
+<charParams l="1707" t="1279" r="1725" b="1299" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1729" t="1277" r="1747" b="1299" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1748" t="1266" r="1769" b="1300"> </charParams>
+<charParams l="1770" t="1266" r="1779" b="1300" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="26" wordPenalty="0" meanStrokeWidth="41">l</charParams>
+<charParams l="1783" t="1279" r="1800" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1801" t="1267" r="1809" b="1309"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1810" t="1267" r="1844" b="1309" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="35">f</charParams>
+<charParams l="1837" t="1280" r="1854" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">o</charParams>
+<charParams l="1858" t="1281" r="1877" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="0" meanStrokeWidth="35">u</charParams>
+<charParams l="1881" t="1282" r="1896" b="1300" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="35">r</charParams>
+<charParams l="1897" t="1288" r="1913" b="1293" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="255" wordPenalty="0" meanStrokeWidth="35">&#172;</charParams></formatting></line>
+<line baseline="1345" l="1165" t="1309" r="1914" b="1354"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1165" t="1326" r="1187" b="1345" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">n</charParams>
+<charParams l="1187" t="1325" r="1203" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="77" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1205" t="1325" r="1223" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="95" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1228" t="1326" r="1247" b="1346" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1251" t="1339" r="1257" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">.</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1258" t="1311" r="1277" b="1345"> </charParams>
+<charParams l="1278" t="1311" r="1306" b="1345" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="88" wordPenalty="0" meanStrokeWidth="38">C</charParams>
+<charParams l="1310" t="1324" r="1326" b="1346" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1329" t="1325" r="1345" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1348" t="1313" r="1358" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1359" t="1313" r="1370" b="1345"> </charParams>
+<charParams l="1371" t="1323" r="1387" b="1344" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1391" t="1325" r="1409" b="1345" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1410" t="1324" r="1423" b="1345"> </charParams>
+<charParams l="1424" t="1324" r="1438" b="1344" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1441" t="1323" r="1458" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1461" t="1311" r="1486" b="1344" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1461" t="1311" r="1486" b="1344" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1488" t="1323" r="1505" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1506" t="1323" r="1517" b="1345"> </charParams>
+<charParams l="1518" t="1323" r="1533" b="1344" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1536" t="1309" r="1562" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1536" t="1309" r="1562" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1563" t="1309" r="1577" b="1343"> </charParams>
+<charParams l="1578" t="1323" r="1598" b="1343" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="86" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1600" t="1324" r="1620" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1623" t="1323" r="1640" b="1344" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1641" t="1323" r="1655" b="1344"> </charParams>
+<charParams l="1656" t="1324" r="1672" b="1343" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1675" t="1309" r="1707" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1675" t="1309" r="1707" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1702" t="1323" r="1717" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="60" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1721" t="1311" r="1729" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1732" t="1323" r="1746" b="1343" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1749" t="1323" r="1766" b="1345" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1767" t="1311" r="1784" b="1345"> </charParams>
+<charParams l="1785" t="1311" r="1804" b="1344" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="72" wordPenalty="2" meanStrokeWidth="37">d</charParams>
+<charParams l="1808" t="1311" r="1815" b="1324" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1818" t="1323" r="1836" b="1345" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1838" t="1324" r="1855" b="1344" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">x</charParams>
+<charParams l="1857" t="1325" r="1876" b="1354" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="96" wordPenalty="2" meanStrokeWidth="37">p</charParams>
+<charParams l="1880" t="1310" r="1896" b="1345" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="2" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="1898" t="1333" r="1914" b="1338" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">-</charParams></formatting></line>
+<line baseline="1390" l="1166" t="1354" r="1916" b="1399"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1166" t="1370" r="1180" b="1389" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1183" t="1357" r="1192" b="1390" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1195" t="1369" r="1212" b="1391" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1215" t="1370" r="1235" b="1391" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1238" t="1370" r="1254" b="1391" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1257" t="1370" r="1274" b="1392" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1284" t="1384" r="1292" b="1399" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1293" t="1354" r="1305" b="1399"> </charParams>
+<charParams l="1306" t="1354" r="1324" b="1390" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="48" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="1320" t="1371" r="1338" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1342" t="1370" r="1356" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1357" t="1355" r="1372" b="1390"> </charParams>
+<charParams l="1373" t="1355" r="1381" b="1388" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="26" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="1385" t="1368" r="1399" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="2" meanStrokeWidth="37">a</charParams>
+<charParams l="1403" t="1370" r="1420" b="1399" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">q</charParams>
+<charParams l="1423" t="1369" r="1441" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="1445" t="1368" r="1462" b="1389" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1464" t="1358" r="1472" b="1389" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="1476" t="1354" r="1484" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="51" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="1488" t="1368" r="1505" b="1389" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1506" t="1368" r="1526" b="1389"> </charParams>
+<charParams l="1527" t="1368" r="1547" b="1388" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1550" t="1367" r="1570" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1571" t="1367" r="1582" b="1388"> </charParams>
+<charParams l="1583" t="1368" r="1605" b="1388" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1606" t="1355" r="1614" b="1368" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1617" t="1368" r="1635" b="1388" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1636" t="1368" r="1648" b="1397"> </charParams>
+<charParams l="1649" t="1368" r="1668" b="1397" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="96" wordPenalty="2" meanStrokeWidth="36">p</charParams>
+<charParams l="1672" t="1367" r="1688" b="1387" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="33" wordPenalty="2" meanStrokeWidth="36">a</charParams>
+<charParams l="1689" t="1368" r="1701" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="10" wordPenalty="2" meanStrokeWidth="36">s</charParams>
+<charParams l="1702" t="1367" r="1718" b="1388"> </charParams>
+<charParams l="1719" t="1367" r="1736" b="1388" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1739" t="1367" r="1759" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1763" t="1368" r="1778" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1781" t="1368" r="1800" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1802" t="1368" r="1817" b="1388" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1820" t="1368" r="1837" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1838" t="1356" r="1856" b="1390"> </charParams>
+<charParams l="1857" t="1356" r="1875" b="1389" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">f</charParams>
+<charParams l="1872" t="1369" r="1887" b="1389" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="60" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1889" t="1357" r="1899" b="1390" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1903" t="1366" r="1916" b="1391" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams></formatting></line>
+<line baseline="1433" l="1169" t="1399" r="1917" b="1443"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="1401" r="1187" b="1434" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="50" wordPenalty="1" meanStrokeWidth="38">b</charParams>
+<charParams l="1191" t="1414" r="1208" b="1435" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="83" wordPenalty="1" meanStrokeWidth="38">e</charParams>
+<charParams l="1210" t="1414" r="1227" b="1435" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="33" wordPenalty="1" meanStrokeWidth="38">a</charParams>
+<charParams l="1229" t="1416" r="1248" b="1436" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="1251" t="1415" r="1266" b="1436" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="26" wordPenalty="1" meanStrokeWidth="38">c</charParams>
+<charParams l="1269" t="1415" r="1289" b="1436" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="1" meanStrokeWidth="38">o</charParams>
+<charParams l="1291" t="1415" r="1310" b="1436" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="97" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="1313" t="1414" r="1333" b="1443" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="96" wordPenalty="1" meanStrokeWidth="38">p</charParams>
+<charParams l="1334" t="1401" r="1356" b="1443"> </charParams>
+<charParams l="1357" t="1401" r="1377" b="1434" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1380" t="1401" r="1386" b="1414" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1390" t="1414" r="1409" b="1434" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1413" t="1400" r="1431" b="1434" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">b</charParams>
+<charParams l="1434" t="1399" r="1451" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="48" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1449" t="1413" r="1465" b="1434" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1469" t="1413" r="1482" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1485" t="1413" r="1505" b="1434" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">v</charParams>
+<charParams l="1508" t="1413" r="1523" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1526" t="1410" r="1539" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1541" t="1400" r="1550" b="1432" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1554" t="1413" r="1573" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1576" t="1412" r="1595" b="1432" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1599" t="1412" r="1610" b="1432" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="10" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1613" t="1426" r="1620" b="1433" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">.</charParams>
+<charParams l="1621" t="1400" r="1641" b="1433"> </charParams>
+<charParams l="1642" t="1400" r="1672" b="1433" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="255" wordPenalty="0" meanStrokeWidth="43">O</charParams>
+<charParams l="1677" t="1412" r="1699" b="1432" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="43">n</charParams>
+<charParams l="1700" t="1412" r="1720" b="1442"> </charParams>
+<charParams l="1721" t="1412" r="1740" b="1442" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="1744" t="1412" r="1760" b="1434" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1763" t="1413" r="1783" b="1433" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1787" t="1411" r="1799" b="1434" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1800" t="1411" r="1818" b="1434"> </charParams>
+<charParams l="1819" t="1413" r="1839" b="1434" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1842" t="1400" r="1857" b="1434" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="39">&#233;</charParams>
+<charParams l="1859" t="1413" r="1876" b="1434" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1878" t="1414" r="1898" b="1434" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1900" t="1422" r="1917" b="1427" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#172;</charParams></formatting></line>
+<line baseline="1478" l="1169" t="1444" r="1918" b="1487"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="1459" r="1200" b="1479" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1204" t="1460" r="1222" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="1226" t="1447" r="1235" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1240" t="1460" r="1257" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1260" t="1460" r="1274" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1275" t="1460" r="1291" b="1480"> </charParams>
+<charParams l="1292" t="1460" r="1309" b="1480" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="53" wordPenalty="12" meanStrokeWidth="29">a</charParams>
+<charParams l="1311" t="1446" r="1344" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="12" meanStrokeWidth="29">s</charParams>
+<charParams l="1311" t="1446" r="1344" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="12" meanStrokeWidth="29">s</charParams>
+<charParams l="1338" t="1459" r="1356" b="1479" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="12" meanStrokeWidth="29">u</charParams>
+<charParams l="1360" t="1458" r="1374" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="12" meanStrokeWidth="29">r</charParams>
+<charParams l="1376" t="1458" r="1393" b="1479" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="12" meanStrokeWidth="29">e</charParams>
+<charParams l="1397" t="1458" r="1411" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="12" meanStrokeWidth="29">r</charParams>
+<charParams l="1412" t="1458" r="1437" b="1487"> </charParams>
+<charParams l="1438" t="1458" r="1457" b="1487" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1459" t="1458" r="1480" b="1478" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1481" t="1445" r="1490" b="1458" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1494" t="1457" r="1510" b="1478" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1513" t="1457" r="1532" b="1477" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1533" t="1444" r="1560" b="1477"> </charParams>
+<charParams l="1561" t="1444" r="1579" b="1477" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="50" wordPenalty="6" meanStrokeWidth="37">f</charParams>
+<charParams l="1575" t="1456" r="1592" b="1477" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="60" wordPenalty="6" meanStrokeWidth="37">a</charParams>
+<charParams l="1594" t="1445" r="1603" b="1477" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="6" meanStrokeWidth="37">i</charParams>
+<charParams l="1606" t="1444" r="1622" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="48" wordPenalty="6" meanStrokeWidth="37">s</charParams>
+<charParams l="1617" t="1457" r="1634" b="1477" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="64" wordPenalty="6" meanStrokeWidth="37">a</charParams>
+<charParams l="1635" t="1456" r="1655" b="1477" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="6" meanStrokeWidth="37">n</charParams>
+<charParams l="1659" t="1454" r="1672" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="6" meanStrokeWidth="37">t</charParams>
+<charParams l="1673" t="1454" r="1690" b="1478"> </charParams>
+<charParams l="1691" t="1457" r="1711" b="1477" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1715" t="1458" r="1734" b="1477" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1735" t="1446" r="1747" b="1487"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1748" t="1446" r="1780" b="1487" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="1774" t="1459" r="1791" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="1794" t="1459" r="1814" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1818" t="1460" r="1832" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1834" t="1459" r="1854" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1859" t="1459" r="1873" b="1478" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="8" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1876" t="1459" r="1894" b="1479" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="95" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1897" t="1459" r="1918" b="1480" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams></formatting></line>
+<line baseline="1523" l="1168" t="1488" r="1920" b="1532"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1168" t="1490" r="1186" b="1523" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1192" t="1503" r="1208" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1209" t="1503" r="1231" b="1525"> </charParams>
+<charParams l="1232" t="1504" r="1264" b="1525" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="12" meanStrokeWidth="38">m</charParams>
+<charParams l="1267" t="1504" r="1283" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="60" wordPenalty="12" meanStrokeWidth="38">a</charParams>
+<charParams l="1286" t="1503" r="1304" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="12" meanStrokeWidth="38">n</charParams>
+<charParams l="1307" t="1491" r="1316" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="0" wordPenalty="12" meanStrokeWidth="38">i</charParams>
+<charParams l="1320" t="1503" r="1337" b="1524" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="12" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1341" t="1504" r="1354" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="100" wordPenalty="12" meanStrokeWidth="38">r</charParams>
+<charParams l="1357" t="1502" r="1374" b="1523" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="12" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1375" t="1502" r="1392" b="1532"> </charParams>
+<charParams l="1393" t="1503" r="1410" b="1532" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1414" t="1503" r="1433" b="1523" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1435" t="1490" r="1443" b="1503" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1447" t="1491" r="1455" b="1523" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1459" t="1489" r="1467" b="1524" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1468" t="1489" r="1490" b="1524"> </charParams>
+<charParams l="1491" t="1503" r="1507" b="1523" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="60" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1509" t="1490" r="1518" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1522" t="1488" r="1529" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1533" t="1488" r="1540" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1545" t="1501" r="1562" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1563" t="1499" r="1582" b="1522"> </charParams>
+<charParams l="1583" t="1499" r="1595" b="1522" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1597" t="1502" r="1617" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1619" t="1502" r="1639" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="97" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1642" t="1489" r="1648" b="1529" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="19" wordPenalty="0" meanStrokeWidth="40">j</charParams>
+<charParams l="1653" t="1502" r="1672" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1676" t="1503" r="1694" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1698" t="1502" r="1712" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1713" t="1502" r="1726" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="41" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1727" t="1502" r="1751" b="1524"> </charParams>
+<charParams l="1752" t="1503" r="1771" b="1524" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="44">e</charParams>
+<charParams l="1773" t="1503" r="1793" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="100" wordPenalty="0" meanStrokeWidth="44">n</charParams>
+<charParams l="1794" t="1503" r="1814" b="1523"> </charParams>
+<charParams l="1815" t="1503" r="1830" b="1523" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1833" t="1489" r="1849" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">&#233;</charParams>
+<charParams l="1852" t="1500" r="1866" b="1524" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1869" t="1503" r="1883" b="1522" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1885" t="1489" r="1902" b="1523" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="75" wordPenalty="0" meanStrokeWidth="40">&#233;</charParams>
+<charParams l="1903" t="1510" r="1920" b="1516" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#172;</charParams></formatting></line>
+<line baseline="1568" l="1169" t="1533" r="1921" b="1578"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="1547" r="1185" b="1568" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1188" t="1536" r="1195" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1200" t="1534" r="1233" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1200" t="1534" r="1233" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1227" t="1550" r="1242" b="1570" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1246" t="1549" r="1264" b="1570" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1269" t="1546" r="1282" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1283" t="1546" r="1293" b="1577"> </charParams>
+<charParams l="1294" t="1562" r="1303" b="1577" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="67" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1304" t="1535" r="1319" b="1577"> </charParams>
+<charParams l="1320" t="1535" r="1330" b="1569" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1333" t="1535" r="1341" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1342" t="1535" r="1358" b="1569"> </charParams>
+<charParams l="1359" t="1548" r="1376" b="1568" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="64" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1378" t="1535" r="1396" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="71" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="1400" t="1548" r="1433" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1435" t="1547" r="1452" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1455" t="1545" r="1468" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="78" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1471" t="1546" r="1483" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1485" t="1547" r="1500" b="1567" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1502" t="1547" r="1518" b="1567" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1519" t="1547" r="1532" b="1576"> </charParams>
+<charParams l="1533" t="1547" r="1554" b="1576" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">p</charParams>
+<charParams l="1557" t="1533" r="1565" b="1566" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="1568" t="1546" r="1588" b="1567" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="1589" t="1546" r="1602" b="1567" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="25" wordPenalty="2" meanStrokeWidth="38">s</charParams>
+<charParams l="1603" t="1534" r="1616" b="1567"> </charParams>
+<charParams l="1617" t="1534" r="1638" b="1567" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1641" t="1534" r="1647" b="1546" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="1651" t="1546" r="1667" b="1567" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="64" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1670" t="1534" r="1680" b="1567" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="40">i</charParams>
+<charParams l="1682" t="1546" r="1697" b="1567" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1698" t="1546" r="1715" b="1578"> </charParams>
+<charParams l="1716" t="1548" r="1735" b="1578" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="1737" t="1547" r="1756" b="1568" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1758" t="1535" r="1765" b="1549" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="1770" t="1536" r="1779" b="1569" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1782" t="1535" r="1791" b="1568" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1792" t="1535" r="1810" b="1569"> </charParams>
+<charParams l="1811" t="1548" r="1833" b="1569" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1836" t="1547" r="1854" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="1855" t="1534" r="1874" b="1569"> </charParams>
+<charParams l="1875" t="1534" r="1884" b="1568" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="26" wordPenalty="0" meanStrokeWidth="46">l</charParams>
+<charParams l="1888" t="1548" r="1906" b="1569" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="91" wordPenalty="0" meanStrokeWidth="46">u</charParams>
+<charParams l="1909" t="1534" r="1921" b="1568" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="0" wordPenalty="0" meanStrokeWidth="46">i</charParams></formatting></line>
+<line baseline="1614" l="1169" t="1581" r="1299" b="1614"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="1592" r="1186" b="1614" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1190" t="1593" r="1210" b="1613" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1211" t="1581" r="1223" b="1614"> </charParams>
+<charParams l="1224" t="1581" r="1241" b="1614" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="50" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="1237" t="1593" r="1254" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="64" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1256" t="1594" r="1274" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1278" t="1591" r="1291" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1294" t="1608" r="1299" b="1614" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="99" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="1657" l="1215" t="1621" r="1922" b="1666"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1215" t="1625" r="1243" b="1659" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="98" wordPenalty="0" meanStrokeWidth="38">A</charParams>
+<charParams l="1245" t="1638" r="1266" b="1659" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="86" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1267" t="1638" r="1286" b="1659"> </charParams>
+<charParams l="1287" t="1638" r="1302" b="1658" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1305" t="1638" r="1322" b="1660" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1325" t="1624" r="1349" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1325" t="1624" r="1349" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1352" t="1637" r="1369" b="1659" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1382" t="1651" r="1390" b="1666" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="48" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">,</charParams>
+<charParams l="1391" t="1623" r="1405" b="1666"> </charParams>
+<charParams l="1406" t="1623" r="1431" b="1658" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">s</charParams>
+<charParams l="1406" t="1623" r="1431" b="1658" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">i</charParams>
+<charParams l="1432" t="1623" r="1449" b="1658"> </charParams>
+<charParams l="1450" t="1623" r="1460" b="1657" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="42">l</charParams>
+<charParams l="1462" t="1624" r="1469" b="1637" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">&#8217;</charParams>
+<charParams l="1473" t="1636" r="1494" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="1496" t="1635" r="1516" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1517" t="1635" r="1541" b="1666"> </charParams>
+<charParams l="1542" t="1636" r="1562" b="1666" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="3" meanStrokeWidth="40">p</charParams>
+<charParams l="1566" t="1634" r="1582" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="82" wordPenalty="3" meanStrokeWidth="40">e</charParams>
+<charParams l="1585" t="1635" r="1605" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="100" wordPenalty="3" meanStrokeWidth="40">n</charParams>
+<charParams l="1608" t="1621" r="1627" b="1655" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="48" wordPenalty="3" meanStrokeWidth="40">s</charParams>
+<charParams l="1622" t="1635" r="1640" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="3" meanStrokeWidth="40">e</charParams>
+<charParams l="1641" t="1635" r="1659" b="1666"> </charParams>
+<charParams l="1660" t="1636" r="1679" b="1666" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">q</charParams>
+<charParams l="1681" t="1637" r="1700" b="1657" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1703" t="1622" r="1712" b="1636" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1715" t="1638" r="1733" b="1657" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1737" t="1636" r="1757" b="1657" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1758" t="1624" r="1772" b="1658"> </charParams>
+<charParams l="1773" t="1624" r="1807" b="1658" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="255" wordPenalty="4" meanStrokeWidth="41">s</charParams>
+<charParams l="1773" t="1624" r="1807" b="1658" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="255" wordPenalty="4" meanStrokeWidth="41">o</charParams>
+<charParams l="1809" t="1637" r="1826" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="91" wordPenalty="4" meanStrokeWidth="41">u</charParams>
+<charParams l="1831" t="1637" r="1849" b="1665" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="4" meanStrokeWidth="41">p</charParams>
+<charParams l="1852" t="1623" r="1860" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="0" wordPenalty="4" meanStrokeWidth="41">i</charParams>
+<charParams l="1863" t="1637" r="1878" b="1657" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="4" meanStrokeWidth="41">r</charParams>
+<charParams l="1880" t="1636" r="1896" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="33" wordPenalty="4" meanStrokeWidth="41">a</charParams>
+<charParams l="1899" t="1623" r="1907" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="0" wordPenalty="4" meanStrokeWidth="41">i</charParams>
+<charParams l="1910" t="1623" r="1922" b="1656" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="4" meanStrokeWidth="41">l</charParams></formatting></line>
+<line baseline="1701" l="1170" t="1666" r="1920" b="1709"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1170" t="1669" r="1189" b="1702" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1193" t="1682" r="1210" b="1703" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1211" t="1682" r="1235" b="1704"> </charParams>
+<charParams l="1236" t="1684" r="1267" b="1704" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1271" t="1671" r="1288" b="1704" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="58" wordPenalty="0" meanStrokeWidth="37">&#234;</charParams>
+<charParams l="1291" t="1684" r="1322" b="1704" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1327" t="1683" r="1344" b="1704" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1345" t="1670" r="1370" b="1704"> </charParams>
+<charParams l="1371" t="1670" r="1389" b="1703" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="80" wordPenalty="19" meanStrokeWidth="37">d</charParams>
+<charParams l="1395" t="1670" r="1402" b="1702" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="19" meanStrokeWidth="37">i</charParams>
+<charParams l="1407" t="1682" r="1422" b="1702" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="53" wordPenalty="19" meanStrokeWidth="37">a</charParams>
+<charParams l="1426" t="1682" r="1456" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="27" wordPenalty="19" meanStrokeWidth="37">m</charParams>
+<charParams l="1459" t="1681" r="1477" b="1702" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="82" wordPenalty="19" meanStrokeWidth="37">&#232;</charParams>
+<charParams l="1479" t="1678" r="1493" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="19" meanStrokeWidth="37">t</charParams>
+<charParams l="1495" t="1681" r="1509" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="100" wordPenalty="19" meanStrokeWidth="37">r</charParams>
+<charParams l="1511" t="1680" r="1529" b="1702" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="37">e</charParams>
+<charParams l="1530" t="1680" r="1554" b="1709"> </charParams>
+<charParams l="1555" t="1681" r="1574" b="1709" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="255" wordPenalty="1" meanStrokeWidth="38">q</charParams>
+<charParams l="1576" t="1680" r="1595" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="1598" t="1679" r="1615" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="82" wordPenalty="1" meanStrokeWidth="38">e</charParams>
+<charParams l="1616" t="1666" r="1641" b="1700"> </charParams>
+<charParams l="1642" t="1666" r="1652" b="1699" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="44">l</charParams>
+<charParams l="1655" t="1680" r="1673" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="83" wordPenalty="0" meanStrokeWidth="44">e</charParams>
+<charParams l="1674" t="1667" r="1688" b="1709"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1689" t="1667" r="1719" b="1709" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="1712" t="1681" r="1730" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">o</charParams>
+<charParams l="1733" t="1681" r="1752" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1756" t="1682" r="1771" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1773" t="1681" r="1792" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1796" t="1681" r="1811" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="77" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1812" t="1681" r="1831" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1835" t="1681" r="1854" b="1700" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1855" t="1680" r="1877" b="1700"> </charParams>
+<charParams l="1878" t="1680" r="1897" b="1700" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1901" t="1679" r="1920" b="1701" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="83" wordPenalty="0" meanStrokeWidth="42">e</charParams></formatting></line>
+<line baseline="1745" l="1170" t="1711" r="1918" b="1757"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1170" t="1712" r="1188" b="1746" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="48" wordPenalty="8" meanStrokeWidth="37">s</charParams>
+<charParams l="1186" t="1727" r="1202" b="1746" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="91" wordPenalty="8" meanStrokeWidth="37">u</charParams>
+<charParams l="1207" t="1714" r="1238" b="1748" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="8" meanStrokeWidth="37">f</charParams>
+<charParams l="1207" t="1714" r="1238" b="1748" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="8" meanStrokeWidth="37">f</charParams>
+<charParams l="1207" t="1714" r="1238" b="1748" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="8" meanStrokeWidth="37">i</charParams>
+<charParams l="1242" t="1714" r="1260" b="1748" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="48" wordPenalty="8" meanStrokeWidth="37">s</charParams>
+<charParams l="1256" t="1727" r="1273" b="1749" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="83" wordPenalty="8" meanStrokeWidth="37">e</charParams>
+<charParams l="1274" t="1727" r="1286" b="1757"> </charParams>
+<charParams l="1287" t="1728" r="1305" b="1757" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="96" wordPenalty="0" meanStrokeWidth="32">p</charParams>
+<charParams l="1308" t="1727" r="1324" b="1747" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="64" wordPenalty="0" meanStrokeWidth="32">a</charParams>
+<charParams l="1326" t="1727" r="1338" b="1748" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="41" wordPenalty="0" meanStrokeWidth="32">s</charParams>
+<charParams l="1350" t="1741" r="1358" b="1755" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="56" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1359" t="1715" r="1372" b="1755"> </charParams>
+<charParams l="1373" t="1715" r="1382" b="1747" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="7" meanStrokeWidth="38">i</charParams>
+<charParams l="1386" t="1713" r="1394" b="1746" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="255" wordPenalty="7" meanStrokeWidth="38">l</charParams>
+<charParams l="1403" t="1713" r="1421" b="1746" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="50" wordPenalty="7" meanStrokeWidth="38">f</charParams>
+<charParams l="1415" t="1726" r="1431" b="1746" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="53" wordPenalty="7" meanStrokeWidth="38">a</charParams>
+<charParams l="1433" t="1726" r="1454" b="1745" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="7" meanStrokeWidth="38">u</charParams>
+<charParams l="1456" t="1713" r="1473" b="1745" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="0" wordPenalty="7" meanStrokeWidth="38">d</charParams>
+<charParams l="1478" t="1725" r="1494" b="1744" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="7" meanStrokeWidth="38">r</charParams>
+<charParams l="1496" t="1725" r="1515" b="1744" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="7" meanStrokeWidth="38">o</charParams>
+<charParams l="1518" t="1712" r="1529" b="1744" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="0" wordPenalty="7" meanStrokeWidth="38">i</charParams>
+<charParams l="1532" t="1723" r="1544" b="1744" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="61" wordPenalty="7" meanStrokeWidth="38">t</charParams>
+<charParams l="1545" t="1723" r="1557" b="1751"> </charParams>
+<charParams l="1558" t="1736" r="1567" b="1751" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="-1" serifProbability="255" wordPenalty="0" meanStrokeWidth="20">&gt;</charParams>
+<charParams l="1568" t="1724" r="1579" b="1751"> </charParams>
+<charParams l="1580" t="1724" r="1601" b="1743" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1603" t="1723" r="1622" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="1626" t="1723" r="1645" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">n</charParams>
+<charParams l="1646" t="1711" r="1657" b="1743"> </charParams>
+<charParams l="1658" t="1711" r="1666" b="1743" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="1" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="2" meanStrokeWidth="39">l</charParams>
+<charParams l="1671" t="1711" r="1679" b="1723" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="18" meanStrokeWidth="39">'</charParams>
+<charParams l="1681" t="1712" r="1698" b="1744" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="75" wordPenalty="18" meanStrokeWidth="39">&#233;</charParams>
+<charParams l="1699" t="1711" r="1709" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="18" meanStrokeWidth="39">l</charParams>
+<charParams l="1710" t="1723" r="1728" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="18" meanStrokeWidth="39">e</charParams>
+<charParams l="1731" t="1723" r="1751" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="18" meanStrokeWidth="39">v</charParams>
+<charParams l="1752" t="1724" r="1769" b="1745" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="18" meanStrokeWidth="39">e</charParams>
+<charParams l="1772" t="1724" r="1787" b="1744" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="18" meanStrokeWidth="39">r</charParams>
+<charParams l="1788" t="1724" r="1795" b="1744"> </charParams>
+<charParams l="1796" t="1724" r="1816" b="1744" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="4" meanStrokeWidth="39">n</charParams>
+<charParams l="1819" t="1712" r="1830" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="4" meanStrokeWidth="39">i</charParams>
+<charParams l="1831" t="1711" r="1837" b="1743"> </charParams>
+<charParams l="1838" t="1711" r="1856" b="1743" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="50" wordPenalty="10" meanStrokeWidth="39">f</charParams>
+<charParams l="1851" t="1724" r="1867" b="1743" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="53" wordPenalty="10" meanStrokeWidth="39">a</charParams>
+<charParams l="1870" t="1712" r="1878" b="1744" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="10" meanStrokeWidth="39">i</charParams>
+<charParams l="1883" t="1724" r="1897" b="1743" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="10" meanStrokeWidth="39">r</charParams>
+<charParams l="1900" t="1724" r="1918" b="1745" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="10" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="1788" l="1170" t="1753" r="1920" b="1799"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1170" t="1770" r="1188" b="1799" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="96" wordPenalty="2" meanStrokeWidth="39">p</charParams>
+<charParams l="1191" t="1757" r="1199" b="1789" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">l</charParams>
+<charParams l="1203" t="1770" r="1221" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="91" wordPenalty="2" meanStrokeWidth="39">u</charParams>
+<charParams l="1225" t="1757" r="1247" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">s</charParams>
+<charParams l="1225" t="1757" r="1247" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="39">i</charParams>
+<charParams l="1249" t="1771" r="1267" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="82" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="1271" t="1771" r="1289" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="91" wordPenalty="2" meanStrokeWidth="39">u</charParams>
+<charParams l="1292" t="1771" r="1306" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">r</charParams>
+<charParams l="1307" t="1771" r="1319" b="1791" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="10" wordPenalty="2" meanStrokeWidth="39">s</charParams>
+<charParams l="1320" t="1771" r="1335" b="1798"> </charParams>
+<charParams l="1336" t="1771" r="1356" b="1798" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="1359" t="1771" r="1378" b="1790" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1380" t="1770" r="1395" b="1789" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1397" t="1767" r="1409" b="1789" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1412" t="1768" r="1429" b="1788" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1430" t="1766" r="1443" b="1788" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="41" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1444" t="1766" r="1458" b="1788"> </charParams>
+<charParams l="1459" t="1766" r="1472" b="1788" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="1474" t="1768" r="1494" b="1787" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1496" t="1767" r="1515" b="1786" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">u</charParams>
+<charParams l="1519" t="1765" r="1531" b="1786" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="61" wordPenalty="0" meanStrokeWidth="41">t</charParams>
+<charParams l="1532" t="1765" r="1545" b="1786"> </charParams>
+<charParams l="1546" t="1767" r="1562" b="1786" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="60" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1566" t="1767" r="1584" b="1786" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1588" t="1764" r="1601" b="1786" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1603" t="1766" r="1622" b="1786" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="89" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1626" t="1766" r="1644" b="1785" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1648" t="1765" r="1663" b="1785" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1664" t="1755" r="1673" b="1787"> </charParams>
+<charParams l="1674" t="1755" r="1694" b="1787" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1698" t="1767" r="1715" b="1787" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1716" t="1753" r="1730" b="1787"> </charParams>
+<charParams l="1731" t="1753" r="1749" b="1786" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="48" wordPenalty="2" meanStrokeWidth="41">f</charParams>
+<charParams l="1744" t="1767" r="1763" b="1787" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="2" meanStrokeWidth="41">o</charParams>
+<charParams l="1767" t="1756" r="1774" b="1788" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="2" meanStrokeWidth="41">l</charParams>
+<charParams l="1775" t="1755" r="1788" b="1788"> </charParams>
+<charParams l="1789" t="1755" r="1807" b="1787" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1812" t="1768" r="1832" b="1787" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1833" t="1766" r="1847" b="1787"> </charParams>
+<charParams l="1848" t="1766" r="1865" b="1787" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1866" t="1768" r="1884" b="1789" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1887" t="1768" r="1906" b="1788" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1907" t="1774" r="1920" b="1781" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#172;</charParams></formatting></line>
+<line baseline="1831" l="1168" t="1796" r="1918" b="1842"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1168" t="1801" r="1188" b="1833" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1191" t="1813" r="1206" b="1833" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1208" t="1801" r="1216" b="1833" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1219" t="1814" r="1236" b="1835" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1240" t="1814" r="1255" b="1834" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1256" t="1814" r="1268" b="1842"> </charParams>
+<charParams l="1269" t="1828" r="1278" b="1842" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1279" t="1813" r="1293" b="1842"> </charParams>
+<charParams l="1294" t="1813" r="1310" b="1833" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1313" t="1813" r="1330" b="1834" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1332" t="1800" r="1339" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1343" t="1813" r="1359" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="60" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1360" t="1799" r="1371" b="1832"> </charParams>
+<charParams l="1372" t="1799" r="1391" b="1832" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="48" wordPenalty="0" meanStrokeWidth="42">f</charParams>
+<charParams l="1385" t="1812" r="1403" b="1832" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="83" wordPenalty="0" meanStrokeWidth="42">e</charParams>
+<charParams l="1405" t="1811" r="1420" b="1830" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">r</charParams>
+<charParams l="1422" t="1811" r="1441" b="1831" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="1444" t="1799" r="1453" b="1830" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="0" wordPenalty="0" meanStrokeWidth="42">i</charParams>
+<charParams l="1456" t="1809" r="1469" b="1831" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="61" wordPenalty="0" meanStrokeWidth="42">t</charParams>
+<charParams l="1470" t="1799" r="1483" b="1831"> </charParams>
+<charParams l="1484" t="1799" r="1494" b="1830" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1498" t="1810" r="1517" b="1830" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1521" t="1810" r="1539" b="1829" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1543" t="1807" r="1557" b="1829" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1557" t="1797" r="1567" b="1829" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1567" t="1796" r="1577" b="1829" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1581" t="1808" r="1599" b="1829" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1609" t="1822" r="1617" b="1836" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="50" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1618" t="1809" r="1631" b="1836"> </charParams>
+<charParams l="1632" t="1809" r="1665" b="1829" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="44" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1668" t="1810" r="1684" b="1830" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1686" t="1798" r="1695" b="1830" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1697" t="1810" r="1710" b="1830" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="10" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1711" t="1810" r="1724" b="1830"> </charParams>
+<charParams l="1725" t="1810" r="1742" b="1829" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="33" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1743" t="1809" r="1763" b="1840" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="53" wordPenalty="0" meanStrokeWidth="39">g</charParams>
+<charParams l="1765" t="1811" r="1781" b="1831" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1783" t="1812" r="1800" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1802" t="1811" r="1821" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1825" t="1798" r="1842" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1846" t="1799" r="1856" b="1831" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1861" t="1812" r="1874" b="1832" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1875" t="1798" r="1886" b="1832"> </charParams>
+<charParams l="1887" t="1798" r="1897" b="1832" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="26" wordPenalty="0" meanStrokeWidth="49">l</charParams>
+<charParams l="1899" t="1812" r="1918" b="1834" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="83" wordPenalty="0" meanStrokeWidth="49">e</charParams></formatting></line>
+<line baseline="1875" l="1168" t="1840" r="1920" b="1886"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1168" t="1844" r="1186" b="1876" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="72" wordPenalty="19" meanStrokeWidth="38">d</charParams>
+<charParams l="1191" t="1845" r="1199" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="0" wordPenalty="19" meanStrokeWidth="38">i</charParams>
+<charParams l="1202" t="1857" r="1218" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="53" wordPenalty="19" meanStrokeWidth="38">a</charParams>
+<charParams l="1221" t="1856" r="1251" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="51" wordPenalty="19" meanStrokeWidth="38">m</charParams>
+<charParams l="1255" t="1856" r="1272" b="1876" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="38">&#232;</charParams>
+<charParams l="1276" t="1854" r="1288" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="19" meanStrokeWidth="38">t</charParams>
+<charParams l="1288" t="1855" r="1303" b="1875" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="19" meanStrokeWidth="38">r</charParams>
+<charParams l="1306" t="1855" r="1323" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="38">e</charParams>
+<charParams l="1324" t="1843" r="1338" b="1876"> </charParams>
+<charParams l="1339" t="1843" r="1358" b="1875" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1363" t="1855" r="1381" b="1874" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1382" t="1853" r="1397" b="1874"> </charParams>
+<charParams l="1398" t="1853" r="1415" b="1874" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">c</charParams>
+<charParams l="1416" t="1853" r="1434" b="1874" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1437" t="1854" r="1456" b="1873" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1459" t="1841" r="1478" b="1873" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="72" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="1480" t="1853" r="1495" b="1873" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1497" t="1841" r="1506" b="1873" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1509" t="1853" r="1527" b="1874" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1529" t="1853" r="1543" b="1872" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1544" t="1840" r="1554" b="1873"> </charParams>
+<charParams l="1555" t="1840" r="1564" b="1873" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1569" t="1853" r="1587" b="1873" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1590" t="1841" r="1599" b="1872" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1603" t="1861" r="1618" b="1866" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">-</charParams>
+<charParams l="1621" t="1853" r="1653" b="1872" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1655" t="1841" r="1673" b="1874" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="75" wordPenalty="0" meanStrokeWidth="37">&#233;</charParams>
+<charParams l="1677" t="1854" r="1706" b="1873" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="0" meanStrokeWidth="37">m</charParams>
+<charParams l="1711" t="1854" r="1728" b="1875" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1729" t="1854" r="1741" b="1875"> </charParams>
+<charParams l="1742" t="1855" r="1748" b="1874" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="71" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">:</charParams>
+<charParams l="1749" t="1845" r="1763" b="1877"> </charParams>
+<charParams l="1764" t="1845" r="1797" b="1877" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&amp;</charParams>
+<charParams l="1798" t="1845" r="1809" b="1886"> </charParams>
+<charParams l="1810" t="1857" r="1830" b="1886" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="96" wordPenalty="0" meanStrokeWidth="42">p</charParams>
+<charParams l="1833" t="1856" r="1849" b="1877" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="33" wordPenalty="0" meanStrokeWidth="42">a</charParams>
+<charParams l="1852" t="1856" r="1866" b="1876" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="42">r</charParams>
+<charParams l="1867" t="1856" r="1880" b="1877"> </charParams>
+<charParams l="1881" t="1856" r="1898" b="1877" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="47">c</charParams>
+<charParams l="1900" t="1856" r="1920" b="1878" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="47">e</charParams></formatting></line>
+<line baseline="1919" l="1168" t="1884" r="1919" b="1933"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1168" t="1899" r="1199" b="1918" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="51" wordPenalty="0" meanStrokeWidth="41">m</charParams>
+<charParams l="1203" t="1898" r="1222" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="41">o</charParams>
+<charParams l="1225" t="1899" r="1244" b="1929" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="49" wordPenalty="0" meanStrokeWidth="41">y</charParams>
+<charParams l="1247" t="1898" r="1264" b="1919" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1266" t="1899" r="1287" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="58" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">n</charParams>
+<charParams l="1288" t="1899" r="1299" b="1919"> </charParams>
+<charParams l="1300" t="1899" r="1319" b="1919" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="46">o</charParams>
+<charParams l="1322" t="1898" r="1343" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="46">n</charParams>
+<charParams l="1344" t="1898" r="1356" b="1918"> </charParams>
+<charParams l="1357" t="1898" r="1373" b="1918" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1376" t="1898" r="1394" b="1918" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1398" t="1898" r="1413" b="1917" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1414" t="1898" r="1435" b="1918" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1438" t="1885" r="1446" b="1917" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1450" t="1895" r="1463" b="1918" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1464" t="1895" r="1477" b="1918"> </charParams>
+<charParams l="1478" t="1898" r="1497" b="1918" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1501" t="1897" r="1520" b="1917" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1524" t="1896" r="1541" b="1917" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1542" t="1896" r="1555" b="1926"> </charParams>
+<charParams l="1556" t="1897" r="1574" b="1926" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="96" wordPenalty="0" meanStrokeWidth="40">p</charParams>
+<charParams l="1577" t="1896" r="1597" b="1917" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1599" t="1896" r="1614" b="1916" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1617" t="1894" r="1630" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1632" t="1897" r="1650" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1651" t="1897" r="1660" b="1927"> </charParams>
+<charParams l="1661" t="1899" r="1682" b="1927" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="83" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="1684" t="1884" r="1692" b="1918" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1696" t="1899" r="1713" b="1919" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1716" t="1898" r="1729" b="1919" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="25" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1730" t="1886" r="1743" b="1919"> </charParams>
+<charParams l="1744" t="1886" r="1751" b="1919" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="51" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1755" t="1901" r="1772" b="1921" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="64" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1774" t="1900" r="1789" b="1920" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">r</charParams>
+<charParams l="1792" t="1901" r="1811" b="1931" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="53" wordPenalty="0" meanStrokeWidth="40">g</charParams>
+<charParams l="1814" t="1900" r="1831" b="1922" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1832" t="1900" r="1845" b="1933"> </charParams>
+<charParams l="1846" t="1900" r="1854" b="1933" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="19" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">;</charParams>
+<charParams l="1855" t="1900" r="1865" b="1933"> </charParams>
+<charParams l="1866" t="1900" r="1883" b="1922" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="1885" t="1901" r="1901" b="1921" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="64" wordPenalty="0" meanStrokeWidth="41">a</charParams>
+<charParams l="1904" t="1901" r="1919" b="1922" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="41">r</charParams></formatting></line>
+<line baseline="1964" l="1167" t="1923" r="1919" b="1976"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1167" t="1929" r="1176" b="1961" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1180" t="1928" r="1187" b="1961" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1188" t="1928" r="1204" b="1961"> </charParams>
+<charParams l="1205" t="1940" r="1222" b="1961" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1224" t="1923" r="1248" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1224" t="1923" r="1248" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1249" t="1923" r="1261" b="1962"> </charParams>
+<charParams l="1262" t="1942" r="1277" b="1962" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="64" wordPenalty="3" meanStrokeWidth="38">a</charParams>
+<charParams l="1280" t="1943" r="1298" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="3" meanStrokeWidth="38">u</charParams>
+<charParams l="1303" t="1929" r="1333" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1303" t="1929" r="1333" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1326" t="1942" r="1336" b="1963" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="91" wordPenalty="3" meanStrokeWidth="38">i</charParams>
+<charParams l="1337" t="1930" r="1348" b="1963"> </charParams>
+<charParams l="1349" t="1930" r="1358" b="1962" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1363" t="1942" r="1381" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1385" t="1942" r="1403" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1408" t="1939" r="1419" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1422" t="1929" r="1432" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1435" t="1928" r="1442" b="1961" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1445" t="1942" r="1463" b="1963" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1464" t="1929" r="1476" b="1963"> </charParams>
+<charParams l="1477" t="1929" r="1498" b="1962" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1500" t="1942" r="1518" b="1963" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1519" t="1928" r="1528" b="1963"> </charParams>
+<charParams l="1529" t="1928" r="1537" b="1962" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="51" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1541" t="1941" r="1558" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1559" t="1929" r="1566" b="1962"> </charParams>
+<charParams l="1567" t="1929" r="1585" b="1961" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="50" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1581" t="1941" r="1598" b="1961" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1600" t="1929" r="1609" b="1961" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1612" t="1941" r="1627" b="1962" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1630" t="1941" r="1647" b="1963" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1648" t="1941" r="1663" b="1971"> </charParams>
+<charParams l="1664" t="1942" r="1683" b="1971" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="96" wordPenalty="4" meanStrokeWidth="37">p</charParams>
+<charParams l="1686" t="1929" r="1696" b="1963" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="255" wordPenalty="4" meanStrokeWidth="37">l</charParams>
+<charParams l="1699" t="1943" r="1717" b="1963" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="91" wordPenalty="4" meanStrokeWidth="37">u</charParams>
+<charParams l="1720" t="1943" r="1732" b="1964" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="25" wordPenalty="4" meanStrokeWidth="37">s</charParams>
+<charParams l="1733" t="1931" r="1744" b="1964"> </charParams>
+<charParams l="1745" t="1931" r="1766" b="1964" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="98" wordPenalty="0" meanStrokeWidth="39">h</charParams>
+<charParams l="1770" t="1945" r="1785" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="92" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1787" t="1946" r="1805" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1810" t="1943" r="1823" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1825" t="1944" r="1843" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1844" t="1944" r="1856" b="1976"> </charParams>
+<charParams l="1857" t="1946" r="1875" b="1976" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="1878" t="1946" r="1899" b="1966" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="86" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1900" t="1946" r="1919" b="1967" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="2009" l="1167" t="1971" r="1922" b="2018"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1167" t="1971" r="1174" b="2004" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="51" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="1178" t="1985" r="1194" b="2005" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="53" wordPenalty="2" meanStrokeWidth="37">a</charParams>
+<charParams l="1197" t="1984" r="1212" b="2004" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">r</charParams>
+<charParams l="1213" t="1985" r="1232" b="2015" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="53" wordPenalty="2" meanStrokeWidth="37">g</charParams>
+<charParams l="1234" t="1985" r="1251" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="83" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1252" t="1985" r="1265" b="2016"> </charParams>
+<charParams l="1266" t="1987" r="1284" b="2016" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="92" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">q</charParams>
+<charParams l="1287" t="1987" r="1305" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="2" meanStrokeWidth="38">u</charParams>
+<charParams l="1309" t="1986" r="1324" b="2006" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="53" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="1327" t="1986" r="1346" b="2006" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1349" t="1974" r="1368" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="72" wordPenalty="2" meanStrokeWidth="38">d</charParams>
+<charParams l="1369" t="1974" r="1387" b="2007"> </charParams>
+<charParams l="1388" t="1985" r="1405" b="2007" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1408" t="1973" r="1417" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1420" t="1974" r="1427" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1431" t="1986" r="1449" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1450" t="1986" r="1468" b="2008"> </charParams>
+<charParams l="1469" t="1986" r="1487" b="2008" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1491" t="1973" r="1515" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1491" t="1973" r="1515" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1516" t="1973" r="1534" b="2007"> </charParams>
+<charParams l="1535" t="1973" r="1553" b="2007" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1558" t="1986" r="1575" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1576" t="1972" r="1594" b="2007"> </charParams>
+<charParams l="1595" t="1972" r="1603" b="2006" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1607" t="1987" r="1625" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="64" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1626" t="1973" r="1639" b="2007"> </charParams>
+<charParams l="1640" t="1973" r="1648" b="2007" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="26" wordPenalty="2" meanStrokeWidth="39">l</charParams>
+<charParams l="1652" t="1987" r="1669" b="2008" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="60" wordPenalty="2" meanStrokeWidth="39">a</charParams>
+<charParams l="1670" t="1987" r="1685" b="2007" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">r</charParams>
+<charParams l="1687" t="1988" r="1705" b="2018" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="53" wordPenalty="2" meanStrokeWidth="39">g</charParams>
+<charParams l="1709" t="1988" r="1726" b="2010" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="82" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="1728" t="1989" r="1749" b="2009" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="86" wordPenalty="2" meanStrokeWidth="39">u</charParams>
+<charParams l="1753" t="1990" r="1767" b="2010" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="2" meanStrokeWidth="39">r</charParams>
+<charParams l="1768" t="1977" r="1786" b="2011"> </charParams>
+<charParams l="1787" t="1977" r="1808" b="2011" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="72" wordPenalty="0" meanStrokeWidth="40">d</charParams>
+<charParams l="1810" t="1991" r="1831" b="2011" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="86" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1832" t="1990" r="1843" b="2011"> </charParams>
+<charParams l="1844" t="1990" r="1861" b="2011" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1863" t="1990" r="1881" b="2013" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1883" t="1991" r="1903" b="2013" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1904" t="1998" r="1922" b="2004" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#172;</charParams></formatting></line>
+<line baseline="2054" l="1168" t="2016" r="1923" b="2061"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1168" t="2016" r="1186" b="2049" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1192" t="2029" r="1205" b="2049" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="77" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1208" t="2017" r="1218" b="2050" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1221" t="2030" r="1238" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1241" t="2031" r="1256" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1265" t="2044" r="1273" b="2060" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">,</charParams>
+<charParams l="1274" t="2032" r="1292" b="2061"> </charParams>
+<charParams l="1293" t="2032" r="1310" b="2061" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">q</charParams>
+<charParams l="1313" t="2031" r="1333" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="1336" t="2030" r="1353" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1354" t="2019" r="1375" b="2052"> </charParams>
+<charParams l="1376" t="2019" r="1395" b="2052" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="80" wordPenalty="0" meanStrokeWidth="37">d</charParams>
+<charParams l="1399" t="2018" r="1406" b="2029" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1409" t="2031" r="1426" b="2052" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1430" t="2032" r="1450" b="2052" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1451" t="2032" r="1471" b="2052"> </charParams>
+<charParams l="1472" t="2032" r="1503" b="2052" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1506" t="2031" r="1523" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1526" t="2028" r="1538" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1541" t="2028" r="1554" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1556" t="2031" r="1571" b="2051" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1573" t="2030" r="1590" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1591" t="2030" r="1607" b="2061"> </charParams>
+<charParams l="1608" t="2032" r="1626" b="2061" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="96" wordPenalty="2" meanStrokeWidth="37">p</charParams>
+<charParams l="1630" t="2018" r="1638" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="51" wordPenalty="2" meanStrokeWidth="37">l</charParams>
+<charParams l="1642" t="2033" r="1660" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="1664" t="2017" r="1686" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">s</charParams>
+<charParams l="1664" t="2017" r="1686" b="2052" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="2" meanStrokeWidth="37">i</charParams>
+<charParams l="1690" t="2033" r="1706" b="2054" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="82" wordPenalty="2" meanStrokeWidth="37">e</charParams>
+<charParams l="1709" t="2034" r="1728" b="2054" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="2" meanStrokeWidth="37">u</charParams>
+<charParams l="1731" t="2033" r="1747" b="2054" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="100" wordPenalty="2" meanStrokeWidth="37">r</charParams>
+<charParams l="1749" t="2035" r="1762" b="2056" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="25" wordPenalty="2" meanStrokeWidth="37">s</charParams>
+<charParams l="1763" t="2032" r="1776" b="2056"> </charParams>
+<charParams l="1777" t="2032" r="1791" b="2056" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="61" wordPenalty="0" meanStrokeWidth="42">t</charParams>
+<charParams l="1793" t="2036" r="1812" b="2057" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="42">o</charParams>
+<charParams l="1815" t="2036" r="1836" b="2056" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="86" wordPenalty="0" meanStrokeWidth="42">u</charParams>
+<charParams l="1838" t="2033" r="1851" b="2056" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="61" wordPenalty="0" meanStrokeWidth="42">t</charParams>
+<charParams l="1852" t="2033" r="1865" b="2057"> </charParams>
+<charParams l="1866" t="2036" r="1885" b="2057" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="92" wordPenalty="1" meanStrokeWidth="44">a</charParams>
+<charParams l="1884" t="2036" r="1904" b="2056" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="86" wordPenalty="1" meanStrokeWidth="44">u</charParams>
+<charParams l="1905" t="2043" r="1923" b="2050" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="255" wordPenalty="1" meanStrokeWidth="44">&#172;</charParams></formatting></line>
+<line baseline="2098" l="1169" t="2063" r="1923" b="2111"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="2070" r="1182" b="2094" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="61" wordPenalty="1" meanStrokeWidth="38">t</charParams>
+<charParams l="1184" t="2074" r="1203" b="2094" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="255" wordPenalty="1" meanStrokeWidth="38">o</charParams>
+<charParams l="1206" t="2074" r="1224" b="2094" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="1227" t="2075" r="1242" b="2096" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">r</charParams>
+<charParams l="1243" t="2075" r="1251" b="2104"> </charParams>
+<charParams l="1252" t="2089" r="1261" b="2104" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1262" t="2064" r="1277" b="2104"> </charParams>
+<charParams l="1278" t="2064" r="1297" b="2097" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="72" wordPenalty="0" meanStrokeWidth="36">d</charParams>
+<charParams l="1301" t="2076" r="1318" b="2098" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="83" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1319" t="2076" r="1334" b="2098"> </charParams>
+<charParams l="1335" t="2076" r="1351" b="2097" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1353" t="2076" r="1371" b="2098" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1375" t="2074" r="1387" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1389" t="2073" r="1400" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1403" t="2076" r="1421" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1422" t="2076" r="1434" b="2097"> </charParams>
+<charParams l="1435" t="2077" r="1466" b="2097" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="51" wordPenalty="2" meanStrokeWidth="38">m</charParams>
+<charParams l="1473" t="2065" r="1486" b="2097" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="58" wordPenalty="2" meanStrokeWidth="38">&#234;</charParams>
+<charParams l="1490" t="2077" r="1521" b="2096" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="2" meanStrokeWidth="38">m</charParams>
+<charParams l="1525" t="2076" r="1542" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1543" t="2063" r="1555" b="2097"> </charParams>
+<charParams l="1556" t="2063" r="1565" b="2096" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="26" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1569" t="2076" r="1584" b="2096" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1588" t="2076" r="1601" b="2096" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1603" t="2076" r="1622" b="2106" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="1625" t="2076" r="1641" b="2098" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1645" t="2077" r="1664" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="91" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1666" t="2077" r="1682" b="2097" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1684" t="2090" r="1691" b="2098" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams>
+<charParams l="1692" t="2065" r="1703" b="2099"> </charParams>
+<charParams l="1704" t="2065" r="1731" b="2099" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="68" wordPenalty="0" meanStrokeWidth="38">C</charParams>
+<charParams l="1734" t="2079" r="1752" b="2100" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1755" t="2066" r="1763" b="2100" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1766" t="2080" r="1782" b="2101" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1783" t="2080" r="1791" b="2101"> </charParams>
+<charParams l="1792" t="2081" r="1813" b="2101" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1816" t="2080" r="1833" b="2102" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1834" t="2080" r="1843" b="2111"> </charParams>
+<charParams l="1844" t="2082" r="1863" b="2111" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="2" meanStrokeWidth="39">p</charParams>
+<charParams l="1867" t="2080" r="1884" b="2102" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="39">e</charParams>
+<charParams l="1886" t="2082" r="1906" b="2102" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="86" wordPenalty="2" meanStrokeWidth="39">u</charParams>
+<charParams l="1908" t="2079" r="1923" b="2103" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="2" meanStrokeWidth="39">t</charParams></formatting></line>
+<line baseline="2144" l="1169" t="2108" r="1924" b="2151"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1169" t="2119" r="1186" b="2139" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="60" wordPenalty="0" meanStrokeWidth="39">a</charParams>
+<charParams l="1188" t="2119" r="1208" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="1210" t="2120" r="1230" b="2140" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1234" t="2109" r="1240" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1244" t="2120" r="1259" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1260" t="2108" r="1280" b="2142"> </charParams>
+<charParams l="1281" t="2108" r="1290" b="2142" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1294" t="2109" r="1302" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1305" t="2120" r="1323" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1327" t="2122" r="1345" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1346" t="2122" r="1368" b="2151"> </charParams>
+<charParams l="1369" t="2122" r="1387" b="2151" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">q</charParams>
+<charParams l="1390" t="2122" r="1408" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="0" meanStrokeWidth="36">u</charParams>
+<charParams l="1413" t="2120" r="1430" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1431" t="2120" r="1445" b="2151"> </charParams>
+<charParams l="1446" t="2122" r="1465" b="2151" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="255" wordPenalty="0" meanStrokeWidth="34">q</charParams>
+<charParams l="1467" t="2122" r="1486" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="100" wordPenalty="0" meanStrokeWidth="34">u</charParams>
+<charParams l="1489" t="2121" r="1506" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="64" wordPenalty="0" meanStrokeWidth="34">a</charParams>
+<charParams l="1507" t="2121" r="1526" b="2141" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="34">n</charParams>
+<charParams l="1531" t="2109" r="1549" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="35" wordPenalty="0" meanStrokeWidth="34">d</charParams>
+<charParams l="1550" t="2109" r="1576" b="2142"> </charParams>
+<charParams l="1577" t="2121" r="1593" b="2141" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="1" meanStrokeWidth="38">c</charParams>
+<charParams l="1596" t="2110" r="1617" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="98" wordPenalty="1" meanStrokeWidth="38">h</charParams>
+<charParams l="1620" t="2121" r="1636" b="2142" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="64" wordPenalty="1" meanStrokeWidth="38">a</charParams>
+<charParams l="1639" t="2121" r="1655" b="2143" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="1" meanStrokeWidth="38">c</charParams>
+<charParams l="1659" t="2123" r="1676" b="2143" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="91" wordPenalty="1" meanStrokeWidth="38">u</charParams>
+<charParams l="1680" t="2122" r="1700" b="2143" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="100" wordPenalty="1" meanStrokeWidth="38">n</charParams>
+<charParams l="1703" t="2123" r="1720" b="2145" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="82" wordPenalty="1" meanStrokeWidth="38">e</charParams>
+<charParams l="1721" t="2112" r="1738" b="2145"> </charParams>
+<charParams l="1739" t="2112" r="1758" b="2145" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="72" wordPenalty="2" meanStrokeWidth="36">d</charParams>
+<charParams l="1761" t="2113" r="1769" b="2127" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">&#8217;</charParams>
+<charParams l="1773" t="2126" r="1791" b="2147" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="54" serifProbability="82" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="1794" t="2112" r="1801" b="2145" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="1805" t="2112" r="1812" b="2145" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="51" wordPenalty="2" meanStrokeWidth="36">l</charParams>
+<charParams l="1817" t="2125" r="1833" b="2147" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="36">e</charParams>
+<charParams l="1836" t="2126" r="1848" b="2147" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="25" wordPenalty="2" meanStrokeWidth="36">s</charParams>
+<charParams l="1849" t="2125" r="1870" b="2147"> </charParams>
+<charParams l="1871" t="2125" r="1892" b="2146" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="46">n</charParams>
+<charParams l="1894" t="2114" r="1903" b="2127" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="46">&#8217;</charParams>
+<charParams l="1907" t="2126" r="1924" b="2146" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="34" wordPenalty="0" meanStrokeWidth="46">a</charParams></formatting></line>
+<line baseline="2188" l="1170" t="2152" r="1924" b="2200"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1170" t="2165" r="1188" b="2194" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="3" meanStrokeWidth="36">q</charParams>
+<charParams l="1191" t="2164" r="1210" b="2185" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="91" wordPenalty="3" meanStrokeWidth="36">u</charParams>
+<charParams l="1213" t="2152" r="1221" b="2165" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="3" meanStrokeWidth="36">&#8217;</charParams>
+<charParams l="1225" t="2166" r="1245" b="2186" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="86" wordPenalty="3" meanStrokeWidth="36">u</charParams>
+<charParams l="1247" t="2166" r="1267" b="2187" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="100" wordPenalty="3" meanStrokeWidth="36">n</charParams>
+<charParams l="1270" t="2165" r="1287" b="2188" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="82" wordPenalty="3" meanStrokeWidth="36">e</charParams>
+<charParams l="1288" t="2165" r="1301" b="2195"> </charParams>
+<charParams l="1302" t="2166" r="1321" b="2195" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1324" t="2166" r="1341" b="2187" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="64" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1343" t="2166" r="1357" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1360" t="2164" r="1373" b="2187" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1376" t="2153" r="1385" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1389" t="2166" r="1406" b="2188" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1407" t="2154" r="1423" b="2188"> </charParams>
+<charParams l="1424" t="2154" r="1444" b="2187" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1448" t="2167" r="1466" b="2187" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1467" t="2153" r="1482" b="2187"> </charParams>
+<charParams l="1483" t="2153" r="1502" b="2187" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="72" wordPenalty="19" meanStrokeWidth="37">d</charParams>
+<charParams l="1505" t="2154" r="1515" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="0" wordPenalty="19" meanStrokeWidth="37">i</charParams>
+<charParams l="1518" t="2166" r="1534" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="64" wordPenalty="19" meanStrokeWidth="37">a</charParams>
+<charParams l="1537" t="2166" r="1567" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="44" wordPenalty="19" meanStrokeWidth="37">m</charParams>
+<charParams l="1571" t="2165" r="1587" b="2187" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="19" meanStrokeWidth="37">&#232;</charParams>
+<charParams l="1591" t="2164" r="1604" b="2187" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="19" meanStrokeWidth="37">t</charParams>
+<charParams l="1605" t="2166" r="1620" b="2186" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="100" wordPenalty="19" meanStrokeWidth="37">r</charParams>
+<charParams l="1625" t="2165" r="1642" b="2187" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="91" serifProbability="82" wordPenalty="19" meanStrokeWidth="37">e</charParams>
+<charParams l="1643" t="2154" r="1654" b="2188"> </charParams>
+<charParams l="1655" t="2154" r="1675" b="2188" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1679" t="2168" r="1697" b="2188" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1698" t="2168" r="1712" b="2189"> </charParams>
+<charParams l="1713" t="2168" r="1729" b="2189" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1732" t="2168" r="1749" b="2190" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1752" t="2170" r="1772" b="2190" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="64" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1775" t="2158" r="1792" b="2191" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="71" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1797" t="2170" r="1812" b="2190" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1814" t="2158" r="1822" b="2191" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1826" t="2170" r="1844" b="2191" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1845" t="2170" r="1860" b="2190" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">r</charParams>
+<charParams l="1871" t="2185" r="1879" b="2200" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1880" t="2159" r="1890" b="2200"> </charParams>
+<charParams l="1891" t="2159" r="1910" b="2191" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">S</charParams>
+<charParams l="1910" t="2169" r="1924" b="2191" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="26" wordPenalty="0" meanStrokeWidth="47">c</charParams></formatting></line>
+<line baseline="2233" l="1171" t="2197" r="1925" b="2236"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1171" t="2208" r="1188" b="2230" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1192" t="2209" r="1212" b="2229" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1213" t="2209" r="1227" b="2230"> </charParams>
+<charParams l="1228" t="2210" r="1245" b="2230" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="41">c</charParams>
+<charParams l="1247" t="2210" r="1265" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="82" wordPenalty="0" meanStrokeWidth="41">e</charParams>
+<charParams l="1266" t="2210" r="1282" b="2232"> </charParams>
+<charParams l="1283" t="2210" r="1300" b="2231" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1302" t="2211" r="1319" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="64" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1321" t="2212" r="1332" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="10" wordPenalty="0" meanStrokeWidth="40">s</charParams>
+<charParams l="1333" t="2212" r="1349" b="2233"> </charParams>
+<charParams l="1350" t="2212" r="1367" b="2233" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1370" t="2197" r="1379" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1383" t="2198" r="1390" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="51" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1394" t="2211" r="1411" b="2233" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="36">e</charParams>
+<charParams l="1414" t="2211" r="1426" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="41" wordPenalty="0" meanStrokeWidth="36">s</charParams>
+<charParams l="1427" t="2211" r="1442" b="2232"> </charParams>
+<charParams l="1443" t="2211" r="1464" b="2231" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1467" t="2210" r="1484" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1485" t="2199" r="1506" b="2231"> </charParams>
+<charParams l="1507" t="2199" r="1526" b="2231" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1530" t="2211" r="1549" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">o</charParams>
+<charParams l="1552" t="2199" r="1562" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1565" t="2211" r="1584" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="50" wordPenalty="0" meanStrokeWidth="39">v</charParams>
+<charParams l="1587" t="2211" r="1604" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1607" t="2211" r="1627" b="2231" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1630" t="2208" r="1643" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="61" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1644" t="2201" r="1660" b="2232"> </charParams>
+<charParams l="1661" t="2201" r="1670" b="2232" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="13" meanStrokeWidth="37">t</charParams>
+<charParams l="1673" t="2212" r="1691" b="2233" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="34" wordPenalty="13" meanStrokeWidth="37">a</charParams>
+<charParams l="1694" t="2200" r="1701" b="2232" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="0" wordPenalty="13" meanStrokeWidth="37">i</charParams>
+<charParams l="1705" t="2213" r="1718" b="2233" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="13" meanStrokeWidth="37">r</charParams>
+<charParams l="1722" t="2212" r="1739" b="2235" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="13" meanStrokeWidth="37">e</charParams>
+<charParams l="1740" t="2212" r="1762" b="2236"> </charParams>
+<charParams l="1763" t="2215" r="1780" b="2236" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1783" t="2215" r="1802" b="2235" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1806" t="2212" r="1819" b="2236" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">t</charParams>
+<charParams l="1821" t="2215" r="1836" b="2235" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="1838" t="2202" r="1845" b="2216" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1849" t="2215" r="1867" b="2236" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1870" t="2201" r="1877" b="2235" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="51" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="1881" t="2200" r="1890" b="2235" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="1892" t="2214" r="1909" b="2236" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1911" t="2213" r="1925" b="2236" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="32" wordPenalty="2" meanStrokeWidth="38">s</charParams></formatting></line>
+<line baseline="2276" l="1171" t="2241" r="1673" b="2286"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1171" t="2254" r="1190" b="2284" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="255" wordPenalty="1" meanStrokeWidth="36">q</charParams>
+<charParams l="1193" t="2254" r="1210" b="2274" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="91" wordPenalty="1" meanStrokeWidth="36">u</charParams>
+<charParams l="1214" t="2254" r="1232" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="82" wordPenalty="1" meanStrokeWidth="36">e</charParams>
+<charParams l="1233" t="2241" r="1244" b="2276"> </charParams>
+<charParams l="1245" t="2241" r="1255" b="2275" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="40">l</charParams>
+<charParams l="1258" t="2255" r="1274" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="34" wordPenalty="0" meanStrokeWidth="40">a</charParams>
+<charParams l="1275" t="2241" r="1289" b="2276"> </charParams>
+<charParams l="1290" t="2241" r="1308" b="2276" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="48" wordPenalty="3" meanStrokeWidth="38">s</charParams>
+<charParams l="1305" t="2257" r="1324" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="255" wordPenalty="3" meanStrokeWidth="38">o</charParams>
+<charParams l="1328" t="2256" r="1359" b="2277" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="44" wordPenalty="3" meanStrokeWidth="38">m</charParams>
+<charParams l="1363" t="2257" r="1394" b="2277" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="51" wordPenalty="3" meanStrokeWidth="38">m</charParams>
+<charParams l="1398" t="2256" r="1415" b="2277" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="3" meanStrokeWidth="38">e</charParams>
+<charParams l="1416" t="2244" r="1431" b="2277"> </charParams>
+<charParams l="1432" t="2244" r="1450" b="2276" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1455" t="2256" r="1472" b="2277" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1473" t="2242" r="1491" b="2277"> </charParams>
+<charParams l="1492" t="2242" r="1510" b="2276" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="48" wordPenalty="4" meanStrokeWidth="37">f</charParams>
+<charParams l="1506" t="2256" r="1522" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="53" wordPenalty="4" meanStrokeWidth="37">a</charParams>
+<charParams l="1523" t="2241" r="1537" b="2276"> </charParams>
+<charParams l="1538" t="2241" r="1547" b="2275" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="26" wordPenalty="0" meanStrokeWidth="32">l</charParams>
+<charParams l="1550" t="2255" r="1566" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="53" wordPenalty="0" meanStrokeWidth="32">a</charParams>
+<charParams l="1571" t="2257" r="1583" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="4" wordPenalty="0" meanStrokeWidth="32">r</charParams>
+<charParams l="1585" t="2256" r="1604" b="2286" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="53" wordPenalty="0" meanStrokeWidth="32">g</charParams>
+<charParams l="1608" t="2255" r="1625" b="2277" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1628" t="2257" r="1645" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="91" wordPenalty="0" meanStrokeWidth="32">u</charParams>
+<charParams l="1649" t="2255" r="1664" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">r</charParams>
+<charParams l="1666" t="2269" r="1673" b="2276" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="32">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="2321" l="1216" t="2282" r="1924" b="2334"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1216" t="2289" r="1254" b="2320" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="50" wordPenalty="0" meanStrokeWidth="46">D</charParams>
+<charParams l="1257" t="2301" r="1272" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="77" wordPenalty="0" meanStrokeWidth="46">e</charParams>
+<charParams l="1274" t="2301" r="1289" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="100" wordPenalty="0" meanStrokeWidth="46">s</charParams>
+<charParams l="1290" t="2287" r="1303" b="2320"> </charParams>
+<charParams l="1304" t="2287" r="1328" b="2320" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">d</charParams>
+<charParams l="1327" t="2301" r="1341" b="2321" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="77" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1341" t="2300" r="1364" b="2332" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">g</charParams>
+<charParams l="1364" t="2302" r="1379" b="2321" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">r</charParams>
+<charParams l="1381" t="2291" r="1401" b="2321" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="52" wordPenalty="0" meanStrokeWidth="32">&#233;</charParams>
+<charParams l="1398" t="2301" r="1415" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">s</charParams>
+<charParams l="1416" t="2286" r="1429" b="2320"> </charParams>
+<charParams l="1430" t="2286" r="1455" b="2320" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">d</charParams>
+<charParams l="1453" t="2301" r="1473" b="2320" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="100" wordPenalty="0" meanStrokeWidth="32">u</charParams>
+<charParams l="1474" t="2288" r="1476" b="2329"> </charParams>
+<charParams l="1477" t="2288" r="1510" b="2329" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="1502" t="2301" r="1517" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1520" t="2301" r="1539" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1543" t="2313" r="1550" b="2320" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">.</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1551" t="2282" r="1567" b="2320"> </charParams>
+<charParams l="1568" t="2282" r="1595" b="2320" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="49" wordPenalty="0" meanStrokeWidth="37">C</charParams>
+<charParams l="1599" t="2289" r="1606" b="2301" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">&#8217;</charParams>
+<charParams l="1609" t="2300" r="1626" b="2321" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1628" t="2286" r="1654" b="2320" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1628" t="2286" r="1654" b="2320" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1655" t="2286" r="1675" b="2330"> </charParams>
+<charParams l="1676" t="2301" r="1695" b="2330" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="1698" t="2301" r="1713" b="2321" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="72" wordPenalty="0" meanStrokeWidth="37">a</charParams>
+<charParams l="1716" t="2301" r="1731" b="2321" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1732" t="2289" r="1748" b="2324"> </charParams>
+<charParams l="1749" t="2289" r="1758" b="2324" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="26" wordPenalty="4" meanStrokeWidth="41">l</charParams>
+<charParams l="1761" t="2303" r="1779" b="2324" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="82" wordPenalty="4" meanStrokeWidth="41">e</charParams>
+<charParams l="1780" t="2303" r="1805" b="2324"> </charParams>
+<charParams l="1806" t="2304" r="1836" b="2323" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="27" wordPenalty="0" meanStrokeWidth="40">m</charParams>
+<charParams l="1840" t="2303" r="1859" b="2324" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="76" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1861" t="2303" r="1881" b="2334" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">y</charParams>
+<charParams l="1884" t="2303" r="1900" b="2324" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1903" t="2303" r="1924" b="2324" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams></formatting></line>
+<line baseline="2366" l="1173" t="2330" r="1925" b="2375"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1173" t="2330" r="1192" b="2363" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="72" wordPenalty="0" meanStrokeWidth="32">d</charParams>
+<charParams l="1197" t="2342" r="1214" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="82" wordPenalty="0" meanStrokeWidth="32">e</charParams>
+<charParams l="1216" t="2343" r="1229" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="73" wordPenalty="0" meanStrokeWidth="32">s</charParams>
+<charParams l="1230" t="2343" r="1242" b="2365"> </charParams>
+<charParams l="1243" t="2345" r="1258" b="2365" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1261" t="2344" r="1278" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1280" t="2344" r="1299" b="2374" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="0" meanStrokeWidth="37">g</charParams>
+<charParams l="1301" t="2332" r="1310" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="37">i</charParams>
+<charParams l="1313" t="2331" r="1338" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1313" t="2331" r="1338" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1340" t="2345" r="1354" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">r</charParams>
+<charParams l="1357" t="2345" r="1373" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1376" t="2344" r="1389" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="80" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1390" t="2333" r="1409" b="2365"> </charParams>
+<charParams l="1410" t="2333" r="1428" b="2365" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="36">S</charParams>
+<charParams l="1428" t="2342" r="1442" b="2364" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="61" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1443" t="2333" r="1458" b="2364"> </charParams>
+<charParams l="1459" t="2333" r="1477" b="2364" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="71" wordPenalty="0" meanStrokeWidth="34">d</charParams>
+<charParams l="1481" t="2344" r="1501" b="2364" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="100" wordPenalty="0" meanStrokeWidth="34">u</charParams>
+<charParams l="1502" t="2331" r="1517" b="2365"> </charParams>
+<charParams l="1518" t="2331" r="1548" b="2365" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="3" meanStrokeWidth="39">s</charParams>
+<charParams l="1518" t="2331" r="1548" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="255" wordPenalty="3" meanStrokeWidth="39">o</charParams>
+<charParams l="1551" t="2345" r="1570" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="93" serifProbability="91" wordPenalty="3" meanStrokeWidth="39">u</charParams>
+<charParams l="1572" t="2345" r="1592" b="2374" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="96" wordPenalty="3" meanStrokeWidth="39">p</charParams>
+<charParams l="1594" t="2344" r="1603" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="26" wordPenalty="3" meanStrokeWidth="39">i</charParams>
+<charParams l="1607" t="2344" r="1621" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="100" wordPenalty="3" meanStrokeWidth="39">r</charParams>
+<charParams l="1623" t="2344" r="1639" b="2365" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="53" wordPenalty="3" meanStrokeWidth="39">a</charParams>
+<charParams l="1642" t="2332" r="1650" b="2364" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="0" wordPenalty="3" meanStrokeWidth="39">i</charParams>
+<charParams l="1653" t="2331" r="1662" b="2364" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="3" meanStrokeWidth="39">l</charParams>
+<charParams l="1676" t="2359" r="1684" b="2375" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="43" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1685" t="2345" r="1700" b="2375"> </charParams>
+<charParams l="1701" t="2345" r="1718" b="2366" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1720" t="2346" r="1739" b="2366" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1741" t="2347" r="1773" b="2368" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1777" t="2348" r="1808" b="2367" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="44" wordPenalty="0" meanStrokeWidth="38">m</charParams>
+<charParams l="1812" t="2348" r="1830" b="2368" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1831" t="2348" r="1843" b="2368"> </charParams>
+<charParams l="1844" t="2349" r="1864" b="2368" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="100" wordPenalty="3" meanStrokeWidth="40">n</charParams>
+<charParams l="1867" t="2348" r="1887" b="2369" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="255" wordPenalty="3" meanStrokeWidth="40">o</charParams>
+<charParams l="1890" t="2341" r="1901" b="2368" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="0" wordPenalty="3" meanStrokeWidth="40">i</charParams>
+<charParams l="1901" t="2348" r="1908" b="2368" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="0" wordPenalty="3" meanStrokeWidth="40">i</charParams>
+<charParams l="1910" t="2348" r="1925" b="2370" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="0" wordPenalty="3" meanStrokeWidth="40">s</charParams></formatting></line>
+<line baseline="2411" l="1172" t="2374" r="1924" b="2422"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1172" t="2374" r="1180" b="2408" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="62" serifProbability="26" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="1184" t="2375" r="1191" b="2388" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1195" t="2388" r="1210" b="2408" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="53" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="1214" t="2388" r="1233" b="2408" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="50" wordPenalty="2" meanStrokeWidth="38">v</charParams>
+<charParams l="1236" t="2390" r="1255" b="2410" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">o</charParams>
+<charParams l="1258" t="2390" r="1276" b="2409" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1280" t="2389" r="1292" b="2410" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="41" wordPenalty="2" meanStrokeWidth="38">s</charParams>
+<charParams l="1299" t="2377" r="1318" b="2410" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="28" serifProbability="72" wordPenalty="2" meanStrokeWidth="38">d</charParams>
+<charParams l="1322" t="2375" r="1338" b="2410" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="2" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1338" t="2377" r="1347" b="2418" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="62" wordPenalty="2" meanStrokeWidth="38">j</charParams>
+<charParams l="1352" t="2375" r="1368" b="2409" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">&#224;</charParams>
+<charParams l="1369" t="2375" r="1378" b="2410" suspicious="1"> </charParams>
+<charParams l="1379" t="2376" r="1399" b="2410" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="72" wordPenalty="0" meanStrokeWidth="33">d</charParams>
+<charParams l="1403" t="2376" r="1410" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="0" wordPenalty="0" meanStrokeWidth="33">i</charParams>
+<charParams l="1415" t="2387" r="1427" b="2410" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="61" wordPenalty="0" meanStrokeWidth="33">t</charParams>
+<charParams l="1428" t="2387" r="1443" b="2410"> </charParams>
+<charParams l="1444" t="2389" r="1461" b="2410" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="82" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1463" t="2389" r="1484" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="79" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">n</charParams>
+<charParams l="1485" t="2389" r="1495" b="2417"> </charParams>
+<charParams l="1496" t="2389" r="1514" b="2417" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="96" wordPenalty="0" meanStrokeWidth="49">p</charParams>
+<charParams l="1517" t="2375" r="1525" b="2408" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="26" wordPenalty="0" meanStrokeWidth="49">l</charParams>
+<charParams l="1529" t="2389" r="1548" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="57" serifProbability="91" wordPenalty="0" meanStrokeWidth="49">u</charParams>
+<charParams l="1551" t="2389" r="1564" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="32" wordPenalty="0" meanStrokeWidth="49">s</charParams>
+<charParams l="1565" t="2377" r="1571" b="2409" suspicious="1"> </charParams>
+<charParams l="1572" t="2377" r="1592" b="2409" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="80" wordPenalty="0" meanStrokeWidth="49">d</charParams>
+<charParams l="1596" t="2377" r="1603" b="2391" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="96" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">&#8217;</charParams>
+<charParams l="1607" t="2389" r="1625" b="2409" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="255" wordPenalty="0" meanStrokeWidth="49">u</charParams>
+<charParams l="1627" t="2388" r="1647" b="2409" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="100" wordPenalty="0" meanStrokeWidth="49">n</charParams>
+<charParams l="1648" t="2388" r="1658" b="2409"> </charParams>
+<charParams l="1659" t="2388" r="1677" b="2409" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1680" t="2389" r="1700" b="2409" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1703" t="2377" r="1721" b="2410" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="71" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1724" t="2390" r="1740" b="2410" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1742" t="2391" r="1761" b="2412" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1765" t="2380" r="1772" b="2412" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="98" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1777" t="2389" r="1790" b="2412" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1801" t="2407" r="1809" b="2422" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">,</charParams>
+<charParams l="1810" t="2393" r="1825" b="2422"> </charParams>
+<charParams l="1826" t="2393" r="1845" b="2422" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">q</charParams>
+<charParams l="1847" t="2392" r="1866" b="2412" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1868" t="2379" r="1876" b="2390" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="1880" t="2393" r="1899" b="2413" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1902" t="2393" r="1924" b="2414" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="39" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams></formatting></line>
+<line baseline="2455" l="1172" t="2419" r="1925" b="2469"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1172" t="2432" r="1187" b="2453" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="100" wordPenalty="12" meanStrokeWidth="38">r</charParams>
+<charParams l="1190" t="2432" r="1207" b="2454" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="82" wordPenalty="12" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1210" t="2433" r="1229" b="2463" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="33" serifProbability="53" wordPenalty="12" meanStrokeWidth="38">g</charParams>
+<charParams l="1231" t="2420" r="1238" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="51" wordPenalty="12" meanStrokeWidth="38">l</charParams>
+<charParams l="1242" t="2434" r="1260" b="2456" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="82" wordPenalty="12" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1261" t="2420" r="1277" b="2456"> </charParams>
+<charParams l="1278" t="2420" r="1286" b="2454" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="51" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1291" t="2434" r="1308" b="2455" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="53" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1310" t="2434" r="1323" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="10" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1324" t="2422" r="1335" b="2455"> </charParams>
+<charParams l="1336" t="2422" r="1356" b="2455" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="80" wordPenalty="4" meanStrokeWidth="36">d</charParams>
+<charParams l="1359" t="2422" r="1368" b="2455" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="75" serifProbability="0" wordPenalty="4" meanStrokeWidth="36">i</charParams>
+<charParams l="1370" t="2420" r="1401" b="2455" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="4" meanStrokeWidth="36">f</charParams>
+<charParams l="1370" t="2420" r="1401" b="2455" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="4" meanStrokeWidth="36">f</charParams>
+<charParams l="1396" t="2420" r="1412" b="2455" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="4" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="1414" t="2434" r="1428" b="2454" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="81" serifProbability="100" wordPenalty="4" meanStrokeWidth="36">r</charParams>
+<charParams l="1430" t="2433" r="1448" b="2455" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="72" serifProbability="82" wordPenalty="4" meanStrokeWidth="36">e</charParams>
+<charParams l="1450" t="2433" r="1470" b="2454" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="4" meanStrokeWidth="36">n</charParams>
+<charParams l="1472" t="2433" r="1484" b="2454" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="10" wordPenalty="4" meanStrokeWidth="36">s</charParams>
+<charParams l="1485" t="2420" r="1496" b="2454"> </charParams>
+<charParams l="1497" t="2420" r="1518" b="2454" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="100" wordPenalty="3" meanStrokeWidth="36">d</charParams>
+<charParams l="1521" t="2433" r="1538" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="3" meanStrokeWidth="36">e</charParams>
+<charParams l="1541" t="2433" r="1560" b="2462" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="53" wordPenalty="3" meanStrokeWidth="36">g</charParams>
+<charParams l="1563" t="2434" r="1576" b="2453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="100" wordPenalty="3" meanStrokeWidth="36">r</charParams>
+<charParams l="1580" t="2419" r="1596" b="2453" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="3" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="1598" t="2434" r="1610" b="2454" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="10" wordPenalty="3" meanStrokeWidth="36">s</charParams>
+<charParams l="1611" t="2420" r="1621" b="2454"> </charParams>
+<charParams l="1622" t="2420" r="1642" b="2453" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="72" wordPenalty="0" meanStrokeWidth="39">d</charParams>
+<charParams l="1645" t="2433" r="1665" b="2453" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="86" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1666" t="2421" r="1677" b="2453"> </charParams>
+<charParams l="1678" t="2421" r="1696" b="2453" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="50" wordPenalty="4" meanStrokeWidth="36">f</charParams>
+<charParams l="1691" t="2434" r="1709" b="2456" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="82" wordPenalty="4" meanStrokeWidth="36">e</charParams>
+<charParams l="1712" t="2435" r="1731" b="2455" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="4" meanStrokeWidth="36">u</charParams>
+<charParams l="1734" t="2447" r="1741" b="2455" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="4" meanStrokeWidth="36">.</charParams>
+<charParams l="1742" t="2426" r="1761" b="2459"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1762" t="2426" r="1800" b="2459" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="4" meanStrokeWidth="39">V</charParams>
+<charParams l="1799" t="2437" r="1817" b="2457" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="255" wordPenalty="4" meanStrokeWidth="39">o</charParams>
+<charParams l="1812" t="2438" r="1840" b="2468" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="100" wordPenalty="4" meanStrokeWidth="39">y</charParams>
+<charParams l="1842" t="2437" r="1856" b="2457" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="27" serifProbability="79" wordPenalty="4" meanStrokeWidth="39">e</charParams>
+<charParams l="1860" t="2437" r="1875" b="2469" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">%</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1876" t="2437" r="1887" b="2469"> </charParams>
+<charParams l="1888" t="2437" r="1904" b="2457" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="49" wordPenalty="0" meanStrokeWidth="40">c</charParams>
+<charParams l="1906" t="2436" r="1925" b="2466" suspicious="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="34" wordPenalty="0" meanStrokeWidth="40">&#231;</charParams></formatting></line>
+<line baseline="2499" l="1173" t="2465" r="1723" b="2508"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1173" t="2479" r="1192" b="2508" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="37" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">q</charParams>
+<charParams l="1195" t="2479" r="1214" b="2499" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="86" wordPenalty="0" meanStrokeWidth="40">u</charParams>
+<charParams l="1217" t="2466" r="1225" b="2477" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">&#8217;</charParams>
+<charParams l="1228" t="2479" r="1248" b="2500" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1251" t="2479" r="1270" b="2499" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1271" t="2479" r="1290" b="2500"> </charParams>
+<charParams l="1291" t="2479" r="1307" b="2500" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="95" serifProbability="82" wordPenalty="0" meanStrokeWidth="40">e</charParams>
+<charParams l="1310" t="2479" r="1330" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1331" t="2479" r="1343" b="2499"> </charParams>
+<charParams l="1344" t="2479" r="1361" b="2499" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="38" serifProbability="34" wordPenalty="0" meanStrokeWidth="45">a</charParams>
+<charParams l="1362" t="2467" r="1377" b="2500"> </charParams>
+<charParams l="1378" t="2467" r="1397" b="2500" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1401" t="2467" r="1410" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="41" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1413" t="2477" r="1426" b="2500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1427" t="2465" r="1440" b="2500"> </charParams>
+<charParams l="1441" t="2465" r="1457" b="2499" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">&#224;</charParams>
+<charParams l="1458" t="2465" r="1472" b="2499"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1473" t="2465" r="1493" b="2499" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="16" wordPenalty="0" meanStrokeWidth="36">Y</charParams>
+<charParams l="1494" t="2465" r="1495" b="2499"> </charParams>
+<charParams l="1496" t="2478" r="1514" b="2498" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="95" wordPenalty="0" meanStrokeWidth="36">a</charParams>
+<charParams l="1519" t="2479" r="1534" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">r</charParams>
+<charParams l="1535" t="2477" r="1549" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="29" wordPenalty="0" meanStrokeWidth="36">t</charParams>
+<charParams l="1549" t="2467" r="1563" b="2497" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">i</charParams>
+<charParams l="1565" t="2478" r="1579" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="52" wordPenalty="0" meanStrokeWidth="36">c</charParams>
+<charParams l="1583" t="2466" r="1598" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">l</charParams>
+<charParams l="1596" t="2478" r="1611" b="2498" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="42" serifProbability="100" wordPenalty="0" meanStrokeWidth="36">e</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" smallcaps="1">
+<charParams l="1612" t="2465" r="1629" b="2498"> </charParams>
+<charParams l="1630" t="2465" r="1657" b="2497" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="59" serifProbability="100" wordPenalty="14" meanStrokeWidth="39">F</charParams>
+<charParams l="1661" t="2474" r="1681" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="100" wordPenalty="14" meanStrokeWidth="39">e</charParams>
+<charParams l="1684" t="2474" r="1712" b="2500" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="100" wordPenalty="14" meanStrokeWidth="39">u</charParams>
+<charParams l="1714" t="2493" r="1723" b="2499" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="255" wordPenalty="14" meanStrokeWidth="39">.</charParams></formatting></line></par>
+<par align="Justified" startIndent="1500" lineSpacing="1056">
+<line baseline="2545" l="1218" t="2508" r="1928" b="2555"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1218" t="2510" r="1244" b="2545" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="0" meanStrokeWidth="54">L</charParams>
+<charParams l="1247" t="2523" r="1265" b="2545" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="82" wordPenalty="0" meanStrokeWidth="54">e</charParams>
+<charParams l="1267" t="2524" r="1279" b="2544" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="41" wordPenalty="0" meanStrokeWidth="54">s</charParams>
+<charParams l="1280" t="2523" r="1291" b="2544"> </charParams>
+<charParams l="1292" t="2523" r="1309" b="2544" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">c</charParams>
+<charParams l="1311" t="2512" r="1331" b="2544" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="63" serifProbability="98" wordPenalty="0" meanStrokeWidth="39">h</charParams>
+<charParams l="1335" t="2525" r="1353" b="2555" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="49" wordPenalty="0" meanStrokeWidth="39">y</charParams>
+<charParams l="1356" t="2525" r="1386" b="2545" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="55" serifProbability="27" wordPenalty="0" meanStrokeWidth="39">m</charParams>
+<charParams l="1390" t="2512" r="1399" b="2545" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1404" t="2511" r="1427" b="2544" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1404" t="2511" r="1427" b="2544" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">t</charParams>
+<charParams l="1430" t="2524" r="1447" b="2545" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1450" t="2524" r="1462" b="2545" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="84" serifProbability="32" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1463" t="2509" r="1477" b="2545"> </charParams>
+<charParams l="1478" t="2509" r="1495" b="2543" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="16" serifProbability="48" wordPenalty="0" meanStrokeWidth="38">f</charParams>
+<charParams l="1491" t="2522" r="1509" b="2543" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="94" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1510" t="2508" r="1524" b="2543"> </charParams>
+<charParams l="1525" t="2508" r="1542" b="2542" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="26" serifProbability="48" wordPenalty="0" meanStrokeWidth="40">f</charParams>
+<charParams l="1538" t="2522" r="1557" b="2543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="255" wordPenalty="0" meanStrokeWidth="40">o</charParams>
+<charParams l="1561" t="2522" r="1580" b="2542" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="52" serifProbability="100" wordPenalty="0" meanStrokeWidth="40">n</charParams>
+<charParams l="1584" t="2519" r="1597" b="2543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="61" wordPenalty="0" meanStrokeWidth="40">t</charParams>
+<charParams l="1598" t="2519" r="1610" b="2543"> </charParams>
+<charParams l="1611" t="2523" r="1630" b="2543" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="88" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1633" t="2523" r="1653" b="2543" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1654" t="2523" r="1667" b="2553"> </charParams>
+<charParams l="1668" t="2524" r="1687" b="2553" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="96" wordPenalty="0" meanStrokeWidth="38">p</charParams>
+<charParams l="1690" t="2524" r="1707" b="2544" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1710" t="2525" r="1728" b="2545" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1729" t="2525" r="1738" b="2554"> </charParams>
+<charParams l="1739" t="2525" r="1758" b="2554" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="96" wordPenalty="0" meanStrokeWidth="37">p</charParams>
+<charParams l="1761" t="2512" r="1769" b="2546" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="51" wordPenalty="0" meanStrokeWidth="37">l</charParams>
+<charParams l="1772" t="2526" r="1789" b="2546" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1794" t="2525" r="1806" b="2547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="85" serifProbability="41" wordPenalty="0" meanStrokeWidth="37">s</charParams>
+<charParams l="1807" t="2513" r="1819" b="2547"> </charParams>
+<charParams l="1820" t="2513" r="1838" b="2547" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="72" wordPenalty="0" meanStrokeWidth="47">d</charParams>
+<charParams l="1841" t="2527" r="1862" b="2547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="255" wordPenalty="0" meanStrokeWidth="47">o</charParams>
+<charParams l="1864" t="2526" r="1884" b="2548" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="100" wordPenalty="0" meanStrokeWidth="47">n</charParams>
+<charParams l="1886" t="2526" r="1908" b="2547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="100" wordPenalty="0" meanStrokeWidth="47">n</charParams>
+<charParams l="1909" t="2511" r="1928" b="2547" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="0" meanStrokeWidth="47">&#233;</charParams></formatting></line>
+<line baseline="2590" l="1175" t="2554" r="1929" b="2601"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1175" t="2555" r="1195" b="2588" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="40" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1198" t="2567" r="1215" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1216" t="2567" r="1226" b="2598"> </charParams>
+<charParams l="1227" t="2569" r="1245" b="2598" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="96" wordPenalty="0" meanStrokeWidth="39">p</charParams>
+<charParams l="1248" t="2569" r="1265" b="2591" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1268" t="2556" r="1277" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="0" wordPenalty="0" meanStrokeWidth="39">i</charParams>
+<charParams l="1282" t="2568" r="1300" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1303" t="2568" r="1321" b="2590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="73" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1322" t="2568" r="1333" b="2598"> </charParams>
+<charParams l="1334" t="2570" r="1351" b="2598" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="32" serifProbability="96" wordPenalty="4" meanStrokeWidth="38">p</charParams>
+<charParams l="1353" t="2569" r="1373" b="2590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="4" meanStrokeWidth="38">o</charParams>
+<charParams l="1376" t="2570" r="1395" b="2590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="91" wordPenalty="4" meanStrokeWidth="38">u</charParams>
+<charParams l="1398" t="2569" r="1412" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="4" meanStrokeWidth="38">r</charParams>
+<charParams l="1413" t="2569" r="1419" b="2589"> </charParams>
+<charParams l="1420" t="2570" r="1435" b="2589" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="1438" t="2555" r="1454" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="75" wordPenalty="2" meanStrokeWidth="38">&#233;</charParams>
+<charParams l="1456" t="2569" r="1475" b="2600" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="97" serifProbability="53" wordPenalty="2" meanStrokeWidth="38">g</charParams>
+<charParams l="1477" t="2555" r="1484" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">l</charParams>
+<charParams l="1488" t="2568" r="1506" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1509" t="2567" r="1522" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">r</charParams>
+<charParams l="1523" t="2554" r="1537" b="2588"> </charParams>
+<charParams l="1538" t="2554" r="1547" b="2587" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="87" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1551" t="2567" r="1568" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="82" wordPenalty="0" meanStrokeWidth="39">e</charParams>
+<charParams l="1570" t="2567" r="1583" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="32" wordPenalty="0" meanStrokeWidth="39">s</charParams>
+<charParams l="1584" t="2554" r="1596" b="2588"> </charParams>
+<charParams l="1597" t="2554" r="1616" b="2587" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="72" wordPenalty="0" meanStrokeWidth="31">d</charParams>
+<charParams l="1620" t="2567" r="1636" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="86" serifProbability="83" wordPenalty="0" meanStrokeWidth="31">e</charParams>
+<charParams l="1640" t="2568" r="1657" b="2599" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="53" wordPenalty="0" meanStrokeWidth="31">g</charParams>
+<charParams l="1660" t="2568" r="1675" b="2588" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="0" meanStrokeWidth="31">r</charParams>
+<charParams l="1678" t="2555" r="1694" b="2589" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="12" serifProbability="75" wordPenalty="0" meanStrokeWidth="31">&#233;</charParams>
+<charParams l="1696" t="2569" r="1709" b="2590" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="68" serifProbability="32" wordPenalty="0" meanStrokeWidth="31">s</charParams>
+<charParams l="1710" t="2557" r="1721" b="2590"> </charParams>
+<charParams l="1722" t="2557" r="1742" b="2590" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="72" wordPenalty="0" meanStrokeWidth="38">d</charParams>
+<charParams l="1745" t="2570" r="1765" b="2591" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1766" t="2558" r="1779" b="2591"> </charParams>
+<charParams l="1780" t="2558" r="1797" b="2590" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="50" wordPenalty="0" meanStrokeWidth="37">f</charParams>
+<charParams l="1793" t="2571" r="1809" b="2592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="83" wordPenalty="0" meanStrokeWidth="37">e</charParams>
+<charParams l="1814" t="2572" r="1835" b="2592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="100" wordPenalty="0" meanStrokeWidth="37">u</charParams>
+<charParams l="1844" t="2585" r="1852" b="2600" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="60" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">,</charParams>
+<charParams l="1853" t="2572" r="1865" b="2601"> </charParams>
+<charParams l="1866" t="2572" r="1884" b="2601" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">q</charParams>
+<charParams l="1888" t="2572" r="1906" b="2592" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="30" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1909" t="2572" r="1929" b="2594" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="83" wordPenalty="0" meanStrokeWidth="39">e</charParams></formatting></line>
+<line baseline="2634" l="1175" t="2600" r="1929" b="2644"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1175" t="2611" r="1194" b="2641" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="90" serifProbability="96" wordPenalty="1" meanStrokeWidth="39">p</charParams>
+<charParams l="1197" t="2612" r="1217" b="2633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="1" meanStrokeWidth="39">o</charParams>
+<charParams l="1220" t="2612" r="1239" b="2634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="1" meanStrokeWidth="39">u</charParams>
+<charParams l="1242" t="2613" r="1258" b="2633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="67" serifProbability="100" wordPenalty="1" meanStrokeWidth="39">r</charParams>
+<charParams l="1259" t="2600" r="1284" b="2634"> </charParams>
+<charParams l="1285" t="2600" r="1294" b="2634" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1297" t="2613" r="1315" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="92" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1316" t="2613" r="1339" b="2635"> </charParams>
+<charParams l="1340" t="2613" r="1357" b="2635" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1360" t="2614" r="1378" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1381" t="2614" r="1401" b="2634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="69" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1405" t="2602" r="1430" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">s</charParams>
+<charParams l="1405" t="2602" r="1430" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1432" t="2614" r="1445" b="2634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="61" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1448" t="2614" r="1465" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="66" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1468" t="2602" r="1495" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">c</charParams>
+<charParams l="1468" t="2602" r="1495" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="49" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1498" t="2601" r="1506" b="2633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="19" serifProbability="0" wordPenalty="0" meanStrokeWidth="38">i</charParams>
+<charParams l="1509" t="2613" r="1529" b="2634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">o</charParams>
+<charParams l="1532" t="2612" r="1551" b="2632" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="46" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">n</charParams>
+<charParams l="1552" t="2600" r="1578" b="2633"> </charParams>
+<charParams l="1579" t="2600" r="1598" b="2633" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="71" wordPenalty="0" meanStrokeWidth="26">d</charParams>
+<charParams l="1603" t="2611" r="1619" b="2633" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="31" serifProbability="83" wordPenalty="0" meanStrokeWidth="26">e</charParams>
+<charParams l="1622" t="2613" r="1635" b="2634" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="10" wordPenalty="0" meanStrokeWidth="26">s</charParams>
+<charParams l="1636" t="2601" r="1654" b="2643"> </charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5" italic="1">
+<charParams l="1655" t="2601" r="1686" b="2643" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">f</charParams>
+<charParams l="1680" t="2615" r="1698" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="255" wordPenalty="6" meanStrokeWidth="26">o</charParams>
+<charParams l="1702" t="2615" r="1720" b="2635" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="22" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">u</charParams>
+<charParams l="1724" t="2616" r="1739" b="2634" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">r</charParams>
+<charParams l="1741" t="2615" r="1760" b="2636" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="70" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">n</charParams>
+<charParams l="1764" t="2616" r="1778" b="2636" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="23" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">e</charParams>
+<charParams l="1780" t="2618" r="1799" b="2636" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="95" wordPenalty="6" meanStrokeWidth="26">a</charParams>
+<charParams l="1804" t="2617" r="1822" b="2637" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="-1" serifProbability="255" wordPenalty="6" meanStrokeWidth="26">u</charParams>
+<charParams l="1826" t="2618" r="1848" b="2638" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="6" meanStrokeWidth="26">x</charParams>
+<charParams l="1849" t="2617" r="1863" b="2644"> </charParams>
+<charParams l="1864" t="2617" r="1877" b="2644" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="38" serifProbability="255" wordPenalty="0" meanStrokeWidth="29">;</charParams></formatting><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1878" t="2607" r="1893" b="2644"> </charParams>
+<charParams l="1894" t="2607" r="1929" b="2639" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="0" wordNumeric="0" wordIdentifier="1" charConfidence="79" serifProbability="255" wordPenalty="0" meanStrokeWidth="29">&amp;</charParams></formatting></line>
+<line baseline="2681" l="1177" t="2644" r="1930" b="2688"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1177" t="2657" r="1193" b="2677" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="49" wordPenalty="2" meanStrokeWidth="38">c</charParams>
+<charParams l="1196" t="2658" r="1213" b="2679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="83" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1216" t="2658" r="1234" b="2688" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="82" serifProbability="96" wordPenalty="2" meanStrokeWidth="38">p</charParams>
+<charParams l="1239" t="2658" r="1255" b="2680" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="2" meanStrokeWidth="38">e</charParams>
+<charParams l="1258" t="2659" r="1278" b="2679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="100" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1280" t="2646" r="1298" b="2679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="80" wordPenalty="2" meanStrokeWidth="38">d</charParams>
+<charParams l="1303" t="2659" r="1317" b="2678" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="44" serifProbability="53" wordPenalty="2" meanStrokeWidth="38">a</charParams>
+<charParams l="1322" t="2658" r="1341" b="2679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="255" wordPenalty="2" meanStrokeWidth="38">n</charParams>
+<charParams l="1345" t="2656" r="1357" b="2680" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="25" serifProbability="61" wordPenalty="2" meanStrokeWidth="38">t</charParams>
+<charParams l="1358" t="2646" r="1378" b="2680"> </charParams>
+<charParams l="1379" t="2646" r="1388" b="2680" suspicious="1" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="39">l</charParams>
+<charParams l="1392" t="2647" r="1399" b="2660" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="39">&#8217;</charParams>
+<charParams l="1403" t="2660" r="1422" b="2681" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="71" serifProbability="91" wordPenalty="0" meanStrokeWidth="39">u</charParams>
+<charParams l="1425" t="2660" r="1446" b="2680" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="43" serifProbability="100" wordPenalty="0" meanStrokeWidth="39">n</charParams>
+<charParams l="1447" t="2648" r="1471" b="2680"> </charParams>
+<charParams l="1472" t="2648" r="1491" b="2680" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="255" wordPenalty="0" meanStrokeWidth="37">S</charParams>
+<charParams l="1491" t="2656" r="1504" b="2679" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="61" wordPenalty="0" meanStrokeWidth="37">t</charParams>
+<charParams l="1505" t="2644" r="1526" b="2679"> </charParams>
+<charParams l="1527" t="2644" r="1537" b="2679" wordFirst="1" wordLeftMost="1" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="26" wordPenalty="0" meanStrokeWidth="38">l</charParams>
+<charParams l="1540" t="2644" r="1548" b="2654" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="0" meanStrokeWidth="38">&#8217;</charParams>
+<charParams l="1549" t="2658" r="1568" b="2679" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="29" serifProbability="53" wordPenalty="0" meanStrokeWidth="38">a</charParams>
+<charParams l="1569" t="2658" r="1588" b="2679" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="74" serifProbability="91" wordPenalty="0" meanStrokeWidth="38">u</charParams>
+<charParams l="1591" t="2655" r="1604" b="2679" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="56" serifProbability="61" wordPenalty="0" meanStrokeWidth="38">t</charParams>
+<charParams l="1607" t="2658" r="1621" b="2678" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="51" serifProbability="100" wordPenalty="0" meanStrokeWidth="38">r</charParams>
+<charParams l="1623" t="2658" r="1641" b="2680" wordFromDictionary="0" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="82" wordPenalty="0" meanStrokeWidth="38">e</charParams>
+<charParams l="1642" t="2646" r="1664" b="2681"> </charParams>
+<charParams l="1665" t="2646" r="1685" b="2681" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="75" wordPenalty="15" meanStrokeWidth="36">d</charParams>
+<charParams l="1689" t="2659" r="1706" b="2681" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="82" wordPenalty="15" meanStrokeWidth="36">&#233;</charParams>
+<charParams l="1710" t="2659" r="1729" b="2681" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="45" serifProbability="50" wordPenalty="15" meanStrokeWidth="36">v</charParams>
+<charParams l="1733" t="2660" r="1752" b="2681" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="36" serifProbability="255" wordPenalty="15" meanStrokeWidth="36">o</charParams>
+<charParams l="1755" t="2649" r="1766" b="2682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="0" wordPenalty="15" meanStrokeWidth="36">i</charParams>
+<charParams l="1768" t="2661" r="1786" b="2684" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="20" serifProbability="26" wordPenalty="15" meanStrokeWidth="36">e</charParams>
+<charParams l="1788" t="2661" r="1808" b="2682" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="35" serifProbability="100" wordPenalty="15" meanStrokeWidth="36">n</charParams>
+<charParams l="1812" t="2659" r="1825" b="2685" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="18" serifProbability="61" wordPenalty="15" meanStrokeWidth="36">t</charParams>
+<charParams l="1826" t="2659" r="1851" b="2685"> </charParams>
+<charParams l="1852" t="2662" r="1870" b="2683" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="65" serifProbability="64" wordPenalty="13" meanStrokeWidth="39">a</charParams>
+<charParams l="1871" t="2649" r="1880" b="2683" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="24" serifProbability="26" wordPenalty="13" meanStrokeWidth="39">i</charParams>
+<charParams l="1880" t="2644" r="1891" b="2683" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="14" serifProbability="26" wordPenalty="13" meanStrokeWidth="39">l</charParams>
+<charParams l="1894" t="2662" r="1911" b="2684" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="83" wordPenalty="13" meanStrokeWidth="39">e</charParams>
+<charParams l="1911" t="2661" r="1930" b="2688" suspicious="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="13" serifProbability="255" wordPenalty="13" meanStrokeWidth="39">s</charParams></formatting></line>
+<line baseline="2726" l="1177" t="2689" r="1350" b="2726"><formatting lang="OldFrench" ff="Times New Roman" fs="10.5">
+<charParams l="1177" t="2701" r="1194" b="2726" wordFirst="1" wordLeftMost="1" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="50" serifProbability="83" wordPenalty="6" meanStrokeWidth="38">e</charParams>
+<charParams l="1197" t="2704" r="1218" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="15" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">n</charParams>
+<charParams l="1219" t="2689" r="1236" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="17" serifProbability="48" wordPenalty="6" meanStrokeWidth="38">s</charParams>
+<charParams l="1233" t="2702" r="1250" b="2726" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="48" serifProbability="83" wordPenalty="6" meanStrokeWidth="38">e</charParams>
+<charParams l="1253" t="2703" r="1284" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="100" wordPenalty="6" meanStrokeWidth="38">m</charParams>
+<charParams l="1289" t="2689" r="1307" b="2725" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="21" serifProbability="50" wordPenalty="6" meanStrokeWidth="38">b</charParams>
+<charParams l="1309" t="2689" r="1319" b="2724" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="47" serifProbability="26" wordPenalty="6" meanStrokeWidth="38">l</charParams>
+<charParams l="1322" t="2702" r="1340" b="2726" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="34" serifProbability="83" wordPenalty="6" meanStrokeWidth="38">e</charParams>
+<charParams l="1342" t="2717" r="1350" b="2726" wordFromDictionary="1" wordNormal="1" wordNumeric="0" wordIdentifier="0" charConfidence="100" serifProbability="255" wordPenalty="6" meanStrokeWidth="38">.</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Separator" blockName="" l="1134" t="425" r="1145" b="1402"><region><rect l="1134" t="425" r="1140" b="501"/><rect l="1136" t="501" r="1141" b="543"/><rect l="1137" t="543" r="1142" b="607"/><rect l="1138" t="607" r="1143" b="645"/><rect l="1139" t="645" r="1144" b="855"/><rect l="1137" t="855" r="1142" b="1118"/><rect l="1138" t="1118" r="1143" b="1207"/><rect l="1139" t="1207" r="1144" b="1262"/><rect l="1140" t="1262" r="1145" b="1402"/></region>
+<separator type="Black" thickness="5"><start x="1139" y="425"/><end x="1139" y="1402"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="1142" t="1406" r="1156" b="2706"><region><rect l="1144" t="1406" r="1150" b="1606"/><rect l="1145" t="1606" r="1151" b="1681"/><rect l="1146" t="1681" r="1152" b="1706"/><rect l="1145" t="1706" r="1152" b="1720"/><rect l="1146" t="1720" r="1152" b="1724"/><rect l="1145" t="1724" r="1152" b="1740"/><rect l="1144" t="1740" r="1151" b="1846"/><rect l="1143" t="1846" r="1149" b="1938"/><rect l="1142" t="1938" r="1148" b="2110"/><rect l="1145" t="2110" r="1149" b="2199"/><rect l="1146" t="2199" r="1151" b="2311"/><rect l="1148" t="2311" r="1153" b="2511"/><rect l="1150" t="2511" r="1155" b="2641"/><rect l="1152" t="2641" r="1156" b="2706"/></region>
+<separator type="Black" thickness="5"><start x="1149" y="1406"/><end x="1149" y="2706"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2319" t="77" r="2335" b="780"><region><rect l="2319" t="77" r="2334" b="109"/><rect l="2321" t="109" r="2334" b="135"/><rect l="2322" t="135" r="2328" b="142"/><rect l="2323" t="142" r="2332" b="159"/><rect l="2323" t="159" r="2333" b="175"/><rect l="2322" t="175" r="2333" b="179"/><rect l="2322" t="179" r="2334" b="182"/><rect l="2323" t="182" r="2334" b="207"/><rect l="2323" t="207" r="2333" b="217"/><rect l="2323" t="217" r="2334" b="227"/><rect l="2323" t="227" r="2333" b="235"/><rect l="2322" t="235" r="2329" b="241"/><rect l="2322" t="241" r="2333" b="242"/><rect l="2322" t="242" r="2334" b="246"/><rect l="2323" t="246" r="2334" b="252"/><rect l="2322" t="252" r="2334" b="267"/><rect l="2322" t="267" r="2332" b="270"/><rect l="2322" t="270" r="2333" b="304"/><rect l="2321" t="304" r="2333" b="316"/><rect l="2321" t="316" r="2333" b="330"/><rect l="2321" t="330" r="2329" b="339"/><rect l="2321" t="339" r="2333" b="351"/><rect l="2321" t="351" r="2333" b="415"/><rect l="2321" t="415" r="2329" b="421"/><rect l="2321" t="421" r="2329" b="424"/><rect l="2321" t="424" r="2329" b="450"/><rect l="2325" t="450" r="2329" b="458"/><rect l="2321" t="458" r="2329" b="462"/><rect l="2322" t="462" r="2329" b="490"/><rect l="2322" t="490" r="2329" b="502"/><rect l="2322" t="502" r="2331" b="580"/><rect l="2324" t="580" r="2333" b="718"/><rect l="2325" t="718" r="2334" b="732"/><rect l="2325" t="732" r="2334" b="750"/><rect l="2329" t="750" r="2334" b="755"/><rect l="2326" t="755" r="2334" b="762"/><rect l="2329" t="762" r="2335" b="780"/></region>
+<separator type="Black" thickness="7"><start x="2327" y="77"/><end x="2327" y="780"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2325" t="762" r="2331" b="946"><region><rect l="2325" t="762" r="2328" b="835"/><rect l="2326" t="835" r="2329" b="843"/><rect l="2326" t="843" r="2328" b="871"/><rect l="2327" t="871" r="2330" b="918"/><rect l="2328" t="918" r="2331" b="946"/></region>
+<separator type="Black" thickness="3"><start x="2328" y="762"/><end x="2328" y="946"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2330" t="780" r="2335" b="893"><region><rect l="2330" t="780" r="2334" b="818"/><rect l="2330" t="818" r="2335" b="860"/><rect l="2332" t="860" r="2335" b="893"/></region>
+<separator type="Black" thickness="4"><start x="2332" y="780"/><end x="2332" y="893"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2332" t="1054" r="2350" b="1393"><region><rect l="2332" t="1054" r="2340" b="1084"/><rect l="2333" t="1084" r="2341" b="1146"/><rect l="2334" t="1146" r="2342" b="1174"/><rect l="2335" t="1174" r="2343" b="1198"/><rect l="2336" t="1198" r="2344" b="1235"/><rect l="2338" t="1235" r="2346" b="1281"/><rect l="2339" t="1281" r="2347" b="1297"/><rect l="2339" t="1297" r="2348" b="1332"/><rect l="2340" t="1332" r="2350" b="1340"/><rect l="2341" t="1340" r="2350" b="1393"/></region>
+<separator type="Black" thickness="8"><start x="2341" y="1054"/><end x="2341" y="1393"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2336" t="710" r="2338" b="786"><region><rect l="2336" t="710" r="2338" b="786"/></region>
+<separator type="Black" thickness="2"><start x="2337" y="710"/><end x="2337" y="786"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2350" t="1563" r="2376" b="2861"><region><rect l="2350" t="1563" r="2360" b="1587"/><rect l="2351" t="1587" r="2361" b="1627"/><rect l="2353" t="1627" r="2361" b="1643"/><rect l="2353" t="1643" r="2370" b="1652"/><rect l="2353" t="1652" r="2371" b="1656"/><rect l="2353" t="1656" r="2361" b="1708"/><rect l="2355" t="1708" r="2362" b="1721"/><rect l="2355" t="1721" r="2372" b="1743"/><rect l="2355" t="1743" r="2371" b="1782"/><rect l="2355" t="1782" r="2362" b="1947"/><rect l="2356" t="1947" r="2363" b="2014"/><rect l="2357" t="2014" r="2364" b="2046"/><rect l="2358" t="2046" r="2365" b="2079"/><rect l="2359" t="2079" r="2366" b="2115"/><rect l="2359" t="2115" r="2376" b="2147"/><rect l="2359" t="2147" r="2366" b="2151"/><rect l="2361" t="2151" r="2367" b="2153"/><rect l="2361" t="2153" r="2368" b="2175"/><rect l="2362" t="2175" r="2369" b="2321"/><rect l="2365" t="2321" r="2370" b="2333"/><rect l="2365" t="2333" r="2371" b="2425"/><rect l="2366" t="2425" r="2372" b="2458"/><rect l="2367" t="2458" r="2373" b="2466"/><rect l="2367" t="2466" r="2374" b="2651"/><rect l="2369" t="2651" r="2376" b="2861"/></region>
+<separator type="Black" thickness="6"><start x="2363" y="1563"/><end x="2363" y="2861"/>
+</separator>
+</block>
+<block blockType="Separator" blockName="" l="2367" t="2876" r="2376" b="3014"><region><rect l="2369" t="2876" r="2376" b="2909"/><rect l="2368" t="2909" r="2375" b="2941"/><rect l="2367" t="2941" r="2375" b="3014"/></region>
+<separator type="Black" thickness="8"><start x="2371" y="2876"/><end x="2371" y="3014"/>
+</separator>
+</block>
+</page>
+</document>

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/FineReader10-schema-v1-with-skew.xsd
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/FineReader10-schema-v1-with-skew.xsd
@@ -1,0 +1,733 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+		targetNamespace="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml"
+		xmlns:tns="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml"
+		elementFormDefault="qualified">
+ <xs:annotation>
+  <xs:documentation xml:lang="en">Schema for representing OCR results exported from FineReader 10.0 SDK. Copyright 2001-2011 ABBYY, Inc.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:element name="document">
+  <xs:complexType>
+   <xs:sequence>
+    <xs:element name="documentData" minOccurs="0" maxOccurs="1">
+	 <xs:annotation>
+	  <xs:documentation xml:lang="en">Global document data
+	  </xs:documentation>
+	 </xs:annotation>
+	 <xs:complexType>
+	  <xs:sequence>
+	   <xs:element name="paragraphStyles" minOccurs="0" maxOccurs="1">
+	    <xs:annotation>
+	     <xs:documentation xml:lang="en">Paragraph formatting styles collection
+	     </xs:documentation>
+	    </xs:annotation>
+	    <xs:complexType>
+	     <xs:sequence>
+		  <xs:element name="paragraphStyle" minOccurs="0" maxOccurs="unbounded" type="tns:ParagraphStyleType">
+	       <xs:annotation>
+	        <xs:documentation xml:lang="en">Paragraph formatting style
+	        </xs:documentation>
+	       </xs:annotation>
+		  </xs:element>
+	     </xs:sequence>
+	    </xs:complexType>
+	   </xs:element>
+	   <xs:element name="sections" minOccurs="0" maxOccurs="1">
+	    <xs:annotation>
+	     <xs:documentation xml:lang="en">Document sections collection
+	     </xs:documentation>
+	    </xs:annotation>
+	    <xs:complexType>
+	     <xs:sequence>
+		  <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="tns:SectionType">
+	       <xs:annotation>
+	        <xs:documentation xml:lang="en">Section
+	        </xs:documentation>
+	       </xs:annotation>
+		  </xs:element>
+	     </xs:sequence>
+	    </xs:complexType>
+	   </xs:element>
+	  </xs:sequence>
+	 </xs:complexType>
+    </xs:element>
+    <xs:element name="page" minOccurs="0" maxOccurs="unbounded">
+     <xs:annotation>
+      <xs:documentation xml:lang="en">Recognized page
+      </xs:documentation>
+     </xs:annotation>
+     <xs:complexType>
+     <xs:sequence>
+       <xs:element name="block" minOccurs="0" maxOccurs="unbounded" type="tns:BlockType">
+        <xs:annotation>
+         <xs:documentation xml:lang="en">Recognized block
+         </xs:documentation>
+        </xs:annotation>
+       </xs:element>
+        <xs:element name="pageSection" minOccurs="0" maxOccurs="unbounded" type="tns:PageSectionType">
+           <xs:annotation>
+             <xs:documentation xml:lang="en">Page Section
+             </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+         <xs:element name="pageStream" minOccurs="0" maxOccurs="unbounded" type="tns:PageStreamType">
+           <xs:annotation>
+             <xs:documentation xml:lang="en">  Running titles and artefacts
+             </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+       </xs:sequence>
+       <xs:attribute name="width" type="xs:integer" use="required"/>
+       <xs:attribute name="height" type="xs:integer" use="required"/>
+       <xs:attribute name="resolution" type="xs:integer" use="required"/>
+       <xs:attribute name="originalCoords" type="xs:boolean" use="optional" default="false">
+         <xs:annotation>
+           <xs:documentation xml:lang="en">If true, all coordinates are relative to original image before opening, otherwise they are relative to the opened (deskewed) image</xs:documentation>
+         </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="rotation" use="optional" default="Normal">
+         <xs:annotation>
+           <xs:documentation xml:lang="en">Stores the type of rotation applied to original page image</xs:documentation>
+         </xs:annotation>        
+         <xs:simpleType>
+           <xs:restriction base="xs:string">
+             <xs:enumeration value="Normal"/>
+             <xs:enumeration value="RotatedClockwise"/>
+             <xs:enumeration value="RotatedUpsidedown"/>
+             <xs:enumeration value="RotatedCounterclockwise"/>
+           </xs:restriction>
+         </xs:simpleType>
+       </xs:attribute>
+       <xs:attribute name="isSkewCorrect" type="xs:boolean" use="optional"/>
+       <xs:attribute name="skewAngle" type="xs:string" use="optional"/>
+     </xs:complexType>
+    </xs:element>
+   </xs:sequence>
+   <xs:attribute name="version" type="xs:string" use="required"/>
+   <xs:attribute name="producer" type="xs:string" use="required"/>
+   <xs:attribute name="pagesCount" type="xs:integer" use="optional" default="1"/>
+   <xs:attribute name="mainLanguage" type="xs:string" use="optional"/>
+   <xs:attribute name="languages" type="xs:string" use="optional"/>
+  </xs:complexType>
+ </xs:element>
+ 
+ <xs:complexType name ="ParagraphStyleType">
+  <xs:sequence>
+    <xs:element name="fontStyle" minOccurs="0" maxOccurs="unbounded" type="tns:FontStyleType" />
+  </xs:sequence>
+  <xs:attribute name="id" type="xs:string" use="required" />
+  <xs:attribute name="name" type="xs:string" use="required" />
+  <xs:attribute name="mainFontStyleId" type="xs:string" use="required" /> 
+  <xs:attribute name="role" use="required">
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="text"/>
+     <xs:enumeration value="tableText"/>
+     <xs:enumeration value="heading"/>
+     <xs:enumeration value="tableHeading"/>
+     <xs:enumeration value="pictureCaption"/>
+     <xs:enumeration value="tableCaption"/>
+     <xs:enumeration value="contents" />
+     <xs:enumeration value="footnote" /> 
+     <xs:enumeration value="endnote" /> 
+     <xs:enumeration value="rt" /> 
+     <xs:enumeration value="garb" /> 
+     <xs:enumeration value="other" />
+     <xs:enumeration value="barcode" />
+     <xs:enumeration value="headingNumber" />
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="roleLevel" type="xs:integer" use="optional" default="-1" />
+  <xs:attribute name="align" type="tns:ParagraphAlignment" use="required" />
+  <xs:attribute name="rtl" type="xs:boolean" use="optional" default="false" />
+  <xs:attribute name="before" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="after" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="startIndent" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="leftIndent" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="rightIndent" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="lineSpacing" type="xs:integer" use="optional" default="-1" />
+  <xs:attribute name="lineSpacingRatio" type="xs:float" use="optional" default="1.0" />
+  <xs:attribute name="fixedLineSpacing" type="xs:boolean" use="optional" default="true" />
+ </xs:complexType>
+ 
+ <xs:complexType name="FontStyleType">
+  <xs:attribute name="id" type="xs:string" use="required" />
+  <xs:attribute name="baseFont" type="xs:boolean" use="optional" default="false" />
+  <xs:attribute name="italic" type="xs:boolean" use="optional" default="false" />
+  <xs:attribute name="bold" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="underline" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="strikeout" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="smallcaps" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="scaling" type="xs:integer" use="optional" default="1000" />
+  <xs:attribute name="spacing" type="xs:integer" use="optional" default="0" />
+  <xs:attribute name="color" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="ff" type="xs:string" use="required"/>
+  <xs:attribute name="fs" type="xs:float" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="PageSectionType">
+  <xs:sequence>
+   <xs:element name="pageStream" minOccurs="0" maxOccurs="unbounded" type="tns:PageStreamType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Page section is the sequence of page streams
+     </xs:documentation>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+   </xs:complexType>
+
+  <xs:complexType name="PageStreamType">
+    <xs:sequence>
+      <xs:element name="pageElement" minOccurs="0" maxOccurs="unbounded" type="tns:PageElementType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">  Page Stream is the sequence of page elements
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="streamType" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PageElementType">
+    <xs:sequence>
+        <xs:element name="text" minOccurs="0" maxOccurs="1" type="tns:TextType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">text</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="table" minOccurs="0" maxOccurs="1" type="tns:TableType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Table</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+       <xs:element name="barcode" minOccurs="0" maxOccurs="1" type="tns:BarcodeType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Barcode</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="picture" minOccurs="0" maxOccurs="1" type="tns:PictureType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Picture</xs:documentation>
+          </xs:annotation>
+         </xs:element>
+    </xs:sequence>
+    <xs:attribute name="pageElemId" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="TableType">
+    <xs:sequence>
+      <xs:element name="caption" minOccurs="0" maxOccurs="unbounded" type="tns:CaptionType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"> Table captions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tableCell" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"> Table cells
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence> 
+		    <xs:element name="pageElement" minOccurs="1" maxOccurs="1" type="tns:PageElementType">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Page element with cell contents (text or picture)
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="topPos" type="xs:integer" use="required" />
+          <xs:attribute name="bottomPos" type="xs:integer" use="required" />
+          <xs:attribute name="leftPos" type="xs:integer" use="required" />
+          <xs:attribute name="rightPos" type="xs:integer" use="required" />
+
+          <xs:attribute name="VerticalAlignment" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="PictureType">
+    <xs:sequence>
+      <xs:element name="pictureFile" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Image file relative path, presents if SavePicture export parameter is set to true</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="path" type="xs:string" use="required" />
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="caption" minOccurs="0" maxOccurs="unbounded" type="tns:CaptionType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">          Picture captions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="BarcodeType">
+    <xs:attribute name="BarcodeValue" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="CaptionType">
+    <xs:sequence>
+      <xs:element name="pageElement" minOccurs="0" maxOccurs="unbounded" type="tns:PageElementType" />     
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SectionType">
+    <xs:sequence>
+      <xs:element name="stream" minOccurs="0" maxOccurs="unbounded" type="tns:TextStreamType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Text Stream is the sequence of paragraphs and/or blocks
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+ <xs:complexType name="TextStreamType">
+  <xs:sequence>
+   <xs:element name="mainText" minOccurs="0" maxOccurs="1">
+     <xs:complexType>
+       <xs:attribute name="rtl" type="xs:boolean" use="optional" default="false" />
+       <xs:attribute name="columnCount" type="xs:integer" use="required" />
+     </xs:complexType>
+    </xs:element>
+   <xs:element name="elemId" minOccurs="0" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Id of page element 
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="id" type="xs:string" use="required" />
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="role" use="optional" default="text">
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="garb" /> 
+     <xs:enumeration value="text" /> 
+     <xs:enumeration value="footnote" /> 
+     <xs:enumeration value="incut" /> 
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="vertCjk" type="xs:boolean" use="optional" default="false" />
+  <xs:attribute name="beginPage" type="xs:integer" use="required" />
+  <xs:attribute name="endPage" type="xs:integer" use="optional" />
+ </xs:complexType>
+
+ <xs:complexType name="BlockType">
+  <xs:sequence>
+   <xs:element name="region" minOccurs="0" maxOccurs="1">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Block region, the set of rectangles
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+	 <xs:sequence>
+	  <xs:element name="rect" minOccurs="1" maxOccurs="unbounded">
+	   <xs:complexType>
+        <xs:attribute name="l" type="xs:integer" use="required"/>
+        <xs:attribute name="t" type="xs:integer" use="required"/>
+        <xs:attribute name="r" type="xs:integer" use="required"/>
+        <xs:attribute name="b" type="xs:integer" use="required"/>
+	   </xs:complexType>
+	  </xs:element>
+	 </xs:sequence>
+	</xs:complexType>
+   </xs:element>
+   <xs:element name="pictureFile" minOccurs="0" maxOccurs="1">
+     <xs:annotation>
+       <xs:documentation xml:lang="en">Image file relative path, presents if blockType attribute is Picture and SavePicture export parameter is set to true</xs:documentation>
+     </xs:annotation>
+	 <xs:complexType>
+       <xs:attribute name="path" type="xs:string" use="required" />
+     </xs:complexType>
+   </xs:element>
+   <xs:element name="text" minOccurs="0" maxOccurs="unbounded" type="tns:TextType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Recognized block text, presents if blockType attribute is Text</xs:documentation>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="row" minOccurs="0" maxOccurs="unbounded" type="tns:TableRowType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">The set of table rows, presents if blockType attribute is Table</xs:documentation>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="separatorsBox" minOccurs="0" maxOccurs="1">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Separators box block, presents if blockType attribute is SeparatorsBox</xs:documentation>
+    </xs:annotation>
+     <xs:complexType>
+       <xs:sequence>
+         <xs:element name="separator" minOccurs="0" maxOccurs="unbounded" type="tns:SeparatorBlockType">
+         </xs:element>
+       </xs:sequence>
+     </xs:complexType>
+   </xs:element >
+   <xs:element name="separator"  minOccurs="0" maxOccurs="1" type="tns:SeparatorBlockType">
+     <xs:annotation>
+       <xs:documentation xml:lang="en">Separator block, presents if blockType attribute is Separator</xs:documentation>
+     </xs:annotation>
+    </xs:element>
+   <xs:element name="barcodeInfo" minOccurs="0" maxOccurs="1" type="tns:BarcodeInfoType">
+     <xs:annotation>
+       <xs:documentation xml:lang="en">Information about barcode, presents if blockType attribute is Barcode</xs:documentation>
+     </xs:annotation>    
+    </xs:element>  
+  </xs:sequence>
+  <xs:attribute name="blockType" use="required">
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="Text"/>
+     <xs:enumeration value="Table"/>
+     <xs:enumeration value="Picture"/>
+     <xs:enumeration value="Barcode"/>
+     <xs:enumeration value="Separator"/>
+     <xs:enumeration value="SeparatorsBox"/>
+     <xs:enumeration value ="Checkmark"/>
+     <xs:enumeration value ="GroupCheckmark"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="pageElemId" type="xs:string" use="optional" />
+  <xs:attribute name="blockName" type="xs:string" use="optional"/>
+  <xs:attribute name="isHidden" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="l" type="xs:integer" use="optional"/>
+  <xs:attribute name="t" type="xs:integer" use="optional"/>
+  <xs:attribute name="r" type="xs:integer" use="optional"/>
+  <xs:attribute name="b" type="xs:integer" use="optional"/>
+
+ </xs:complexType>
+
+ <xs:complexType name="TextType">
+  <xs:sequence>
+   <xs:element name="par" minOccurs="0" maxOccurs="unbounded" type="tns:ParagraphType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Text paragraph</xs:documentation>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="id" type="xs:string" use="optional" />
+  <xs:attribute name="orientation" use="optional" default="Normal">
+    <xs:simpleType>
+     <xs:restriction base="xs:string">
+      <xs:enumeration value="Normal"/>
+      <xs:enumeration value="RotatedClockwise"/>
+      <xs:enumeration value="RotatedUpsidedown"/>
+      <xs:enumeration value="RotatedCounterclockwise"/>
+     </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="16777215"/>
+  <xs:attribute name="mirrored" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="inverted" type="xs:boolean" use="optional" default="false"/>
+ </xs:complexType>
+
+
+ <xs:complexType name="TableRowType">
+  <xs:sequence>
+   <xs:element name="cell" minOccurs="0" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Table cell</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="text" minOccurs="0" maxOccurs="unbounded" type="tns:TextType">
+       <xs:annotation>
+        <xs:documentation xml:lang="en">Cell text</xs:documentation>
+       </xs:annotation>
+	  </xs:element>
+     </xs:sequence>
+     <xs:attribute name="colSpan" type="xs:integer" use="optional" default="1"/>
+     <xs:attribute name="rowSpan" type="xs:integer" use="optional" default="1"/>
+	 <xs:attribute name="align" use="optional" default="Top">
+      <xs:simpleType>
+       <xs:restriction base="xs:string">
+        <xs:enumeration value="Top"/>
+        <xs:enumeration value="Center"/>
+        <xs:enumeration value="Bottom"/>
+       </xs:restriction>
+      </xs:simpleType>
+	 </xs:attribute>
+	 <xs:attribute name="picture" type="xs:boolean" use="optional" default="false"/>
+     <xs:attribute name="leftBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+     <xs:attribute name="topBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+     <xs:attribute name="rightBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+     <xs:attribute name="bottomBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+     <xs:attribute name="width" type="xs:integer" use="required"/>
+     <xs:attribute name="height" type="xs:integer" use="required"/>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+
+
+ <xs:complexType name="ParagraphType">
+  <xs:sequence>
+   <xs:element name="line" minOccurs="0" maxOccurs="unbounded" type="tns:LineType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Text paragraph line</xs:documentation>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="dropCapCharsCount" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="dropCap-l" type="xs:integer" use="optional"/>
+  <xs:attribute name="dropCap-t" type="xs:integer" use="optional"/>
+  <xs:attribute name="dropCap-r" type="xs:integer" use="optional"/>
+  <xs:attribute name="dropCap-b" type="xs:integer" use="optional"/>
+  <xs:attribute name="align" type="tns:ParagraphAlignment" use="optional" default="Left" />
+  <xs:attribute name="leftIndent" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="rightIndent" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="startIndent" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="lineSpacing" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="id" type="xs:string" use="optional" />
+  <xs:attribute name="style" type="xs:string" use="optional" />
+  <xs:attribute name="hasOverflowedHead" type="xs:boolean" use="optional" default="false">
+    <xs:annotation>
+      <xs:documentation>Attribute deprecated.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="hasOverflowedTail" type="xs:boolean" use="optional" default="false">
+    <xs:annotation>
+      <xs:documentation>Attribute deprecated.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="isListItem" type="xs:boolean" use="optional" default="false" />
+  <xs:attribute name="lstLvl" type="xs:integer" use="optional"/>
+  <xs:attribute name="lstNum" type="xs:integer" use="optional"/>
+</xs:complexType>
+ 
+<xs:simpleType name="ParagraphAlignment">
+ <xs:restriction base="xs:string">
+  <xs:enumeration value="Left"/>
+  <xs:enumeration value="Center"/>
+  <xs:enumeration value="Right"/>
+  <xs:enumeration value="Justified"/>
+  <xs:enumeration value ="CjkJustified"/>
+  <xs:enumeration value ="ThaiJustified"/>
+ </xs:restriction>
+</xs:simpleType>
+
+ <xs:complexType name="LineType">
+  <xs:sequence>
+   <xs:element name="formatting" minOccurs="0" maxOccurs="unbounded" type="tns:FormattingType">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Group of characters with uniform formatting</xs:documentation>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="baseline" type="xs:integer" use="required"/>
+  <xs:attribute name="l" type="xs:integer" use="required"/>
+  <xs:attribute name="t" type="xs:integer" use="required"/>
+  <xs:attribute name="r" type="xs:integer" use="required"/>
+  <xs:attribute name="b" type="xs:integer" use="required"/>
+ </xs:complexType>
+
+ <xs:complexType name="FormattingType" mixed="true">
+  <xs:sequence>
+   <xs:choice minOccurs="0" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation xml:lang="en">Attributes of characters are alternated with word's recognition variants. The variants of recognition of the word are written before the word</xs:documentation>
+    </xs:annotation>
+    <xs:element name="charParams" type="tns:CharParamsType">
+     <xs:annotation>
+      <xs:documentation xml:lang="en">Attributes of single character</xs:documentation>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="wordRecVariants">
+     <xs:annotation>
+      <xs:documentation xml:lang="en">Variants of recognition of the next word</xs:documentation>
+     </xs:annotation>
+     <xs:complexType>
+      <xs:sequence>
+       <xs:element name="wordRecVariant" minOccurs="0" maxOccurs="unbounded" type="tns:WordRecognitionVariant"/>
+      </xs:sequence>
+     </xs:complexType>
+    </xs:element>
+   </xs:choice>
+  </xs:sequence>
+  <xs:attribute name="lang" type="xs:string" use="required"/>
+  <xs:attribute name="ff" type="xs:string" use="optional"/>
+  <xs:attribute name="fs" type="xs:float" use="optional"/>
+  <xs:attribute name="bold" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="italic" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="subscript" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="superscript" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="smallcaps" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="underline" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="strikeout" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="color" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="scaling" type="xs:integer" use="optional" default="1000"/>
+  <xs:attribute name="spacing" type="xs:integer" use="optional" default="0"/>
+  <xs:attribute name="style" type="xs:string" use="optional" />
+  <xs:attribute name="base64encoded" type="xs:boolean" use="optional" default="false"/>
+ </xs:complexType>
+
+ <xs:complexType name="WordRecognitionVariant">
+  <xs:sequence>
+   <xs:element name="variantText" minOccurs="1" maxOccurs="1">
+    <xs:complexType mixed="true">
+     <xs:sequence>
+      <xs:element name="charParams" minOccurs="0" maxOccurs="unbounded" type="tns:CharParamsType"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="wordFromDictionary" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordNormal" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordNumeric" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordIdentifier" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordPenalty" type="xs:integer" use="optional"/>
+  <xs:attribute name="meanStrokeWidth" type="xs:integer" use="optional"/>
+ </xs:complexType>
+
+ <xs:complexType name="CharRecognitionVariant" mixed="true">
+  <xs:attribute name="charConfidence" type="xs:integer" use="optional"/>
+  <xs:attribute name="serifProbability" type="xs:integer" use="optional"/>  
+ </xs:complexType>
+
+ <xs:complexType name="CharParamsType" mixed="true">
+  <xs:sequence>
+   <xs:element name="charRecVariants" minOccurs="0">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="charRecVariant" minOccurs="0" maxOccurs="unbounded" type="tns:CharRecognitionVariant"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="l" type="xs:integer" use="required"/>
+  <xs:attribute name="t" type="xs:integer" use="required"/>
+  <xs:attribute name="r" type="xs:integer" use="required"/>
+  <xs:attribute name="b" type="xs:integer" use="required"/>
+  <xs:attribute name="suspicious" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="proofed" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="wordStart" type="xs:boolean" use="optional" default="false">
+    <xs:annotation>
+		  <xs:documentation>Attribute deprecated. "wordFirst" and "wordLeftMost" attributes should be used instead.</xs:documentation>
+	</xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="wordFirst" type="xs:boolean" use="optional"  default="false"/>
+  <xs:attribute name="wordLeftMost" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="wordFromDictionary" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordNormal" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordNumeric" type="xs:boolean" use="optional"/>
+  <xs:attribute name="wordIdentifier" type="xs:boolean" use="optional"/>
+  <xs:attribute name="charConfidence" type="xs:integer" use="optional"/>
+  <xs:attribute name="serifProbability" type="xs:integer" use="optional"/>
+  <xs:attribute name="wordPenalty" type="xs:integer" use="optional"/>
+  <xs:attribute name="meanStrokeWidth" type="xs:integer" use="optional"/>
+  <xs:attribute name="characterHeight" type="xs:integer" use="optional"/>
+  <xs:attribute name="hasUncertainHeight" type="xs:boolean" use="optional"/>
+  <xs:attribute name="baseLine" type="xs:integer" use="optional"/>
+  <xs:attribute name="isTab" type="xs:boolean" use="optional" default="false"/>
+  <xs:attribute name="tabLeaderCount" type="xs:integer" use="optional" default="1"/>
+ </xs:complexType>
+
+ <xs:simpleType name="TableCellBorderType">
+  <xs:restriction base="xs:string">
+   <xs:enumeration value="Absent"/>
+   <xs:enumeration value="Unknown"/>
+   <xs:enumeration value="White"/>
+   <xs:enumeration value="Black"/>
+  </xs:restriction>
+ </xs:simpleType>
+
+  <xs:complexType name="SeparatorBlockType" mixed="true">
+    <xs:sequence>
+      <xs:element name="start" minOccurs="1" maxOccurs="1" type="tns:Point">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Starting point of the separator</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="end" minOccurs="1" maxOccurs="1" type="tns:Point">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Ending point of the separator</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="thickness" type="xs:integer" use="required" />
+    <xs:attribute name="type" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Unknown"/>
+          <xs:enumeration value="Black"/>
+          <xs:enumeration value="Dotted"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="Point">
+   <xs:attribute name="x" type="xs:integer" use="required" />
+   <xs:attribute name="y" type="xs:integer" use="required" />
+ </xs:complexType>
+
+  <xs:complexType name="BarcodeInfoType">
+    <xs:attribute name="type" type="tns:BarcodeTypeEnum" use="required" />
+    <xs:attribute name="supplement" type="tns:BarcodeSupplementEnum" use="optional" default="void" />
+  </xs:complexType>
+
+  <xs:simpleType name="BarcodeTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CODE39"/>
+      <xs:enumeration value="INTERLEAVED25"/>
+      <xs:enumeration value="EAN13"/>
+      <xs:enumeration value="CODE128"/>
+      <xs:enumeration value="EAN8"/>
+      <xs:enumeration value="PDF417"/>
+      <xs:enumeration value="CODABAR" />
+      <xs:enumeration value="UPCE" />
+      <xs:enumeration value="INDUSTRIAL25" />
+      <xs:enumeration value="IATA25" />
+      <xs:enumeration value="MATRIX25" />
+      <xs:enumeration value="CODE93" />
+      <xs:enumeration value="POSTNET" />
+      <xs:enumeration value="UCC128" />
+      <xs:enumeration value="PATCH"/>
+      <xs:enumeration value="AZTEC"/>
+      <xs:enumeration value="DATAMATRIX"/>
+      <xs:enumeration value="QRCODE"/>
+      <xs:enumeration value="UPCA"/>
+      <xs:enumeration value="MAXICODE"/>
+      <xs:enumeration value="CODE32" />
+      <xs:enumeration value="FULLASCII" />
+      <xs:enumeration value="ROYAL" />
+      <xs:enumeration value="KIX" />
+      <xs:enumeration value="INTELLIGENT" />
+      <xs:enumeration value="AUSTRALIA_POST" />
+      <xs:enumeration value="JAPAN_POST" />
+      <xs:enumeration value="Unknown" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="BarcodeSupplementEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="void"/>
+      <xs:enumeration value="2dig"/>
+      <xs:enumeration value="5dig"/>
+    </xs:restriction>
+  </xs:simpleType>      
+
+</xs:schema>

--- a/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/FineReader10-schema-v1.xsd
+++ b/jhove-modules/xml-hul/src/test/resources/edu/harvard/hul/ois/jhove/module/FineReader10-schema-v1.xsd
@@ -1,0 +1,728 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml" xmlns:tns="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml" elementFormDefault="qualified">
+  <xs:annotation>
+    <xs:documentation xml:lang="en">Schema for representing OCR results exported from FineReader 10.0 SDK. Copyright 2001-2011 ABBYY, Inc.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="document">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="documentData" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Global document data
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="paragraphStyles" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation xml:lang="en">Paragraph formatting styles collection
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="paragraphStyle" minOccurs="0" maxOccurs="unbounded" type="tns:ParagraphStyleType">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">Paragraph formatting style
+                        </xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="sections" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation xml:lang="en">Document sections collection
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="section" minOccurs="0" maxOccurs="unbounded" type="tns:SectionType">
+                      <xs:annotation>
+                        <xs:documentation xml:lang="en">Section
+                        </xs:documentation>
+                      </xs:annotation>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="page" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Recognized page
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="block" minOccurs="0" maxOccurs="unbounded" type="tns:BlockType">
+                <xs:annotation>
+                  <xs:documentation xml:lang="en">Recognized block
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="pageSection" minOccurs="0" maxOccurs="unbounded" type="tns:PageSectionType">
+                <xs:annotation>
+                  <xs:documentation xml:lang="en">Page Section
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="pageStream" minOccurs="0" maxOccurs="unbounded" type="tns:PageStreamType">
+                <xs:annotation>
+                  <xs:documentation xml:lang="en">  Running titles and artefacts
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="width" type="xs:integer" use="required"/>
+            <xs:attribute name="height" type="xs:integer" use="required"/>
+            <xs:attribute name="resolution" type="xs:integer" use="required"/>
+            <xs:attribute name="originalCoords" type="xs:boolean" use="optional" default="false">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">If true, all coordinates are relative to original image before opening, otherwise they are relative to the opened (deskewed) image</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="rotation" use="optional" default="Normal">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Stores the type of rotation applied to original page image</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Normal"/>
+                  <xs:enumeration value="RotatedClockwise"/>
+                  <xs:enumeration value="RotatedUpsidedown"/>
+                  <xs:enumeration value="RotatedCounterclockwise"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="version" type="xs:string" use="required"/>
+      <xs:attribute name="producer" type="xs:string" use="required"/>
+      <xs:attribute name="pagesCount" type="xs:integer" use="optional" default="1"/>
+      <xs:attribute name="mainLanguage" type="xs:string" use="optional"/>
+      <xs:attribute name="languages" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name ="ParagraphStyleType">
+    <xs:sequence>
+      <xs:element name="fontStyle" minOccurs="0" maxOccurs="unbounded" type="tns:FontStyleType" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+    <xs:attribute name="name" type="xs:string" use="required" />
+    <xs:attribute name="mainFontStyleId" type="xs:string" use="required" />
+    <xs:attribute name="role" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="text"/>
+          <xs:enumeration value="tableText"/>
+          <xs:enumeration value="heading"/>
+          <xs:enumeration value="tableHeading"/>
+          <xs:enumeration value="pictureCaption"/>
+          <xs:enumeration value="tableCaption"/>
+          <xs:enumeration value="contents" />
+          <xs:enumeration value="footnote" />
+          <xs:enumeration value="endnote" />
+          <xs:enumeration value="rt" />
+          <xs:enumeration value="garb" />
+          <xs:enumeration value="other" />
+          <xs:enumeration value="barcode" />
+          <xs:enumeration value="headingNumber" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="roleLevel" type="xs:integer" use="optional" default="-1" />
+    <xs:attribute name="align" type="tns:ParagraphAlignment" use="required" />
+    <xs:attribute name="rtl" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="before" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="after" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="startIndent" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="leftIndent" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="rightIndent" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="lineSpacing" type="xs:integer" use="optional" default="-1" />
+    <xs:attribute name="lineSpacingRatio" type="xs:float" use="optional" default="1.0" />
+    <xs:attribute name="fixedLineSpacing" type="xs:boolean" use="optional" default="true" />
+  </xs:complexType>
+
+  <xs:complexType name="FontStyleType">
+    <xs:attribute name="id" type="xs:string" use="required" />
+    <xs:attribute name="baseFont" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="italic" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="bold" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="underline" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="strikeout" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="smallcaps" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="scaling" type="xs:integer" use="optional" default="1000" />
+    <xs:attribute name="spacing" type="xs:integer" use="optional" default="0" />
+    <xs:attribute name="color" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="ff" type="xs:string" use="required"/>
+    <xs:attribute name="fs" type="xs:float" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PageSectionType">
+    <xs:sequence>
+      <xs:element name="pageStream" minOccurs="0" maxOccurs="unbounded" type="tns:PageStreamType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Page section is the sequence of page streams
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PageStreamType">
+    <xs:sequence>
+      <xs:element name="pageElement" minOccurs="0" maxOccurs="unbounded" type="tns:PageElementType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">  Page Stream is the sequence of page elements
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="streamType" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PageElementType">
+    <xs:sequence>
+      <xs:element name="text" minOccurs="0" maxOccurs="1" type="tns:TextType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">text</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="table" minOccurs="0" maxOccurs="1" type="tns:TableType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Table</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="barcode" minOccurs="0" maxOccurs="1" type="tns:BarcodeType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Barcode</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="picture" minOccurs="0" maxOccurs="1" type="tns:PictureType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Picture</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="pageElemId" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="TableType">
+    <xs:sequence>
+      <xs:element name="caption" minOccurs="0" maxOccurs="unbounded" type="tns:CaptionType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"> Table captions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tableCell" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"> Table cells
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="pageElement" minOccurs="1" maxOccurs="1" type="tns:PageElementType">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Page element with cell contents (text or picture)
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="topPos" type="xs:integer" use="required" />
+          <xs:attribute name="bottomPos" type="xs:integer" use="required" />
+          <xs:attribute name="leftPos" type="xs:integer" use="required" />
+          <xs:attribute name="rightPos" type="xs:integer" use="required" />
+
+          <xs:attribute name="VerticalAlignment" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="top"/>
+                <xs:enumeration value="center"/>
+                <xs:enumeration value="bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="PictureType">
+    <xs:sequence>
+      <xs:element name="pictureFile" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Image file relative path, presents if SavePicture export parameter is set to true</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="path" type="xs:string" use="required" />
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="caption" minOccurs="0" maxOccurs="unbounded" type="tns:CaptionType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">          Picture captions
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="BarcodeType">
+    <xs:attribute name="BarcodeValue" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="CaptionType">
+    <xs:sequence>
+      <xs:element name="pageElement" minOccurs="0" maxOccurs="unbounded" type="tns:PageElementType" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SectionType">
+    <xs:sequence>
+      <xs:element name="stream" minOccurs="0" maxOccurs="unbounded" type="tns:TextStreamType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Text Stream is the sequence of paragraphs and/or blocks
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="TextStreamType">
+    <xs:sequence>
+      <xs:element name="mainText" minOccurs="0" maxOccurs="1">
+        <xs:complexType>
+          <xs:attribute name="rtl" type="xs:boolean" use="optional" default="false" />
+          <xs:attribute name="columnCount" type="xs:integer" use="required" />
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="elemId" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Id of page element 
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="role" use="optional" default="text">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="garb" />
+          <xs:enumeration value="text" />
+          <xs:enumeration value="footnote" />
+          <xs:enumeration value="incut" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="vertCjk" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="beginPage" type="xs:integer" use="required" />
+    <xs:attribute name="endPage" type="xs:integer" use="optional" />
+  </xs:complexType>
+
+  <xs:complexType name="BlockType">
+    <xs:sequence>
+      <xs:element name="region" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Block region, the set of rectangles
+          </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="rect" minOccurs="1" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:attribute name="l" type="xs:integer" use="required"/>
+                <xs:attribute name="t" type="xs:integer" use="required"/>
+                <xs:attribute name="r" type="xs:integer" use="required"/>
+                <xs:attribute name="b" type="xs:integer" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="pictureFile" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Image file relative path, presents if blockType attribute is Picture and SavePicture export parameter is set to true</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="path" type="xs:string" use="required" />
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="text" minOccurs="0" maxOccurs="unbounded" type="tns:TextType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Recognized block text, presents if blockType attribute is Text</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="row" minOccurs="0" maxOccurs="unbounded" type="tns:TableRowType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">The set of table rows, presents if blockType attribute is Table</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="separatorsBox" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Separators box block, presents if blockType attribute is SeparatorsBox</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="separator" minOccurs="0" maxOccurs="unbounded" type="tns:SeparatorBlockType">
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element >
+      <xs:element name="separator" minOccurs="0" maxOccurs="1" type="tns:SeparatorBlockType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Separator block, presents if blockType attribute is Separator</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="barcodeInfo" minOccurs="0" maxOccurs="1" type="tns:BarcodeInfoType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Information about barcode, presents if blockType attribute is Barcode</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="blockType" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Text"/>
+          <xs:enumeration value="Table"/>
+          <xs:enumeration value="Picture"/>
+          <xs:enumeration value="Barcode"/>
+          <xs:enumeration value="Separator"/>
+          <xs:enumeration value="SeparatorsBox"/>
+          <xs:enumeration value ="Checkmark"/>
+          <xs:enumeration value ="GroupCheckmark"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="pageElemId" type="xs:string" use="optional" />
+    <xs:attribute name="blockName" type="xs:string" use="optional"/>
+    <xs:attribute name="isHidden" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="l" type="xs:integer" use="optional"/>
+    <xs:attribute name="t" type="xs:integer" use="optional"/>
+    <xs:attribute name="r" type="xs:integer" use="optional"/>
+    <xs:attribute name="b" type="xs:integer" use="optional"/>
+
+  </xs:complexType>
+
+  <xs:complexType name="TextType">
+    <xs:sequence>
+      <xs:element name="par" minOccurs="0" maxOccurs="unbounded" type="tns:ParagraphType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Text paragraph</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="optional" />
+    <xs:attribute name="orientation" use="optional" default="Normal">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Normal"/>
+          <xs:enumeration value="RotatedClockwise"/>
+          <xs:enumeration value="RotatedUpsidedown"/>
+          <xs:enumeration value="RotatedCounterclockwise"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="16777215"/>
+    <xs:attribute name="mirrored" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="inverted" type="xs:boolean" use="optional" default="false"/>
+  </xs:complexType>
+
+
+  <xs:complexType name="TableRowType">
+    <xs:sequence>
+      <xs:element name="cell" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Table cell</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="text" minOccurs="0" maxOccurs="unbounded" type="tns:TextType">
+              <xs:annotation>
+                <xs:documentation xml:lang="en">Cell text</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="colSpan" type="xs:integer" use="optional" default="1"/>
+          <xs:attribute name="rowSpan" type="xs:integer" use="optional" default="1"/>
+          <xs:attribute name="align" use="optional" default="Top">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="Top"/>
+                <xs:enumeration value="Center"/>
+                <xs:enumeration value="Bottom"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="picture" type="xs:boolean" use="optional" default="false"/>
+          <xs:attribute name="leftBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+          <xs:attribute name="topBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+          <xs:attribute name="rightBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+          <xs:attribute name="bottomBorder" use="optional" type="tns:TableCellBorderType" default="Black"/>
+          <xs:attribute name="width" type="xs:integer" use="required"/>
+          <xs:attribute name="height" type="xs:integer" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="ParagraphType">
+    <xs:sequence>
+      <xs:element name="line" minOccurs="0" maxOccurs="unbounded" type="tns:LineType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Text paragraph line</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="dropCapCharsCount" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="dropCap-l" type="xs:integer" use="optional"/>
+    <xs:attribute name="dropCap-t" type="xs:integer" use="optional"/>
+    <xs:attribute name="dropCap-r" type="xs:integer" use="optional"/>
+    <xs:attribute name="dropCap-b" type="xs:integer" use="optional"/>
+    <xs:attribute name="align" type="tns:ParagraphAlignment" use="optional" default="Left" />
+    <xs:attribute name="leftIndent" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="rightIndent" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="startIndent" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="lineSpacing" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="id" type="xs:string" use="optional" />
+    <xs:attribute name="style" type="xs:string" use="optional" />
+    <xs:attribute name="hasOverflowedHead" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>Attribute deprecated.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="hasOverflowedTail" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>Attribute deprecated.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="isListItem" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="lstLvl" type="xs:integer" use="optional"/>
+    <xs:attribute name="lstNum" type="xs:integer" use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ParagraphAlignment">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Left"/>
+      <xs:enumeration value="Center"/>
+      <xs:enumeration value="Right"/>
+      <xs:enumeration value="Justified"/>
+      <xs:enumeration value ="CjkJustified"/>
+      <xs:enumeration value ="ThaiJustified"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="LineType">
+    <xs:sequence>
+      <xs:element name="formatting" minOccurs="0" maxOccurs="unbounded" type="tns:FormattingType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Group of characters with uniform formatting</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="baseline" type="xs:integer" use="required"/>
+    <xs:attribute name="l" type="xs:integer" use="required"/>
+    <xs:attribute name="t" type="xs:integer" use="required"/>
+    <xs:attribute name="r" type="xs:integer" use="required"/>
+    <xs:attribute name="b" type="xs:integer" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="FormattingType" mixed="true">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Attributes of characters are alternated with word's recognition variants. The variants of recognition of the word are written before the word</xs:documentation>
+        </xs:annotation>
+        <xs:element name="charParams" type="tns:CharParamsType">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Attributes of single character</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="wordRecVariants">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Variants of recognition of the next word</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="wordRecVariant" minOccurs="0" maxOccurs="unbounded" type="tns:WordRecognitionVariant"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="lang" type="xs:string" use="required"/>
+    <xs:attribute name="ff" type="xs:string" use="optional"/>
+    <xs:attribute name="fs" type="xs:float" use="optional"/>
+    <xs:attribute name="bold" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="italic" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="subscript" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="superscript" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="smallcaps" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="underline" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="strikeout" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="color" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="backgroundColor" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="scaling" type="xs:integer" use="optional" default="1000"/>
+    <xs:attribute name="spacing" type="xs:integer" use="optional" default="0"/>
+    <xs:attribute name="style" type="xs:string" use="optional" />
+    <xs:attribute name="base64encoded" type="xs:boolean" use="optional" default="false"/>
+  </xs:complexType>
+
+  <xs:complexType name="WordRecognitionVariant">
+    <xs:sequence>
+      <xs:element name="variantText" minOccurs="1" maxOccurs="1">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element name="charParams" minOccurs="0" maxOccurs="unbounded" type="tns:CharParamsType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="wordFromDictionary" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordNormal" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordNumeric" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordIdentifier" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordPenalty" type="xs:integer" use="optional"/>
+    <xs:attribute name="meanStrokeWidth" type="xs:integer" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CharRecognitionVariant" mixed="true">
+    <xs:attribute name="charConfidence" type="xs:integer" use="optional"/>
+    <xs:attribute name="serifProbability" type="xs:integer" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="CharParamsType" mixed="true">
+    <xs:sequence>
+      <xs:element name="charRecVariants" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="charRecVariant" minOccurs="0" maxOccurs="unbounded" type="tns:CharRecognitionVariant"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="l" type="xs:integer" use="required"/>
+    <xs:attribute name="t" type="xs:integer" use="required"/>
+    <xs:attribute name="r" type="xs:integer" use="required"/>
+    <xs:attribute name="b" type="xs:integer" use="required"/>
+    <xs:attribute name="suspicious" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="proofed" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="wordStart" type="xs:boolean" use="optional" default="false">
+      <xs:annotation>
+        <xs:documentation>Attribute deprecated. "wordFirst" and "wordLeftMost" attributes should be used instead.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="wordFirst" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="wordLeftMost" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="wordFromDictionary" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordNormal" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordNumeric" type="xs:boolean" use="optional"/>
+    <xs:attribute name="wordIdentifier" type="xs:boolean" use="optional"/>
+    <xs:attribute name="charConfidence" type="xs:integer" use="optional"/>
+    <xs:attribute name="serifProbability" type="xs:integer" use="optional"/>
+    <xs:attribute name="wordPenalty" type="xs:integer" use="optional"/>
+    <xs:attribute name="meanStrokeWidth" type="xs:integer" use="optional"/>
+    <xs:attribute name="characterHeight" type="xs:integer" use="optional"/>
+    <xs:attribute name="hasUncertainHeight" type="xs:boolean" use="optional"/>
+    <xs:attribute name="baseLine" type="xs:integer" use="optional"/>
+    <xs:attribute name="isTab" type="xs:boolean" use="optional" default="false"/>
+    <xs:attribute name="tabLeaderCount" type="xs:integer" use="optional" default="1"/>
+  </xs:complexType>
+
+  <xs:simpleType name="TableCellBorderType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Absent"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="White"/>
+      <xs:enumeration value="Black"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="SeparatorBlockType" mixed="true">
+    <xs:sequence>
+      <xs:element name="start" minOccurs="1" maxOccurs="1" type="tns:Point">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Starting point of the separator</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="end" minOccurs="1" maxOccurs="1" type="tns:Point">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Ending point of the separator</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="thickness" type="xs:integer" use="required" />
+    <xs:attribute name="type" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Unknown"/>
+          <xs:enumeration value="Black"/>
+          <xs:enumeration value="Dotted"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="Point">
+    <xs:attribute name="x" type="xs:integer" use="required" />
+    <xs:attribute name="y" type="xs:integer" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="BarcodeInfoType">
+    <xs:attribute name="type" type="tns:BarcodeTypeEnum" use="required" />
+    <xs:attribute name="supplement" type="tns:BarcodeSupplementEnum" use="optional" default="void" />
+  </xs:complexType>
+
+  <xs:simpleType name="BarcodeTypeEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CODE39"/>
+      <xs:enumeration value="INTERLEAVED25"/>
+      <xs:enumeration value="EAN13"/>
+      <xs:enumeration value="CODE128"/>
+      <xs:enumeration value="EAN8"/>
+      <xs:enumeration value="PDF417"/>
+      <xs:enumeration value="CODABAR" />
+      <xs:enumeration value="UPCE" />
+      <xs:enumeration value="INDUSTRIAL25" />
+      <xs:enumeration value="IATA25" />
+      <xs:enumeration value="MATRIX25" />
+      <xs:enumeration value="CODE93" />
+      <xs:enumeration value="POSTNET" />
+      <xs:enumeration value="UCC128" />
+      <xs:enumeration value="PATCH"/>
+      <xs:enumeration value="AZTEC"/>
+      <xs:enumeration value="DATAMATRIX"/>
+      <xs:enumeration value="QRCODE"/>
+      <xs:enumeration value="UPCA"/>
+      <xs:enumeration value="MAXICODE"/>
+      <xs:enumeration value="CODE32" />
+      <xs:enumeration value="FULLASCII" />
+      <xs:enumeration value="ROYAL" />
+      <xs:enumeration value="KIX" />
+      <xs:enumeration value="INTELLIGENT" />
+      <xs:enumeration value="AUSTRALIA_POST" />
+      <xs:enumeration value="JAPAN_POST" />
+      <xs:enumeration value="Unknown" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="BarcodeSupplementEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="void"/>
+      <xs:enumeration value="2dig"/>
+      <xs:enumeration value="5dig"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
Case insensitive search of SchemaURI in jhove.conf does not work. In XMLModuleHandler.java line 332, the SchemaURI from the XML file is converted to lower case before performing the lookup, but the SchemaURI values from the jhove.conf are loaded as-is in XMLModule.java. This PR fixes this by converting the SchemaURI loaded from jhove.conf to lower case as well. A test case was added as well using a FineReader sample XML from the test corpus.