### PR TITLE
XML Schema caching

### DIFF
--- a/docs/modules/xml/index.md
+++ b/docs/modules/xml/index.md
@@ -42,6 +42,23 @@ Example: `schema=http://example.com/schema.xsd;C:\schemas\example.com\schema.xsd
 
 Indicates that [textMD](/references#textmd) metadata should be included as part of a document's representation information.
 
+**cacheDirectory=_path-for-schema-cache_**
+
+Specifies the path where downloaded XML schema files will be cached. If the parameter is omitted, there will be no caching enabled.
+
+The schema files will be stored in a sub-path derived from the download URL. `https://www.example.com/schema/example.xsd` will be cached as `<cacheDirectory>/www.example.com/schema/example.xsd`.
+
+**cacheExpiration=_expiration-time-in-seconds_**
+
+The number of seconds the cached file will remain valid. If the file is expired, it will no longer be used and be overwritten with a newly downloaded file
+upon the next request for this schema.
+
+Note that the file will not be deleted after the expiration time, it will just no longer be used. Provide your own cleanup routine if you want expired schema files to be physically removed from the cache.
+
+The file's modification time is used as a reference point to calculate the expiration timestamp from.
+
+A negative value causes the cached files to never expire.
+
 {: #coverage .section-heading}
 ## 2 Coverage
 

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/XmlModule.java
@@ -107,6 +107,12 @@ public class XmlModule extends ModuleBase {
     /** Map of URLs to locally stored schemas. */
     protected Map<String, File> _localSchemas;
 
+    /** Optional directory for cached downloaded schemas. */
+    protected File _schemaCacheDirectory;
+
+    /** Expiration time for cached schemas in seconds. Negative means never expire. */
+    protected long _schemaCacheExpiration;
+
     /**
      * Class constructor.
      *
@@ -160,6 +166,8 @@ public class XmlModule extends ModuleBase {
     public void resetParams() {
         _baseURL = null;
         _localSchemas = new HashMap<>();
+        _schemaCacheDirectory = null;
+        _schemaCacheExpiration = -1;
         _parseFromSig = false;
         _sigWantsDecl = false;
         _withTextMD = false;
@@ -196,7 +204,38 @@ public class XmlModule extends ModuleBase {
         if (param != null) {
             param = param.trim();
             String lowerCaseParam = param.toLowerCase();
-            if (lowerCaseParam.startsWith("schema=")) {
+            if (lowerCaseParam.startsWith("schemacachedirectory=")
+                    || lowerCaseParam.startsWith("cachedirectory=")) {
+                int eq = param.indexOf('=');
+                if (eq >= 0) {
+                    String dir = param.substring(eq + 1);
+                    if (!dir.isEmpty()) {
+                        File cacheDir = new File(dir);
+                        if (!cacheDir.exists()) {
+                            cacheDir.mkdirs();
+                        }
+                        if (cacheDir.isDirectory()) {
+                            _schemaCacheDirectory = cacheDir;
+                        } else {
+                            _logger.warning("Ignoring module parameter with invalid cache directory: \""
+                                    + dir + "\"");
+                        }
+                    }
+                }
+            } else if (lowerCaseParam.startsWith("schemacacheexpiration=")
+                    || lowerCaseParam.startsWith("cacheexpiration=")) {
+                int eq = param.indexOf('=');
+                if (eq >= 0) {
+                    String value = param.substring(eq + 1);
+                    try {
+                        long seconds = Long.parseLong(value);
+                        _schemaCacheExpiration = seconds;
+                    } catch (NumberFormatException nfe) {
+                        _logger.warning("Ignoring module parameter with invalid cache expiration: \""
+                                + value + "\"");
+                    }
+                }
+            } else if (lowerCaseParam.startsWith("schema=")) {
                 addLocalSchema(param);
             } else if (lowerCaseParam.startsWith("s")) {
                 _sigWantsDecl = true;
@@ -300,6 +339,8 @@ public class XmlModule extends ModuleBase {
             handler = new XmlModuleHandler();
             handler.setXhtmlFlag(_xhtmlDoctype != null);
             handler.setLocalSchemas(_localSchemas);
+            handler.setCacheDirectory(_schemaCacheDirectory);
+            handler.setCacheExpiration(_schemaCacheExpiration);
             parser.setContentHandler(handler);
             parser.setErrorHandler(handler);
             parser.setEntityResolver(handler);

--- a/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
+++ b/jhove-modules/xml-hul/src/main/java/edu/harvard/hul/ois/jhove/module/xml/XmlModuleHandler.java
@@ -8,10 +8,15 @@ package edu.harvard.hul.ois.jhove.module.xml;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.channels.FileLock;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -38,6 +44,8 @@ import edu.harvard.hul.ois.jhove.messages.JhoveMessages;
  * @author Gary McGath
  */
 public class XmlModuleHandler extends DefaultHandler {
+
+    private static final Map<String, Object> CACHE_FILE_LOCKS = new ConcurrentHashMap<>();
 
     /** Map of namespace prefixes to URIs. */
     private Map<String, String> _namespaces;
@@ -111,6 +119,12 @@ public class XmlModuleHandler extends DefaultHandler {
     /** Map from URIs to local schema files. */
     private Map<String, File> _localSchemas;
 
+    /** Schema cache directory. */
+    private File _cacheDir;
+
+    /** Schema cache expiration time (in milliseconds). */
+    private long _cacheExp;
+
     /**
      * Constructor.
      */
@@ -128,6 +142,8 @@ public class XmlModuleHandler extends DefaultHandler {
         _schemas = new LinkedList<>();
         _unparsedEntities = new LinkedList<>();
         _notations = new LinkedList<>();
+        _cacheDir = null;
+        _cacheExp = -1;
         _sigFlag = false;
     }
 
@@ -145,6 +161,20 @@ public class XmlModuleHandler extends DefaultHandler {
      */
     public void setLocalSchemas(Map<String, File> schemas) {
         _localSchemas = schemas;
+    }
+
+    /**
+     * Sets the schema cache directory used for downloaded XML schemas.
+     */
+    public void setCacheDirectory(File cacheDirectory) {
+        _cacheDir = cacheDirectory;
+    }
+
+    /**
+     * Sets the expiration time for cached schemas, in milliseconds.
+     */
+    public void setCacheExpiration(long cacheExpiration) {
+        _cacheExp = cacheExpiration * 1000L;
     }
 
     /**
@@ -343,9 +373,9 @@ public class XmlModuleHandler extends DefaultHandler {
         // Attempt to resolve public identifiers to local JHOVE resources.
         InputSource ent = DTDMapper.publicIDToFile(publicId);
 
-        // Attempt to resolve redirected URLs.
+        // Attempt to resolve using the URLs.
         if (ent == null) {
-            return this.resolveEntity(systemId);
+            return this.resolveEntityFromURL(systemId);
         } else {
             // A little magic so SAX won't give up in advance on
             // relative URI's.
@@ -355,22 +385,33 @@ public class XmlModuleHandler extends DefaultHandler {
         return ent;
     }
 
-    private final InputSource resolveEntity(String entityUrl) throws SAXException {
+    /**
+     * Attempts to resolve the given system ID as a URL, following redirects
+     * and using a local cache for downloaded schemas if configured. Returns
+     * an InputSource for the resolved entity, or null if it cannot be resolved.
+     */
+    private final InputSource resolveEntityFromURL(String entityUrl) throws SAXException {
         try {
-            URLConnection conn = new URL(entityUrl).openConnection();
+            URL url = new URL(entityUrl);
+            File cacheFile = getCachedSchemaFile(url);
+            if (cacheFile != null) {
+                if (cacheFile.exists() && isCacheFresh(cacheFile)) {
+                    return new InputSource(new FileInputStream(cacheFile));
+                }
+                File downloaded = downloadToCache(url, cacheFile);
+                if (downloaded != null) {
+                    return new InputSource(new FileInputStream(downloaded));
+                }
+                if (cacheFile.exists()) {
+                    return new InputSource(new FileInputStream(cacheFile));
+                }
+            }
+
+            URLConnection conn = openURLWithRedirects(url);
             if (conn instanceof HttpURLConnection) {
                 int status = ((HttpURLConnection) conn).getResponseCode();
                 if (status == HttpURLConnection.HTTP_OK) {
                     return new InputSource(conn.getInputStream());
-                }
-                if (status == HttpURLConnection.HTTP_MOVED_TEMP
-                        || status == HttpURLConnection.HTTP_MOVED_PERM
-                        || status == HttpURLConnection.HTTP_SEE_OTHER
-                        || status == 307
-                        || status == 308) {
-
-                    String newUrl = conn.getHeaderField("Location");
-                    return this.resolveEntity(newUrl);
                 }
             }
         } catch (IOException ioe) {
@@ -379,6 +420,185 @@ public class XmlModuleHandler extends DefaultHandler {
             throw new SAXException(ioe);
         }
         return null;
+    }
+
+    /**
+     * Checks if the cache file is fresh based on the configured expiration time (in seconds).
+     */
+    private boolean isCacheFresh(File cacheFile) {
+        if (cacheFile == null || !cacheFile.exists()) {
+            return false;
+        }
+        if (_cacheExp < 0) {
+            return true;
+        }
+        long age = System.currentTimeMillis() - cacheFile.lastModified();
+        return age < _cacheExp;
+    }
+
+    /**
+     * Returns a File object for the cached schema corresponding to the given URL,
+     * or null if caching is not configured or the URL is not valid for caching.
+     */
+    private File getCachedSchemaFile(URL url) {
+        if (_cacheDir == null || url == null) {
+            return null;
+        }
+        String protocol = url.getProtocol();
+        if (!"http".equalsIgnoreCase(protocol)
+                && !"https".equalsIgnoreCase(protocol)) {
+            return null;
+        }
+        String cachedPath = getCacheRelativePath(url);
+        if (cachedPath == null || cachedPath.isEmpty()) {
+            return null;
+        }
+        File cacheFile = new File(_cacheDir, cachedPath);
+        File parentDir = cacheFile.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+        return cacheFile;
+    }
+
+    /**
+     * Generates a relative path for caching the schema based on the URL. This method
+     * converts the URL into a filesystem-friendly path by using the host and path components.
+     */
+    private String getCacheRelativePath(URL url) {
+        try {
+            URI uri = url.toURI();
+            String path = uri.getHost();
+            if (path == null) {
+                path = uri.getPath();
+            } else {
+                path += uri.getPath();
+            }
+            if (path == null) {
+                return null;
+            }
+            while (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            path = path.replaceAll("[^a-zA-Z0-9./_-]", "_");
+            return path;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Downloads the file at the given URL to the cache file, if possible.
+     * 
+     * It supports multiple instances downloading simultaneously by using 
+     * a lock file to coordinate access to the cache file. If the download 
+     * is successful, it returns the cache file. If the download fails but 
+     * a cache file already exists, it returns the existing cache file. 
+     * 
+     * If the download fails and no cache file exists, it returns null.
+     */
+    private File downloadToCache(URL url, File cacheFile) {
+        if (cacheFile == null) {
+            return null;
+        }
+
+        Object localLock;
+        try {
+            localLock = CACHE_FILE_LOCKS.computeIfAbsent(cacheFile.getCanonicalPath(), k -> new Object());
+        } catch (IOException e) {
+            localLock = new Object();
+        }
+
+        synchronized (localLock) {
+            File lockFile = new File(cacheFile.getAbsolutePath() + ".lock");
+            FileLock lock = null;
+            RandomAccessFile lockRaf = null;
+
+            try {
+                // Acquire exclusive lock to coordinate concurrent downloads across processes
+                lockRaf = new RandomAccessFile(lockFile, "rw");
+                lock = lockRaf.getChannel().lock();
+
+                // Double-check if cache file was created by another process
+                if (cacheFile.exists() && isCacheFresh(cacheFile)) {
+                    return cacheFile;
+                }
+
+                // Download the file to a temporary location
+                URLConnection conn = openURLWithRedirects(url);
+                File tempFile = new File(cacheFile.getAbsolutePath() + ".download");
+                try (InputStream in = conn.getInputStream();
+                        FileOutputStream out = new FileOutputStream(tempFile)) {
+                    byte[] buf = new byte[8192];
+                    int n;
+                    while ((n = in.read(buf)) != -1) {
+                        out.write(buf, 0, n);
+                    }
+                }
+
+                // Atomically rename temp file to cache file
+                if (!tempFile.renameTo(cacheFile)) {
+                    if (cacheFile.exists()) {
+                        cacheFile.delete();
+                    }
+                    tempFile.renameTo(cacheFile);
+                }
+                return cacheFile;
+            } catch (IOException ioe) {
+                if (cacheFile.exists()) {
+                    return cacheFile;
+                }
+                return null;
+            } finally {
+                // Release lock and clean up resources
+                if (lock != null) {
+                    try {
+                        lock.release();
+                    } catch (IOException e) {
+                        // Ignore lock release errors
+                    }
+                }
+                if (lockRaf != null) {
+                    try {
+                        lockRaf.close();
+                    } catch (IOException e) {
+                        // Ignore close errors
+                    }
+                }
+                // Clean up lock file
+                if (lockFile.exists()) {
+                    lockFile.delete();
+                }
+            }
+        }
+    }
+
+    /**
+     * Opens a URL connection, following redirects.
+     */
+    private URLConnection openURLWithRedirects(URL url) throws IOException {
+        URLConnection conn = url.openConnection();
+        if (conn instanceof HttpURLConnection) {
+            int status = ((HttpURLConnection) conn).getResponseCode();
+            if (isRedirectStatus(status)) {
+                String newUrl = conn.getHeaderField("Location");
+                if (newUrl != null && !newUrl.isEmpty()) {
+                    return openURLWithRedirects(new URL(newUrl));
+                }
+            }
+        }
+        return conn;
+    }
+
+    /**
+     * Checks if the given HTTP status code indicates a redirect.
+     */
+    private boolean isRedirectStatus(int status) {
+        return status == HttpURLConnection.HTTP_MOVED_TEMP
+                || status == HttpURLConnection.HTTP_MOVED_PERM
+                || status == HttpURLConnection.HTTP_SEE_OTHER
+                || status == 307
+                || status == 308;
     }
 
     /**

--- a/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleCacheTest.java
+++ b/jhove-modules/xml-hul/src/test/java/edu/harvard/hul/ois/jhove/module/XmlModuleCacheTest.java
@@ -1,0 +1,250 @@
+package edu.harvard.hul.ois.jhove.module;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import edu.harvard.hul.ois.jhove.JhoveBase;
+import edu.harvard.hul.ois.jhove.JhoveException;
+import edu.harvard.hul.ois.jhove.RepInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class XmlModuleCacheTest {
+
+    private static final String XML_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"%s\">\n" +
+            "  <child>value</child>\n" +
+            "</root>\n";
+
+    private static final String XSD_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\">\n" +
+            "  <xs:element name=\"root\">\n" +
+            "    <xs:complexType>\n" +
+            "      <xs:sequence>\n" +
+            "        <xs:element name=\"child\" type=\"xs:string\"/>\n" +
+            "      </xs:sequence>\n" +
+            "    </xs:complexType>\n" +
+            "  </xs:element>\n" +
+            "</xs:schema>\n";
+
+    private HttpServer server;
+    private ExecutorService serverExecutor;
+    private Path tempDir;
+
+    @Before
+    public void setup() throws IOException {
+        tempDir = Files.createTempDirectory("xml-cache-test");
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+            serverExecutor = null;
+        }
+        if (tempDir != null) {
+            deleteRecursively(tempDir.toFile());
+            tempDir = null;
+        }
+    }
+
+    @Test
+    public void shouldNotCacheSchemaWithoutCacheDirectory() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger(0);
+        startHttpServer(requestCount, false);
+
+        XmlModule module = createModule();
+        String xml = String.format(XML_TEMPLATE, getSchemaUrl());
+
+        validateDocument(module, xml);
+        validateDocument(module, xml);
+
+        assertEquals(2, requestCount.get());
+    }
+
+    @Test
+    public void shouldCacheSchemaWithCacheDirectory() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger(0);
+        startHttpServer(requestCount, false);
+
+        XmlModule module = createModule();
+        module.param("schemacachedirectory=" + tempDir.toFile().getAbsolutePath());
+        String xml = String.format(XML_TEMPLATE, getSchemaUrl());
+
+        validateDocument(module, xml);
+        validateDocument(module, xml);
+
+        assertEquals(1, requestCount.get());
+        Path cachedSchema = tempDir.resolve("localhost").resolve("test.xsd");
+        assertTrue(Files.exists(cachedSchema));
+        assertTrue(Files.isRegularFile(cachedSchema));
+        assertTrue(Files.notExists(tempDir.resolve("localhost").resolve("test.xsd.download")));
+    }
+
+    @Test
+    public void shouldExpireVeryShortCache() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger(0);
+        startHttpServer(requestCount, false);
+
+        XmlModule module = createModule();
+        module.param("schemacachedirectory=" + tempDir.toFile().getAbsolutePath());
+        module.param("schemacacheexpiration=1");
+        String xml = String.format(XML_TEMPLATE, getSchemaUrl());
+
+        validateDocument(module, xml);
+        // Allow the cached schema to expire before validating again.
+        TimeUnit.MILLISECONDS.sleep(1100);
+        validateDocument(module, xml);
+
+        assertEquals(2, requestCount.get());
+    }
+
+    @Test
+    public void shouldUsePermanentCacheWhenExpirationNotSet() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger(0);
+        startHttpServer(requestCount, false);
+
+        XmlModule module = createModule();
+        module.param("schemacachedirectory=" + tempDir.toFile().getAbsolutePath());
+        String xml = String.format(XML_TEMPLATE, getSchemaUrl());
+
+        validateDocument(module, xml);
+        validateDocument(module, xml);
+
+        assertEquals(1, requestCount.get());
+        Path cachedSchema = tempDir.resolve("localhost").resolve("test.xsd");
+        assertTrue(Files.exists(cachedSchema));
+        assertTrue(Files.isRegularFile(cachedSchema));
+        assertTrue(Files.notExists(tempDir.resolve("localhost").resolve("test.xsd.download")));
+    }
+
+    @Test
+    public void shouldProtectConcurrentSchemaDownloads() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger(0);
+        startHttpServer(requestCount, true);
+
+        int tasks = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(tasks);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        String xml = String.format(XML_TEMPLATE, getSchemaUrl());
+
+        List<Future<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < tasks; i++) {
+            futures.add(executor.submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    startLatch.await();
+                    XmlModule module = createModule();
+                    module.param("schemacachedirectory=" + tempDir.toFile().getAbsolutePath());
+                    String xmlContent = xml;
+                    validateDocument(module, xmlContent);
+                    return null;
+                }
+            }));
+        }
+        startLatch.countDown();
+
+        for (Future<Void> future : futures) {
+            future.get(10, TimeUnit.SECONDS);
+        }
+
+        executor.shutdownNow();
+        assertEquals(1, requestCount.get());
+        assertTrue(Files.notExists(tempDir.resolve("localhost").resolve("test.xsd.download")));
+    }
+
+    private XmlModule createModule() throws JhoveException {
+        JhoveBase base = new JhoveBase();
+        base.setSigBytes(1024);
+        XmlModule module = new XmlModule();
+        module.setBase(base);
+        return module;
+    }
+
+    private void validateDocument(XmlModule module, String xml) throws IOException {
+        RepInfo info = new RepInfo("uri:test");
+        int parseIndex = module.parse(stream(xml), info, 0);
+        assertEquals(1, parseIndex);
+        parseIndex = module.parse(stream(xml), info, parseIndex);
+        assertEquals(0, parseIndex);
+        assertEquals(RepInfo.TRUE, info.getWellFormed());
+        assertEquals(RepInfo.TRUE, info.getValid());
+    }
+
+    private InputStream stream(String xml) {
+        return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void startHttpServer(AtomicInteger requestCount, boolean delayFirstRequest) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        serverExecutor = Executors.newCachedThreadPool();
+        server.setExecutor(serverExecutor);
+        server.createContext("/test.xsd", new HttpHandler() {
+            private volatile boolean firstRequest = true;
+
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                if (delayFirstRequest && firstRequest) {
+                    firstRequest = false;
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(500);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                requestCount.incrementAndGet();
+                byte[] body = XSD_CONTENT.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/xml");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+        });
+        server.start();
+    }
+
+    private String getSchemaUrl() {
+        InetSocketAddress address = server.getAddress();
+        return "http://localhost:" + address.getPort() + "/test.xsd";
+    }
+
+    private void deleteRecursively(File file) throws IOException {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        Files.deleteIfExists(file.toPath());
+    }
+}


### PR DESCRIPTION
This PR adds a feature to enable caching for XML schema files as per #1091.

In order to prevent web sites that host the XSD files from blocking or throttling access to the schema files when making frequent calls, one can now enable local caching of the downloaded files. By default, caching is disabled, but by configuring the path to a directory, caching will be enabled.

It is also possible to configure the duration of the cache. When not set or when set to a negative value, the cached files will not expire. A positive value makes the cached files expire after the given number of seconds.

The cache is also protected from concurrent read/write access using both a lock file and a temporary download file. It should allow multiple instances to share the cache if running in different threads, different processes or even different machines.

Tests have been included to test the cache and concurrency protection.

**Disclaimer:** _created by hand, with a lot of help from Google and some help from Copilot_.